### PR TITLE
Ensure consistent orderings for acls

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/procedures/pg/sql/11_plus/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/procedures/pg/sql/11_plus/acl.sql
@@ -32,4 +32,5 @@ FROM
     ) d
     LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/procedures/ppas/sql/default/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/procedures/ppas/sql/default/acl.sql
@@ -32,4 +32,5 @@ FROM
     ) d
     LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/trigger_functions/pg/sql/default/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/trigger_functions/pg/sql/default/acl.sql
@@ -32,4 +32,5 @@ FROM
     ) d
     LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/trigger_functions/ppas/sql/default/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/templates/trigger_functions/ppas/sql/default/acl.sql
@@ -32,4 +32,5 @@ FROM
     ) d
     LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/templates/tables/sql/default/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/templates/tables/sql/default/acl.sql
@@ -44,3 +44,4 @@ FROM
   LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
   LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
 GROUP BY g.rolname, gt.rolname
+ORDER BY grantee

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/pg/9.1_plus/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/pg/9.1_plus/sql/acl.sql
@@ -20,4 +20,5 @@ FROM
     ) b
     LEFT JOIN pg_catalog.pg_roles g ON (b.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (b.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/pg/9.2_plus/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/pg/9.2_plus/sql/acl.sql
@@ -20,4 +20,5 @@ FROM
     ) b
     LEFT JOIN pg_catalog.pg_roles g ON (b.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (b.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/pg/default/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/pg/default/sql/acl.sql
@@ -20,4 +20,5 @@ FROM
     ) b
     LEFT JOIN pg_catalog.pg_roles g ON (b.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (b.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/ppas/9.1_plus/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/ppas/9.1_plus/sql/acl.sql
@@ -20,4 +20,5 @@ FROM
     ) b
     LEFT JOIN pg_catalog.pg_roles g ON (b.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (b.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/ppas/9.2_plus/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/ppas/9.2_plus/sql/acl.sql
@@ -20,4 +20,5 @@ FROM
     ) b
     LEFT JOIN pg_catalog.pg_roles g ON (b.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (b.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/ppas/default/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/templates/catalog/ppas/default/sql/acl.sql
@@ -20,4 +20,5 @@ FROM
     ) b
     LEFT JOIN pg_catalog.pg_roles g ON (b.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (b.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/acl.sql
@@ -38,4 +38,5 @@ LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
 GROUP BY
     g.rolname,
     gt.rolname
+ORDER BY grantee
 {% endif %}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/views/pg/default/sql/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/views/pg/default/sql/acl.sql
@@ -36,4 +36,5 @@ LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
 GROUP BY
     g.rolname,
     gt.rolname
+ORDER BY grantee
 {% endif %}

--- a/web/pgadmin/browser/server_groups/servers/databases/templates/databases/sql/default/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/templates/databases/sql/default/acl.sql
@@ -32,4 +32,5 @@ FROM
     ) d
     LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
     LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
-GROUP BY g.rolname, gt.rolname;
+GROUP BY g.rolname, gt.rolname
+ORDER BY grantee;

--- a/web/pgadmin/browser/server_groups/servers/tablespaces/templates/tablespaces/sql/default/acl.sql
+++ b/web/pgadmin/browser/server_groups/servers/tablespaces/templates/tablespaces/sql/default/acl.sql
@@ -26,3 +26,4 @@ FROM
   LEFT JOIN pg_catalog.pg_roles g ON (d.grantor = g.oid)
   LEFT JOIN pg_catalog.pg_roles gt ON (d.grantee = gt.oid)
 GROUP BY g.rolname, gt.rolname
+ORDER BY grantee


### PR DESCRIPTION
When comparing schemas between two databases schema diff was showing different ordering for grants, though the actual grants themselves were the same.  This applies the order by grantee clause to the query for acls where it was missing to avoid this issue.