### PR TITLE
Fixed an issue where CSV file was not downloading if CSV quote character length was more than 1

### DIFF
--- a/web/pgadmin/static/js/components/FormComponents.jsx
+++ b/web/pgadmin/static/js/components/FormComponents.jsx
@@ -919,7 +919,8 @@ export const InputSelect = forwardRef(({
       Option: CustomSelectOption,
       SingleValue: CustomSelectSingleValue,
       IndicatorSeparator: (props) => controlProps.noDropdown ? null: <RSComponents.IndicatorSeparator {...props} />,
-      DropdownIndicator: (props) => controlProps.noDropdown ? null: <RSComponents.DropdownIndicator {...props} />
+      DropdownIndicator: (props) => controlProps.noDropdown ? null: <RSComponents.DropdownIndicator {...props} />,
+      Input: props => <RSComponents.Input {...props} maxLength={controlProps.maxLength} />
     },
     isMulti: Boolean(controlProps.multiple),
     openMenuOnClick: !readonly,

--- a/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
+++ b/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
@@ -197,6 +197,7 @@ def register_query_tool_preferences(self):
             'allowClear': False,
             'tags': False,
             'creatable': True,
+            'maxLength': 1
         }
     )
 
@@ -212,6 +213,7 @@ def register_query_tool_preferences(self):
             'allowClear': False,
             'tags': False,
             'creatable': True,
+            'maxLength': 1
         }
     )
 


### PR DESCRIPTION
The reason for the issue is that the quote and delimiter must be 1 character string. So, added max length attribute for this input field.