### PR TITLE
Add support for multiple ways to bind to the LDAP server.

### DIFF
--- a/web/config.py
+++ b/web/config.py
@@ -646,12 +646,13 @@ LDAP_ANONYMOUS_BIND = False
 LDAP_BASE_DN = '<Base-DN>'
 
 # Configure the bind format string
-# Default: LDAP_BIND_FORMAT="{LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}"
+# Default: LDAP_BIND_FORMAT="
+#   {LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}"
 # The current available options are:
 # LDAP_USERNAME_ATTRIBUTE, LDAP_USERNAME, LDAP_BASE_DN
 # Example: LDAP_BIND_FORMAT="myldapuser@sales.example.com"
 #          LDAP_BIND_FORMAT="NET\\myldapuser"
-LDAP_BIND_FORMAT="{LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}"
+LDAP_BIND_FORMAT = '{LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}'
 
 ##########################################################################
 

--- a/web/config.py
+++ b/web/config.py
@@ -645,6 +645,14 @@ LDAP_ANONYMOUS_BIND = False
 # OpenLDAP example: CN=Users,dc=example,dc=com
 LDAP_BASE_DN = '<Base-DN>'
 
+# Configure the bind format string
+# Default: LDAP_BIND_FORMAT="{LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}"
+# The current available options are:
+# LDAP_USERNAME_ATTRIBUTE, LDAP_USERNAME, LDAP_BASE_DN
+# Example: LDAP_BIND_FORMAT="myldapuser@sales.example.com"
+#          LDAP_BIND_FORMAT="NET\\myldapuser"
+LDAP_BIND_FORMAT="{LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}"
+
 ##########################################################################
 
 # Search ldap for further authentication (REQUIRED)

--- a/web/pgadmin/authenticate/ldap.py
+++ b/web/pgadmin/authenticate/ldap.py
@@ -66,10 +66,12 @@ class LDAPAuthentication(BaseAuthentication):
         if not self.bind_user and not self.bind_pass and\
                 self.anonymous_bind is False:
 
-            user_dn = config.LDAP_BIND_FORMAT.format(LDAP_USERNAME=self.username
-                            , LDAP_BASE_DN=config.LDAP_BASE_DN
-                            , LDAP_USERNAME_ATTRIBUTE=config.LDAP_USERNAME_ATTRIBUTE
-                        )
+            user_dn = config.LDAP_BIND_FORMAT\
+                .format(
+                    LDAP_USERNAME=self.username,
+                    LDAP_BASE_DN=config.LDAP_BASE_DN,
+                    LDAP_USERNAME_ATTRIBUTE=config.LDAP_USERNAME_ATTRIBUTE
+                )
 
             self.bind_user = user_dn
             self.bind_pass = self.password

--- a/web/pgadmin/authenticate/ldap.py
+++ b/web/pgadmin/authenticate/ldap.py
@@ -65,10 +65,11 @@ class LDAPAuthentication(BaseAuthentication):
         # username and password
         if not self.bind_user and not self.bind_pass and\
                 self.anonymous_bind is False:
-            user_dn = "{0}={1},{2}".format(config.LDAP_USERNAME_ATTRIBUTE,
-                                           self.username,
-                                           config.LDAP_BASE_DN
-                                           )
+
+            user_dn = config.LDAP_BIND_FORMAT.format (LDAP_USERNAME=self.username
+                            , LDAP_BASE_DN=config.LDAP_BASE_DN
+                            , LDAP_USERNAME_ATTRIBUTE=config.LDAP_USERNAME_ATTRIBUTE
+                        )
 
             self.bind_user = user_dn
             self.bind_pass = self.password

--- a/web/pgadmin/authenticate/ldap.py
+++ b/web/pgadmin/authenticate/ldap.py
@@ -66,7 +66,7 @@ class LDAPAuthentication(BaseAuthentication):
         if not self.bind_user and not self.bind_pass and\
                 self.anonymous_bind is False:
 
-            user_dn = config.LDAP_BIND_FORMAT.format (LDAP_USERNAME=self.username
+            user_dn = config.LDAP_BIND_FORMAT.format(LDAP_USERNAME=self.username
                             , LDAP_BASE_DN=config.LDAP_BASE_DN
                             , LDAP_USERNAME_ATTRIBUTE=config.LDAP_USERNAME_ATTRIBUTE
                         )


### PR DESCRIPTION
The current format

```py
"{LDAP_USERNAME_ATTRIBUTE}={LDAP_USERNAME},{LDAP_BASE_DN}"
```
does not work with scenarios where LDAP_USERNAME_ATTRIBUTE is for example 'sAMAccountName'

This "limitation" has been previously mentioned in https://github.com/pgadmin-org/pgadmin4/issues/3541
