### PR TITLE
feat(oauth2): Add possibility to configure a custom Oauth2 username claim

### DIFF
--- a/docs/en_US/oauth2.rst
+++ b/docs/en_US/oauth2.rst
@@ -33,6 +33,8 @@ and modify the values for the following parameters:
     "OAUTH2_SCOPE", "Oauth scope, ex: 'openid email profile'. Note that an 'email' claim is required in the resulting profile."
     "OAUTH2_ICON", "The Font-awesome icon to be placed on the oauth2 button,  ex: fa-github"
     "OAUTH2_BUTTON_COLOR", "Oauth2 button color"
+    "OAUTH2_USERNAME_CLAIM", "The claim which is used for the username. If the value is empty
+    the email is used as username, but if a value is provided, the claim has to exist. Ex: *oid* (for AzureAD)"
     "OAUTH2_AUTO_CREATE_USER", "Set the value to *True* if you want to automatically
     create a pgAdmin user corresponding to a successfully authenticated Oauth2 user.
     Please note that password is not stored in the pgAdmin database."

--- a/docs/en_US/release_notes_6_16.rst
+++ b/docs/en_US/release_notes_6_16.rst
@@ -16,7 +16,8 @@ New features
 ************
 
   | `Issue #1832 <https://github.com/pgadmin-org/pgadmin4/issues/1832>`_ -  Added support for storing configurations of pgAdmin in an external database.
-
+  | `Issue #5468 <https://github.com/pgadmin-org/pgadmin4/issues/5468>`_ -  Add the possibility to configure the Oauth2 claim which is used for the pgAdmin username.
+  
 Housekeeping
 ************
 

--- a/web/config.py
+++ b/web/config.py
@@ -11,6 +11,7 @@
 #
 ##########################################################################
 
+from pgadmin.utils import env, IS_WIN, fs_short_path
 import builtins
 import logging
 import os
@@ -22,7 +23,6 @@ root = os.path.dirname(os.path.realpath(__file__))
 if sys.path[0] != root:
     sys.path.insert(0, root)
 
-from pgadmin.utils import env, IS_WIN, fs_short_path
 
 ##########################################################################
 # Application settings
@@ -754,6 +754,10 @@ OAUTH2_CONFIG = [
         # Oauth scope, ex: 'openid email profile'
         # Note that an 'email' claim is required in the resulting profile
         'OAUTH2_SCOPE': None,
+        # The claim which is used for the username. If the value is empty the
+        # email is used as username, but if a value is provided,
+        # the claim has to exist.
+        'OAUTH2_USERNAME_CLAIM': None,
         # Font-awesome icon, ex: fa-github
         'OAUTH2_ICON': None,
         # UI button colour, ex: #0000ff


### PR DESCRIPTION
There are cases where you don't want to use the email as username when using Oauth2 authentication.
This feature provides the possibility to configure the Oauth2 claim which should be used as username. The key in the config.py is called 'OAUTH2_USERNAME_CLAIM'. If you don't provide a custom key, the email is used as username, like before. So it is completely backwards compatible.

#5468 