### PR TITLE
fix: :bug:  incorrect password used with shared server

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/__init__.py
@@ -162,6 +162,7 @@ class ServerModule(sg.ServerGroupPluginModule):
         server.sslcert = sharedserver.sslcert
         server.username = sharedserver.username
         server.server_owner = sharedserver.server_owner
+        server.password = sharedserver.password
 
         return server
 


### PR DESCRIPTION
ISSUE: When connecting with shared server using saved password fails, due trying to decrypt saved password of User who created the server with the logged In user keys. 

FIX: for the shared server use the logged In user password as db password to connect.

Closes Failed to decrypt the saved password #5487