### PR TITLE
Pin Flask-WTF to latest (1.1.1) and Flask-Seurity-Too to latest (5.1.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,11 @@ Flask-Migrate==3.*
 dnspython==2.2.1
 greenlet==1.1.2;  python_version <= '3.10'
 Flask-SQLAlchemy==2.5.*
-Flask-WTF==1.0.1
+Flask-WTF==1.1.1
 Flask-Compress==1.*
 Flask-Paranoid==0.*
 Flask-Babel==2.*
-Flask-Security-Too==4.1.*
+Flask-Security-Too==5.1.0
 Flask-SocketIO<=5.2.0
 WTForms==3.*
 passlib==1.*


### PR DESCRIPTION
Hi! Thank you for the fabulous db viewer open source.

@adityatoshniwal  pgadmin4 uses LoginForm of Flask-Security. And Flask-wtf's validate_on_submit function calls their derived class Flask-Security 4.1.5 LoginForm's validate function and that does not receive extra_validators and it throws an error. Refer to https://github.com/wtforms/flask-wtf/issues/547

However, now the Flask-Security-Too new 5.1.0 version receives extra_validators.

https://github.com/Flask-Middleware/flask-security/blob/a2f43ff35527f37839fa8da7af6827a4c5e52e31/flask_security/forms.py#L495-L503

So, it works with Flask-WTF latest version (1.1.1) and Flask-Security-Too latest version (5.1.0)

Fixes #5741