### PR TITLE
Remove dependency on simplejson package.

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -40,7 +40,6 @@ Flask-SocketIO                                                   5.2.0          
 WTForms                                                          3.0.1            BSD-3-Clause                         https://wtforms.readthedocs.io/
 passlib                                                          1.7.4            BSD                                  https://passlib.readthedocs.io
 pytz                                                             2021.3           MIT                                  http://pythonhosted.org/pytz
-simplejson                                                       3.18.3           MIT License                          https://github.com/simplejson/simplejson
 speaklater3                                                      1.4              UNKNOWN                              https://github.com/ThomasWaldmann/speaklater
 sqlparse                                                         0.4.3            BSD-3-Clause                         https://github.com/andialbrecht/sqlparse
 psutil                                                           5.9.3            BSD-3-Clause                         https://github.com/giampaolo/psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ Flask-SocketIO<=5.2.0
 WTForms==3.*
 passlib==1.*
 pytz==2021.*
-simplejson==3.*
 speaklater3==1.*
 sqlparse==0.*
 psutil==5.9.3

--- a/web/pgadmin/browser/server_groups/__init__.py
+++ b/web/pgadmin/browser/server_groups/__init__.py
@@ -9,7 +9,7 @@
 
 """Defines views for management of server groups"""
 
-import simplejson as json
+import json
 from abc import ABCMeta, abstractmethod
 
 from flask import request, jsonify, render_template
@@ -235,7 +235,7 @@ class ServerGroupView(NodeView):
             id=gid).first()
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         if servergroup is None:
@@ -294,7 +294,7 @@ class ServerGroupView(NodeView):
     def create(self):
         """Creates new server-group """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         if data['name'] != '':
             try:

--- a/web/pgadmin/browser/server_groups/servers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/__init__.py
@@ -7,7 +7,7 @@
 #
 ##########################################################################
 
-import simplejson as json
+import json
 import pgadmin.browser.server_groups as sg
 from flask import render_template, request, make_response, jsonify, \
     current_app, url_for, session
@@ -781,7 +781,7 @@ class ServerNode(PGChildNodeView):
 
         idx = 0
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         if 'db_res' in data:
             data['db_res'] = ','.join(data['db_res'])
@@ -1040,7 +1040,7 @@ class ServerNode(PGChildNodeView):
         required_args = ['name', 'db']
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         # Loop through data and if found any value is blank string then
@@ -1357,7 +1357,7 @@ class ServerNode(PGChildNodeView):
         if request.form:
             data = request.form
         elif request.data:
-            data = json.loads(request.data, encoding='utf-8')
+            data = json.loads(request.data)
 
         if data is None:
             data = {}
@@ -1656,7 +1656,7 @@ class ServerNode(PGChildNodeView):
             if request.form:
                 data = request.form
             elif request.data:
-                data = json.loads(request.data, encoding='utf-8')
+                data = json.loads(request.data)
 
             crypt_key = get_crypt_key()[1]
 

--- a/web/pgadmin/browser/server_groups/servers/databases/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/__init__.py
@@ -12,7 +12,7 @@
 import re
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, current_app, request, jsonify
 from flask_babel import gettext as _
 from flask_security import current_user
@@ -661,7 +661,7 @@ class DatabaseView(PGChildNodeView):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for arg in required_args:
@@ -823,7 +823,7 @@ class DatabaseView(PGChildNodeView):
 
     def _get_data_from_request(self):
         return request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
     @check_precondition(action='update')
@@ -960,7 +960,7 @@ class DatabaseView(PGChildNodeView):
 
         if did is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [did]}
@@ -1028,7 +1028,7 @@ class DatabaseView(PGChildNodeView):
                 if k in ('comments',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         status, res = self.get_sql(gid, sid, data, did)
@@ -1096,7 +1096,7 @@ class DatabaseView(PGChildNodeView):
             acls = render_template(
                 "/".join([self.template_path, 'allowed_privs.json'])
             )
-            acls = json.loads(acls, encoding='utf-8')
+            acls = json.loads(acls)
         except Exception as e:
             current_app.logger.exception(e)
 
@@ -1132,7 +1132,7 @@ class DatabaseView(PGChildNodeView):
             acls = render_template(
                 "/".join([self.template_path, 'allowed_privs.json'])
             )
-            acls = json.loads(acls, encoding='utf-8')
+            acls = json.loads(acls)
         except Exception as e:
             current_app.logger.exception(e)
 

--- a/web/pgadmin/browser/server_groups/servers/databases/casts/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/casts/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Cast Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -378,7 +378,7 @@ class CastView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -436,7 +436,7 @@ class CastView(PGChildNodeView, SchemaDiffObjectCompare):
         :return:
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             sql, name = self.get_sql(gid, sid, did, data, cid)
@@ -476,7 +476,7 @@ class CastView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if cid is None:
             data = request_object.form if request_object.form else \
-                json.loads(request_object.data, encoding='utf-8')
+                json.loads(request_object.data)
         else:
             data = {'ids': [cid]}
 
@@ -624,7 +624,7 @@ class CastView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         res = []
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         sql = render_template("/".join([self.template_path,

--- a/web/pgadmin/browser/server_groups/servers/databases/event_triggers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/event_triggers/__init__.py
@@ -7,7 +7,7 @@
 #
 ##########################################################################
 
-import simplejson as json
+import json
 import re
 from functools import wraps
 
@@ -387,7 +387,7 @@ class EventTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         required_args = {
@@ -461,7 +461,7 @@ class EventTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -521,7 +521,7 @@ class EventTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if etid is None:
             data = request_object.form if request_object.form else \
-                json.loads(request_object.data, encoding='utf-8')
+                json.loads(request_object.data)
         else:
             data = {'ids': [etid]}
 
@@ -606,7 +606,7 @@ class EventTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
         data = {}
         for k, v in request.args.items():
             try:
-                data[k] = json.loads(v, encoding='utf-8')
+                data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/databases/extensions/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/extensions/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Extension Node """
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -267,7 +267,7 @@ class ExtensionView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for arg in required_args:
@@ -311,7 +311,7 @@ class ExtensionView(PGChildNodeView, SchemaDiffObjectCompare):
         This function will update an extension object
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -343,7 +343,7 @@ class ExtensionView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if eid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [eid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/foreign_data_wrappers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/foreign_data_wrappers/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Foreign Data Wrapper Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -425,7 +425,7 @@ class ForeignDataWrapperView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -493,7 +493,7 @@ class ForeignDataWrapperView(PGChildNodeView, SchemaDiffObjectCompare):
             fid: foreign data wrapper ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -533,7 +533,7 @@ class ForeignDataWrapperView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if fid is None:
             data = request_object.form if request_object.form else \
-                json.loads(request_object.data, encoding='utf-8')
+                json.loads(request_object.data)
         else:
             data = {'ids': [fid]}
 
@@ -620,7 +620,7 @@ class ForeignDataWrapperView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/databases/foreign_data_wrappers/foreign_servers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/foreign_data_wrappers/foreign_servers/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Foreign Server Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -414,7 +414,7 @@ class ForeignServerView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -490,7 +490,7 @@ class ForeignServerView(PGChildNodeView, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -532,7 +532,7 @@ class ForeignServerView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if fsid is None:
             data = request_object.form if request_object.form else \
-                json.loads(request_object.data, encoding='utf-8')
+                json.loads(request_object.data)
         else:
             data = {'ids': [fsid]}
 
@@ -621,7 +621,7 @@ class ForeignServerView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/databases/foreign_data_wrappers/foreign_servers/user_mappings/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/foreign_data_wrappers/foreign_servers/user_mappings/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements User Mapping Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups import servers
@@ -412,7 +412,7 @@ class UserMappingView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -489,7 +489,7 @@ class UserMappingView(PGChildNodeView, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             sql, name = self.get_sql(data=data, fsid=fsid, umid=umid)
@@ -530,7 +530,7 @@ class UserMappingView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if umid is None:
             data = request_object.form if request_object.form else \
-                json.loads(request_object.data, encoding='utf-8')
+                json.loads(request_object.data)
         else:
             data = {'ids': [umid]}
 
@@ -652,7 +652,7 @@ class UserMappingView(PGChildNodeView, SchemaDiffObjectCompare):
         data = {}
         for k, v in request.args.items():
             try:
-                data[k] = json.loads(v, encoding='utf-8')
+                data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/databases/languages/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/languages/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Language Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -418,7 +418,7 @@ class LanguageView(PGChildNodeView, SchemaDiffObjectCompare):
             lid: Language ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -457,7 +457,7 @@ class LanguageView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -516,7 +516,7 @@ class LanguageView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if lid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [lid]}
@@ -577,7 +577,7 @@ class LanguageView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/databases/publications/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/publications/__init__.py
@@ -8,7 +8,7 @@
 ##########################################################################
 
 """Implements Publication Node"""
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -414,7 +414,7 @@ class PublicationView(PGChildNodeView, SchemaDiffObjectCompare):
             pbid: Publication ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -455,7 +455,7 @@ class PublicationView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -511,7 +511,7 @@ class PublicationView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if pbid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [pbid]}
@@ -573,7 +573,7 @@ class PublicationView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/__init__.py
@@ -10,7 +10,7 @@
 import re
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify, current_app
 from flask_babel import gettext
 
@@ -344,7 +344,7 @@ class SchemaView(PGChildNodeView):
             acls = render_template(
                 "/".join([self.template_path, 'allowed_privs.json'])
             )
-            acls = json.loads(acls, encoding='utf-8')
+            acls = json.loads(acls)
         except Exception as e:
             current_app.logger.exception(e)
 
@@ -660,7 +660,7 @@ It may have been removed by another user.
            did: Database ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         required_args = {
@@ -726,7 +726,7 @@ It may have been removed by another user.
            scid: Schema ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             SQL, name = self.get_sql(gid, sid, data, scid)
@@ -761,7 +761,7 @@ It may have been removed by another user.
 
         if scid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [scid]}
@@ -832,7 +832,7 @@ It may have been removed by another user.
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/collations/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/collations/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify
 from flask_babel import gettext
 
@@ -449,7 +449,7 @@ class CollationView(PGChildNodeView, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         required_args = [
@@ -523,7 +523,7 @@ class CollationView(PGChildNodeView, SchemaDiffObjectCompare):
            coid: Collation ID
            only_sql: Return only sql if True
         """
-        data = json.loads(request.data, encoding='utf-8') if coid is None \
+        data = json.loads(request.data) if coid is None \
             else {'ids': [coid]}
 
         # Below will decide if it's simple drop or drop with cascade call
@@ -580,7 +580,7 @@ class CollationView(PGChildNodeView, SchemaDiffObjectCompare):
            coid: Collation ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         SQL, name = self.get_sql(gid, sid, data, scid, coid)
         # Most probably this is due to error
@@ -631,7 +631,7 @@ class CollationView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/domains/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/domains/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, make_response, request, jsonify
 from flask_babel import gettext
 
@@ -193,7 +193,7 @@ class DomainView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
         :return: if any error return error, else return req.
         """
         if request.data:
-            req = json.loads(request.data, encoding='utf-8')
+            req = json.loads(request.data)
         else:
             req = request.args or request.form
 
@@ -232,7 +232,7 @@ class DomainView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
                 req[key] is not None
             ):
                 # Coverts string into python list as expected.
-                data[key] = json.loads(req[key], encoding='utf-8')
+                data[key] = json.loads(req[key])
             elif key == 'typnotnull':
                 if req[key] == 'true' or req[key] is True:
                     data[key] = True
@@ -634,7 +634,7 @@ AND relkind != 'c'))"""
         """
         if doid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [doid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/domains/domain_constraints/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/domains/domain_constraints/__init__.py
@@ -12,7 +12,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify
 from flask_babel import gettext
 
@@ -188,7 +188,7 @@ class DomainConstraintView(PGChildNodeView):
         :return: if any error return error with error msg else return req data
         """
         if request.data:
-            req = json.loads(request.data, encoding='utf-8')
+            req = json.loads(request.data)
         else:
             req = request.args or request.form
 
@@ -484,7 +484,7 @@ class DomainConstraintView(PGChildNodeView):
         """
         if coid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [coid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/foreign_tables/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/foreign_tables/__init__.py
@@ -13,7 +13,7 @@ import sys
 import traceback
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, make_response, request, jsonify, \
     current_app
 from flask_babel import gettext
@@ -237,7 +237,7 @@ class ForeignTableView(PGChildNodeView, DataTypeReader,
         def wrap(self, **kwargs):
 
             if request.data:
-                req = json.loads(request.data, encoding='utf-8')
+                req = json.loads(request.data)
             else:
                 req = request.args or request.form
 
@@ -336,7 +336,7 @@ class ForeignTableView(PGChildNodeView, DataTypeReader,
         """
 
         if not isinstance(req[key], list) and req[key]:
-            data[key] = json.loads(req[key], encoding='utf-8')
+            data[key] = json.loads(req[key])
         elif req[key]:
             data[key] = req[key]
 
@@ -748,7 +748,7 @@ class ForeignTableView(PGChildNodeView, DataTypeReader,
         """
         if foid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [foid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_configurations/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_configurations/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, make_response, current_app, request, jsonify
 from flask_babel import gettext as _
 
@@ -423,7 +423,7 @@ class FtsConfigurationView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -503,7 +503,7 @@ class FtsConfigurationView(PGChildNodeView, SchemaDiffObjectCompare):
         :param cfgid: fts Configuration id
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         # Fetch sql query to update fts Configuration
         sql, name = self.get_sql(gid, sid, did, scid, data, cfgid)
@@ -553,7 +553,7 @@ class FtsConfigurationView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if cfgid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [cfgid]}
@@ -627,7 +627,7 @@ class FtsConfigurationView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_dictionaries/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_dictionaries/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, make_response, current_app, request, jsonify
 from flask_babel import gettext as _
 
@@ -432,7 +432,7 @@ class FtsDictionaryView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -498,7 +498,7 @@ class FtsDictionaryView(PGChildNodeView, SchemaDiffObjectCompare):
         :param dcid: fts dictionary id
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         # Fetch sql query to update fts dictionary
@@ -549,7 +549,7 @@ class FtsDictionaryView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if dcid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [dcid]}
@@ -623,7 +623,7 @@ class FtsDictionaryView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_parsers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_parsers/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify, current_app
 from flask_babel import gettext as _
 
@@ -378,7 +378,7 @@ class FtsParserView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -444,7 +444,7 @@ class FtsParserView(PGChildNodeView, SchemaDiffObjectCompare):
         :param pid: fts parser id
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         # Fetch sql query to update fts parser
         sql, name = self.get_sql(gid, sid, did, scid, data, pid)
@@ -495,7 +495,7 @@ class FtsParserView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if pid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [pid]}
@@ -568,7 +568,7 @@ class FtsParserView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_templates/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_templates/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, make_response, request, jsonify
 from flask_babel import gettext
 
@@ -349,7 +349,7 @@ class FtsTemplateView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -415,7 +415,7 @@ class FtsTemplateView(PGChildNodeView, SchemaDiffObjectCompare):
         :param tid: fts tempate id
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         # Fetch sql query to update fts template
@@ -460,7 +460,7 @@ class FtsTemplateView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if tid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [tid]}
@@ -526,7 +526,7 @@ class FtsTemplateView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/__init__.py
@@ -15,7 +15,7 @@ import sys
 import traceback
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify, \
     current_app
 from flask_babel import gettext
@@ -263,7 +263,7 @@ class FunctionView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
 
         if key in list_params and req[key] != '' and req[key] is not None:
             # Coverts string into python list as expected.
-            data[key] = json.loads(req[key], encoding='utf-8')
+            data[key] = json.loads(req[key])
         elif (key == 'proretset' or key == 'proisstrict' or
               key == 'prosecdef' or key == 'proiswindow' or
               key == 'proleakproof'):
@@ -294,7 +294,7 @@ class FunctionView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
         :return:
         """
         if request.data:
-            req = json.loads(request.data, encoding='utf-8')
+            req = json.loads(request.data)
         else:
             req = request.args or request.form
         return req
@@ -882,7 +882,7 @@ class FunctionView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
         """
         if fnid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [fnid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/packages/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/packages/__init__.py
@@ -11,7 +11,7 @@
 import re
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, make_response, request, jsonify
 from flask_babel import gettext as _
 
@@ -386,7 +386,7 @@ class PackageView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for arg in required_args:
@@ -448,7 +448,7 @@ class PackageView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if pkgid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [pkgid]}
@@ -514,7 +514,7 @@ class PackageView(PGChildNodeView, SchemaDiffObjectCompare):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         sql, name = self.getSQL(data=data, scid=scid, pkgid=pkgid)
@@ -552,7 +552,7 @@ class PackageView(PGChildNodeView, SchemaDiffObjectCompare):
         data = {}
         for k, v in request.args.items():
             try:
-                data[k] = json.loads(v, encoding='utf-8')
+                data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/sequences/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/sequences/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify
 from flask_babel import gettext as _
 
@@ -388,7 +388,7 @@ class SequenceView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for arg in required_args:
@@ -469,7 +469,7 @@ class SequenceView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if seid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [seid]}
@@ -533,7 +533,7 @@ class SequenceView(PGChildNodeView, SchemaDiffObjectCompare):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         sql, name = self.get_SQL(gid, sid, did, data, scid, seid)
         # Most probably this is due to error
@@ -585,7 +585,7 @@ class SequenceView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/synonyms/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/synonyms/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Synonym Node """
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -344,7 +344,7 @@ class SynonymView(PGChildNodeView, SchemaDiffObjectCompare):
         data = dict()
         for k, v in request.args.items():
             try:
-                data[k] = json.loads(v, encoding='utf-8')
+                data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 
@@ -443,7 +443,7 @@ class SynonymView(PGChildNodeView, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         required_args = [
@@ -506,7 +506,7 @@ class SynonymView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if syid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [syid]}
@@ -561,7 +561,7 @@ class SynonymView(PGChildNodeView, SchemaDiffObjectCompare):
            syid: Synonym ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         SQL, name = self.get_sql(gid, sid, data, scid, syid)
         # Most probably this is due to error
@@ -600,7 +600,7 @@ class SynonymView(PGChildNodeView, SchemaDiffObjectCompare):
         data = dict()
         for k, v in request.args.items():
             try:
-                data[k] = json.loads(v, encoding='utf-8')
+                data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Table Node """
 
-import simplejson as json
+import json
 import re
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -884,7 +884,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
         if 'coll_inherits' in data and \
                 isinstance(data['coll_inherits'], str):
             data['coll_inherits'] = json.loads(
-                data['coll_inherits'], encoding='utf-8'
+                data['coll_inherits']
             )
 
         if 'foreign_key' in data:
@@ -920,7 +920,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
            scid: Schema ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -930,7 +930,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -1024,7 +1024,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
            tid: Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -1034,7 +1034,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -1067,7 +1067,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
         """
         if tid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [tid]}
@@ -1159,7 +1159,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
         """
         # Below will decide if it's simple drop or drop with cascade call
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         # Convert str 'true' to boolean type
         is_enable_trigger = data['is_enable_trigger']
@@ -1294,7 +1294,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/columns/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/columns/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Column Node """
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -364,7 +364,7 @@ class ColumnsView(PGChildNodeView, DataTypeReader):
            tid: Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -373,8 +373,7 @@ class ColumnsView(PGChildNodeView, DataTypeReader):
             if k in ('description',):
                 data[k] = v
             else:
-                data[k] = json.loads(v, encoding='utf-8',
-                                     cls=ColParamsJSONDecoder)
+                data[k] = json.loads(v, cls=ColParamsJSONDecoder)
 
         required_args = {
             'name': 'Name',
@@ -446,7 +445,7 @@ class ColumnsView(PGChildNodeView, DataTypeReader):
         """
         if clid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [clid]}
@@ -512,7 +511,7 @@ class ColumnsView(PGChildNodeView, DataTypeReader):
            clid: Column ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         # Adding parent into data dict, will be using it while creating sql
@@ -556,7 +555,7 @@ class ColumnsView(PGChildNodeView, DataTypeReader):
         """
         data = dict()
         for k, v in request.args.items():
-            data[k] = json.loads(v, encoding='utf-8', cls=ColParamsJSONDecoder)
+            data[k] = json.loads(v, cls=ColParamsJSONDecoder)
 
         # Adding parent into data dict, will be using it while creating sql
         data['schema'] = self.schema

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/compound_triggers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/compound_triggers/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Compound Trigger Node """
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -477,7 +477,7 @@ class CompoundTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
            tid: Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -487,7 +487,7 @@ class CompoundTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -554,7 +554,7 @@ class CompoundTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if trid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [trid]}
@@ -621,7 +621,7 @@ class CompoundTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
            trid: Trigger ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -698,7 +698,7 @@ class CompoundTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 
@@ -761,7 +761,7 @@ class CompoundTriggerView(PGChildNodeView, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         # Convert str 'true' to boolean type

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Constraint Node"""
 
-import simplejson as json
+import json
 from flask import request
 from functools import wraps
 from pgadmin.utils.driver import get_driver
@@ -172,7 +172,7 @@ def delete(**kwargs):
 
     """
     data = request.form if request.form else json.loads(
-        request.data, encoding='utf-8')
+        request.data)
 
     if 'delete' in request.base_url:
         cmd = {"cmd": "delete"}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/check_constraint/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/check_constraint/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements the Check Constraint Module."""
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -460,7 +460,7 @@ class CheckConstraintView(PGChildNodeView):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for k, v in data.items():
             try:
@@ -469,7 +469,7 @@ class CheckConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -610,7 +610,7 @@ class CheckConstraintView(PGChildNodeView):
         """
         if cid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [cid]}
@@ -668,7 +668,7 @@ class CheckConstraintView(PGChildNodeView):
             cid: Check Constraint Id
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -778,7 +778,7 @@ class CheckConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/exclusion_constraint/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/exclusion_constraint/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Exclusion constraint Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -482,7 +482,7 @@ class ExclusionConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -521,7 +521,7 @@ class ExclusionConstraintView(PGChildNodeView):
         """
         required_args = ['columns']
 
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
         data = self.parse_input_data(data)
         arg_missing = self.check_required_args(data, required_args)
         if arg_missing is not None:
@@ -616,7 +616,7 @@ class ExclusionConstraintView(PGChildNodeView):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -669,7 +669,7 @@ class ExclusionConstraintView(PGChildNodeView):
         """
         if exid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [exid]}
@@ -743,7 +743,7 @@ class ExclusionConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/foreign_key/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/foreign_key/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Foreign key constraint Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -492,7 +492,7 @@ class ForeignKeyConstraintView(PGChildNodeView):
         return: Data.
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -502,7 +502,7 @@ class ForeignKeyConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -670,7 +670,7 @@ class ForeignKeyConstraintView(PGChildNodeView):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -731,7 +731,7 @@ class ForeignKeyConstraintView(PGChildNodeView):
         """
         if fkid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [fkid]}
@@ -802,7 +802,7 @@ class ForeignKeyConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 
@@ -993,7 +993,7 @@ class ForeignKeyConstraintView(PGChildNodeView):
         index = None
         try:
             if data and 'cols' in data:
-                cols = set(json.loads(data['cols'], encoding='utf-8'))
+                cols = set(json.loads(data['cols']))
                 index = fkey_utils.search_coveringindex(self.conn, tid, cols)
 
             return make_json_response(

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/index_constraint/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/index_constraint/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Primary key constraint Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -498,7 +498,7 @@ class IndexConstraintView(PGChildNodeView):
         return: data.
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -508,7 +508,7 @@ class IndexConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -658,7 +658,7 @@ class IndexConstraintView(PGChildNodeView):
 
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -713,7 +713,7 @@ class IndexConstraintView(PGChildNodeView):
         """
         if cid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [cid]}
@@ -794,7 +794,7 @@ class IndexConstraintView(PGChildNodeView):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/indexes/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/indexes/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Index Node """
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -564,7 +564,7 @@ class IndexesView(PGChildNodeView, SchemaDiffObjectCompare):
            tid: Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -574,7 +574,7 @@ class IndexesView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -678,7 +678,7 @@ class IndexesView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if idx is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [idx]}
@@ -744,7 +744,7 @@ class IndexesView(PGChildNodeView, SchemaDiffObjectCompare):
            idx: Index ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         data['schema'] = self.schema
         data['table'] = self.table
@@ -791,7 +791,7 @@ class IndexesView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/partitions/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/partitions/__init__.py
@@ -11,7 +11,7 @@
 
 import re
 import secrets
-import simplejson as json
+import json
 import pgadmin.browser.server_groups.servers.databases.schemas as schema
 from flask import render_template, request, current_app
 from flask_babel import gettext
@@ -634,7 +634,7 @@ class PartitionsView(BaseTableView, DataTypeReader, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -668,7 +668,7 @@ class PartitionsView(BaseTableView, DataTypeReader, SchemaDiffObjectCompare):
            ptid: Partition Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -678,7 +678,7 @@ class PartitionsView(BaseTableView, DataTypeReader, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -738,7 +738,7 @@ class PartitionsView(BaseTableView, DataTypeReader, SchemaDiffObjectCompare):
         """
         if ptid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [ptid]}
@@ -794,7 +794,7 @@ class PartitionsView(BaseTableView, DataTypeReader, SchemaDiffObjectCompare):
            ptid: Partition Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         # Convert str 'true' to boolean type
         is_enable_trigger = data['is_enable_trigger']

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/row_security_policies/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/row_security_policies/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements policy Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -350,7 +350,7 @@ class RowSecurityView(PGChildNodeView):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         data['schema'] = self.schema
         data['table'] = self.table
@@ -405,7 +405,7 @@ class RowSecurityView(PGChildNodeView):
         :return:
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             sql, name = row_security_policies_utils.get_sql(
@@ -441,7 +441,7 @@ class RowSecurityView(PGChildNodeView):
         """
         if plid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [plid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/rules/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/rules/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Rule Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers.databases import schemas
@@ -326,7 +326,7 @@ class RuleView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -368,7 +368,7 @@ class RuleView(PGChildNodeView, SchemaDiffObjectCompare):
         This function will update a rule object
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             SQL, name = self.getSQL(gid, sid, data, tid, rid)
@@ -402,7 +402,7 @@ class RuleView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if rid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [rid]}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py
@@ -9,7 +9,7 @@
 
 """ Implements Trigger Node """
 
-import simplejson as json
+import json
 from functools import wraps
 
 import pgadmin.browser.server_groups.servers.databases as database
@@ -564,7 +564,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
            tid: Table ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for k, v in data.items():
@@ -574,7 +574,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except (ValueError, TypeError, KeyError):
                 data[k] = v
 
@@ -644,7 +644,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
 
         if trid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [trid]}
@@ -710,7 +710,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
            trid: Trigger ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -790,7 +790,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 
@@ -897,7 +897,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         is_enable_trigger = data['is_enable_trigger']

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/utils.py
@@ -12,7 +12,7 @@
 import re
 import copy
 from functools import wraps
-import simplejson as json
+import json
 from flask import render_template, jsonify, request
 from flask_babel import gettext
 
@@ -1962,7 +1962,7 @@ class BaseTableView(PGChildNodeView, BasePartitionTable, VacuumSettings):
         """
         # Below will decide if it's simple drop or drop with cascade call
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         # Convert str 'true' to boolean type
         is_cascade = data.get('cascade') or False

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/types/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/types/__init__.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify
 from flask_babel import gettext
 import re
@@ -1001,7 +1001,7 @@ class TypeView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
            tid: Type ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         is_error, errmsg = TypeView._checks_for_create_type(data)
@@ -1078,7 +1078,7 @@ class TypeView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
         """
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             SQL, name = self.get_sql(gid, sid, data, scid, tid)
@@ -1118,7 +1118,7 @@ class TypeView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
         """
         if tid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [tid]}
@@ -1214,7 +1214,7 @@ class TypeView(PGChildNodeView, DataTypeReader, SchemaDiffObjectCompare):
         # converting nested request data in proper json format
         for key, val in req.items():
             if key in ['composite', 'enum', 'seclabels', 'typacl']:
-                data[key] = json.loads(val, encoding='utf-8')
+                data[key] = json.loads(val)
             else:
                 data[key] = val
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/__init__.py
@@ -13,7 +13,7 @@ import copy
 import re
 from functools import wraps
 
-import simplejson as json
+import json
 from flask import render_template, request, jsonify, current_app
 from flask_babel import gettext
 from flask_security import current_user
@@ -256,7 +256,7 @@ def check_precondition(f):
             self.allowed_acls = render_template(
                 "/".join([self.template_path, self._ALLOWED_PRIVS_JSON])
             )
-            self.allowed_acls = json.loads(self.allowed_acls, encoding='utf-8')
+            self.allowed_acls = json.loads(self.allowed_acls)
         except Exception as e:
             current_app.logger.exception(e)
 
@@ -547,7 +547,7 @@ class ViewNode(PGChildNodeView, VacuumSettings, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -601,7 +601,7 @@ class ViewNode(PGChildNodeView, VacuumSettings, SchemaDiffObjectCompare):
         This function will update a view object
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         try:
             SQL, name = self.getSQL(gid, sid, did, data, vid)
@@ -649,7 +649,7 @@ class ViewNode(PGChildNodeView, VacuumSettings, SchemaDiffObjectCompare):
         """
         if vid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [vid]}
@@ -735,7 +735,7 @@ class ViewNode(PGChildNodeView, VacuumSettings, SchemaDiffObjectCompare):
                 if k in ('comment',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 
@@ -2158,7 +2158,7 @@ class MViewNode(ViewNode, VacuumSettings):
 
         # Below will decide if it's refresh data or refresh concurrently
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         is_concurrent = data['concurrent']

--- a/web/pgadmin/browser/server_groups/servers/databases/subscriptions/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/subscriptions/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Subscription Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups.servers import databases
@@ -402,7 +402,7 @@ class SubscriptionView(PGChildNodeView, SchemaDiffObjectCompare):
             subid: Subscription ID
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -441,7 +441,7 @@ class SubscriptionView(PGChildNodeView, SchemaDiffObjectCompare):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
         for arg in required_args:
             if arg not in data:
@@ -497,7 +497,7 @@ class SubscriptionView(PGChildNodeView, SchemaDiffObjectCompare):
         """
         if subid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [subid]}
@@ -558,7 +558,7 @@ class SubscriptionView(PGChildNodeView, SchemaDiffObjectCompare):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
         try:

--- a/web/pgadmin/browser/server_groups/servers/pgagent/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements the pgAgent Jobs Node"""
 from functools import wraps
-import simplejson as json
+import json
 from datetime import datetime, time
 
 from flask import render_template, request, jsonify
@@ -407,7 +407,7 @@ SELECT EXISTS(
 
         if jid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [jid]}

--- a/web/pgadmin/browser/server_groups/servers/pgagent/schedules/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/schedules/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements pgAgent Job Schedule Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from flask import render_template, request, jsonify
@@ -341,7 +341,7 @@ class JobScheduleView(PGChildNodeView):
             sid: Server ID
             jid: Job ID
         """
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
         # convert python list literal to postgres array literal.
         format_schedule_data(data)
 
@@ -460,7 +460,7 @@ class JobScheduleView(PGChildNodeView):
 
         if jscid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [jscid]}

--- a/web/pgadmin/browser/server_groups/servers/pgagent/schedules/tests/test_pgagent_add_schedule.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/schedules/tests/test_pgagent_add_schedule.py
@@ -7,7 +7,7 @@
 #
 ##########################################################################
 from unittest.mock import patch
-import simplejson as json
+import json
 import uuid
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils

--- a/web/pgadmin/browser/server_groups/servers/pgagent/steps/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/steps/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements pgAgent Job Step Node"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from flask import render_template, request, jsonify
@@ -480,7 +480,7 @@ SELECT EXISTS(
 
         if jstid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [jstid]}

--- a/web/pgadmin/browser/server_groups/servers/pgagent/steps/tests/test_pgagent_add_steps.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/steps/tests/test_pgagent_add_steps.py
@@ -8,7 +8,7 @@
 ##########################################################################
 from unittest.mock import patch
 
-import simplejson as json
+import json
 import uuid
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils

--- a/web/pgadmin/browser/server_groups/servers/pgagent/steps/tests/test_pgagent_put_steps.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/steps/tests/test_pgagent_put_steps.py
@@ -8,7 +8,7 @@
 ##########################################################################
 from unittest.mock import patch
 
-import simplejson as json
+import json
 import uuid
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils

--- a/web/pgadmin/browser/server_groups/servers/pgagent/tests/test_pgagent_job_add.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/tests/test_pgagent_job_add.py
@@ -8,7 +8,7 @@
 ##########################################################################
 from unittest.mock import patch
 
-import simplejson as json
+import json
 import uuid
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils

--- a/web/pgadmin/browser/server_groups/servers/pgagent/tests/test_pgagent_job_get_msql.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/tests/test_pgagent_job_get_msql.py
@@ -8,7 +8,7 @@
 ##########################################################################
 from unittest.mock import patch
 
-import simplejson as json
+import json
 import uuid
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils

--- a/web/pgadmin/browser/server_groups/servers/pgagent/tests/test_pgagent_job_put.py
+++ b/web/pgadmin/browser/server_groups/servers/pgagent/tests/test_pgagent_job_put.py
@@ -8,7 +8,7 @@
 ##########################################################################
 from unittest.mock import patch
 
-import simplejson as json
+import json
 import uuid
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils

--- a/web/pgadmin/browser/server_groups/servers/resource_groups/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/resource_groups/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Resource Groups for PPAS 9.4 and above"""
 
-import simplejson as json
+import json
 from functools import wraps
 
 from pgadmin.browser.server_groups import servers
@@ -388,7 +388,7 @@ class ResourceGroupView(NodeView):
         ]
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         is_error, errmsg = ResourceGroupView._check_req_parameters(
@@ -484,7 +484,7 @@ class ResourceGroupView(NodeView):
             'name', 'cpu_rate_limit', 'dirty_rate_limit'
         ]
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -539,7 +539,7 @@ class ResourceGroupView(NodeView):
         """
         if rg_id is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [rg_id]}
@@ -598,7 +598,7 @@ class ResourceGroupView(NodeView):
         data = dict()
         for k, v in request.args.items():
             try:
-                data[k] = json.loads(v, encoding='utf-8')
+                data[k] = json.loads(v)
             except ValueError:
                 data[k] = v
 

--- a/web/pgadmin/browser/server_groups/servers/roles/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/__init__.py
@@ -1319,12 +1319,12 @@ WHERE
             data = dict()
 
             if request.data:
-                data = json.loads(request.data, encoding='utf-8')
+                data = json.loads(request.data)
             else:
                 rargs = request.args or request.form
                 for k, v in rargs.items():
                     try:
-                        data[k] = json.loads(v, encoding='utf-8')
+                        data[k] = json.loads(v)
                     except ValueError:
                         data[k] = v
 
@@ -1369,7 +1369,7 @@ WHERE
         Returns: Json object with success/failure status
         """
         if request.data:
-            data = json.loads(request.data, encoding='utf-8')
+            data = json.loads(request.data)
         else:
             data = request.args or request.form
 

--- a/web/pgadmin/browser/server_groups/servers/roles/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/__init__.py
@@ -10,7 +10,7 @@ import re
 from functools import wraps
 
 import pgadmin.browser.server_groups as sg
-import simplejson as json
+import json
 from flask import render_template, request, jsonify, current_app
 from flask_babel import gettext as _
 import dateutil.parser as dateutil_parser
@@ -526,7 +526,7 @@ rolmembership:{
         @wraps(f)
         def wrap(self, **kwargs):
             if request.data:
-                data = json.loads(request.data, encoding='utf-8')
+                data = json.loads(request.data)
             else:
                 data = dict()
                 req = request.args or request.form
@@ -540,7 +540,7 @@ rolmembership:{
                         'rolcatupdate', 'variables', 'rolmembership',
                         'seclabels', 'rolmembers'
                     ]:
-                        data[key] = json.loads(val, encoding='utf-8')
+                        data[key] = json.loads(val)
                     else:
                         data[key] = val
 
@@ -854,7 +854,7 @@ rolmembership:{
 
         if rid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [rid]}

--- a/web/pgadmin/browser/server_groups/servers/tablespaces/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/tablespaces/__init__.py
@@ -6,7 +6,7 @@
 # This software is released under the PostgreSQL Licence
 #
 ##########################################################################
-import simplejson as json
+import json
 import re
 from functools import wraps
 
@@ -292,7 +292,7 @@ class TablespaceView(PGChildNodeView):
         }
 
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         for arg in required_args:
@@ -375,7 +375,7 @@ class TablespaceView(PGChildNodeView):
         This function will update tablespace object
         """
         data = request.form if request.form else json.loads(
-            request.data, encoding='utf-8'
+            request.data
         )
 
         try:
@@ -408,7 +408,7 @@ class TablespaceView(PGChildNodeView):
         """
         if tsid is None:
             data = request.form if request.form else json.loads(
-                request.data, encoding='utf-8'
+                request.data
             )
         else:
             data = {'ids': [tsid]}
@@ -469,7 +469,7 @@ class TablespaceView(PGChildNodeView):
                 if k in ('description',):
                     data[k] = v
                 else:
-                    data[k] = json.loads(v, encoding='utf-8')
+                    data[k] = json.loads(v)
             except ValueError as ve:
                 current_app.logger.exception(ve)
                 data[k] = v

--- a/web/pgadmin/dashboard/__init__.py
+++ b/web/pgadmin/dashboard/__init__.py
@@ -13,7 +13,7 @@ from functools import wraps
 from flask import render_template, url_for, Response, g, request
 from flask_babel import gettext
 from flask_security import login_required
-import simplejson as json
+import json
 from pgadmin.utils import PgAdminModule
 from pgadmin.utils.ajax import make_response as ajax_response,\
     internal_server_error

--- a/web/pgadmin/dashboard/tests/test_dashboard_graphs.py
+++ b/web/pgadmin/dashboard/tests/test_dashboard_graphs.py
@@ -10,7 +10,7 @@
 from pgadmin.utils.route import BaseTestGenerator
 from pgadmin.utils import server_utils
 from regression import parent_node_dict
-import simplejson as json
+import json
 
 
 class DashboardGraphsTestCase(BaseTestGenerator):

--- a/web/pgadmin/misc/cloud/__init__.py
+++ b/web/pgadmin/misc/cloud/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Cloud Deployment"""
 
-import simplejson as json
+import json
 from flask import Response, url_for
 from flask import render_template, request
 from flask_babel import gettext
@@ -128,7 +128,7 @@ def get_host_ip():
 def deploy_on_cloud():
     """Deploy on Cloud."""
 
-    data = json.loads(request.data, encoding='utf-8')
+    data = json.loads(request.data)
     if data['cloud'] == 'rds':
         status, p, resp = deploy_on_rds(data)
     elif data['cloud'] == 'biganimal':
@@ -237,7 +237,7 @@ def update_cloud_process(sid):
 @login_required
 def update_cloud_server():
     """Update Cloud Server."""
-    server_data = json.loads(request.data, encoding='utf-8')
+    server_data = json.loads(request.data)
     status, server = update_server(server_data)
 
     if not status:

--- a/web/pgadmin/misc/cloud/azure/__init__.py
+++ b/web/pgadmin/misc/cloud/azure/__init__.py
@@ -15,7 +15,7 @@ from pgadmin.misc.bgprocess.processes import BatchProcess
 from pgadmin import make_json_response
 from pgadmin.utils import PgAdminModule
 from flask_security import login_required
-import simplejson as json
+import json
 from flask import session, current_app, request
 from flask_login import current_user
 from config import root
@@ -69,7 +69,7 @@ blueprint = AzurePostgresqlModule(MODULE_NAME, __name__,
 @login_required
 def verify_credentials():
     """Verify Credentials."""
-    data = json.loads(request.data, encoding='utf-8')
+    data = json.loads(request.data)
     session_token = data['secret']['session_token'] if \
         'session_token' in data['secret'] else None
     tenant_id = data['secret']['azure_tenant_id'] if \

--- a/web/pgadmin/misc/cloud/biganimal/__init__.py
+++ b/web/pgadmin/misc/cloud/biganimal/__init__.py
@@ -13,7 +13,6 @@ import requests
 import json
 import pickle
 from flask_babel import gettext
-import simplejson as json
 from flask import session, current_app
 from flask_security import login_required
 from werkzeug.datastructures import Headers

--- a/web/pgadmin/misc/cloud/rds/__init__.py
+++ b/web/pgadmin/misc/cloud/rds/__init__.py
@@ -24,7 +24,7 @@ from pgadmin.misc.bgprocess.processes import BatchProcess
 from pgadmin.utils.ajax import make_json_response,\
     internal_server_error, bad_request, success_return
 from .regions import AWS_REGIONS
-import simplejson as json
+import json
 
 from config import root
 
@@ -59,7 +59,7 @@ blueprint = RDSModule(MODULE_NAME, __name__,
 def verify_credentials():
     """Verify Credentials."""
     msg = ''
-    data = json.loads(request.data, encoding='utf-8')
+    data = json.loads(request.data)
 
     session_token = data['secret']['session_token'] if\
         'session_token' in data['secret'] else None

--- a/web/pgadmin/misc/file_manager/__init__.py
+++ b/web/pgadmin/misc/file_manager/__init__.py
@@ -20,7 +20,7 @@ import config
 import codecs
 import pathlib
 
-import simplejson as json
+import json
 from flask import render_template, Response, session, request as req, \
     url_for, current_app, send_from_directory
 from flask_babel import gettext

--- a/web/pgadmin/preferences/__init__.py
+++ b/web/pgadmin/preferences/__init__.py
@@ -13,7 +13,7 @@ side and for getting/setting preferences.
 """
 
 import config
-import simplejson as json
+import json
 from flask import render_template, url_for, Response, request, session
 from flask_babel import gettext
 from flask_security import login_required

--- a/web/pgadmin/settings/__init__.py
+++ b/web/pgadmin/settings/__init__.py
@@ -254,7 +254,7 @@ def get_file_format_setting():
     data = dict()
     for k, v in request.args.items():
         try:
-            data[k] = json.loads(v, encoding='utf-8')
+            data[k] = json.loads(v)
         except (ValueError, TypeError, KeyError):
             data[k] = v
 

--- a/web/pgadmin/tools/backup/__init__.py
+++ b/web/pgadmin/tools/backup/__init__.py
@@ -8,7 +8,7 @@
 ##########################################################################
 """Implements Backup Utility"""
 
-import simplejson as json
+import json
 import os
 import functools
 import operator
@@ -328,7 +328,7 @@ def create_backup_objects_job(sid):
         None
     """
 
-    data = json.loads(request.data, encoding='utf-8')
+    data = json.loads(request.data)
     backup_obj_type = data.get('type', 'objects')
 
     try:

--- a/web/pgadmin/tools/backup/tests/test_backup_create_job_unit_test.py
+++ b/web/pgadmin/tools/backup/tests/test_backup_create_job_unit_test.py
@@ -7,7 +7,7 @@
 #
 ##########################################################################
 
-import simplejson as json
+import json
 import os
 
 from pgadmin.utils.route import BaseTestGenerator

--- a/web/pgadmin/tools/backup/tests/test_backup_utils.py
+++ b/web/pgadmin/tools/backup/tests/test_backup_utils.py
@@ -9,7 +9,7 @@
 
 import time
 import secrets
-import simplejson as json
+import json
 
 
 def create_backup_job(tester, url, params, assert_equal):

--- a/web/pgadmin/tools/debugger/__init__.py
+++ b/web/pgadmin/tools/debugger/__init__.py
@@ -9,7 +9,7 @@
 
 """A blueprint module implementing the debugger"""
 
-import simplejson as json
+import json
 import secrets
 import re
 import copy
@@ -827,7 +827,7 @@ def initialize_target(debug_type, trans_id, sid, did,
     # be be required
     if request.data:
         de_inst.function_data['args_value'] = \
-            json.loads(request.data, encoding='utf-8')
+            json.loads(request.data)
 
     # Update the debugger data session variable
     # Here frame_id is required when user debug the multilevel function.
@@ -984,7 +984,7 @@ def start_debugger_listener(trans_id):
     # If user again start the same debug function with different arguments
     # then we need to save that values to session variable and database.
     if request.data:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
         if data:
             de_inst.function_data['args_value'] = data
             de_inst.update_session()
@@ -1609,7 +1609,7 @@ def deposit_parameter_value(trans_id):
 
     if conn.connected():
         # get the data sent through post from client
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
         if data:
             sql = render_template(
@@ -1815,7 +1815,7 @@ def set_arguments_sqlite(sid, did, scid, func_id):
     """
 
     if request.data:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
     try:
         for i in range(0, len(data)):

--- a/web/pgadmin/tools/erd/__init__.py
+++ b/web/pgadmin/tools/erd/__init__.py
@@ -8,7 +8,7 @@
 ##########################################################################
 
 """A blueprint module implementing the erd tool."""
-import simplejson as json
+import json
 
 from flask import url_for, request, Response
 from flask import render_template, current_app as app
@@ -615,7 +615,7 @@ def translate_foreign_keys(tab_fks, tab_data, all_nodes):
                  endpoint='sql')
 @login_required
 def sql(trans_id, sgid, sid, did):
-    data = json.loads(request.data, encoding='utf-8')
+    data = json.loads(request.data)
     with_drop = False
     if request.args and 'with_drop' in request.args:
         with_drop = True if request.args.get('with_drop') == 'true' else False

--- a/web/pgadmin/tools/grant_wizard/__init__.py
+++ b/web/pgadmin/tools/grant_wizard/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Grant Wizard"""
 
-import simplejson as json
+import json
 from flask import Response, url_for
 from flask import render_template, request, current_app
 from flask_babel import gettext

--- a/web/pgadmin/tools/import_export/__init__.py
+++ b/web/pgadmin/tools/import_export/__init__.py
@@ -9,7 +9,7 @@
 
 """A blueprint module implementing the import and export functionality"""
 
-import simplejson as json
+import json
 import os
 import copy
 from flask import url_for, Response, render_template, request, current_app
@@ -233,9 +233,9 @@ def create_import_export_job(sid):
         None
     """
     if request.form:
-        data = json.loads(request.form['data'], encoding='utf-8')
+        data = json.loads(request.form['data'])
     else:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
     # Fetch the server details like hostname, port, roles etc
     server = Server.query.filter_by(

--- a/web/pgadmin/tools/import_export/tests/test_import_export_create_job_unit_test.py
+++ b/web/pgadmin/tools/import_export/tests/test_import_export_create_job_unit_test.py
@@ -7,7 +7,7 @@
 #
 ##########################################################################
 
-import simplejson as json
+import json
 import os
 
 from pgadmin.utils.route import BaseTestGenerator

--- a/web/pgadmin/tools/import_export/tests/test_import_export_utils.py
+++ b/web/pgadmin/tools/import_export/tests/test_import_export_utils.py
@@ -9,7 +9,7 @@
 
 import time
 import secrets
-import simplejson as json
+import json
 import uuid
 
 from regression import parent_node_dict

--- a/web/pgadmin/tools/maintenance/__init__.py
+++ b/web/pgadmin/tools/maintenance/__init__.py
@@ -9,7 +9,7 @@
 
 """A blueprint module implementing the maintenance tool for vacuum"""
 
-import simplejson as json
+import json
 
 from flask import url_for, Response, render_template, request, current_app
 from flask_babel import gettext as _
@@ -190,9 +190,9 @@ def create_maintenance_job(sid, did):
         None
     """
     if request.form:
-        data = json.loads(request.form['data'], encoding='utf-8')
+        data = json.loads(request.form['data'])
     else:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
     index_name = get_index_name(data)
 

--- a/web/pgadmin/tools/maintenance/tests/test_create_maintenance_job.py
+++ b/web/pgadmin/tools/maintenance/tests/test_create_maintenance_job.py
@@ -9,7 +9,7 @@
 
 import time
 import secrets
-import simplejson as json
+import json
 import os
 
 from pgadmin.utils.route import BaseTestGenerator

--- a/web/pgadmin/tools/maintenance/tests/test_maintenance_create_job_unit_test.py
+++ b/web/pgadmin/tools/maintenance/tests/test_maintenance_create_job_unit_test.py
@@ -8,7 +8,7 @@
 ##########################################################################
 
 import os
-import simplejson as json
+import json
 
 from pgadmin.utils.route import BaseTestGenerator
 from regression import parent_node_dict

--- a/web/pgadmin/tools/restore/__init__.py
+++ b/web/pgadmin/tools/restore/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements Restore Utility"""
 
-import simplejson as json
+import json
 import os
 
 from flask import render_template, request, current_app, \
@@ -137,9 +137,9 @@ def _get_create_req_data():
     :return: return data if no error occurred.
     """
     if request.form:
-        data = json.loads(request.form['data'], encoding='utf-8')
+        data = json.loads(request.form['data'])
     else:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
     try:
         _file = filename_with_file_manager_path(data['file'])

--- a/web/pgadmin/tools/restore/tests/test_create_restore_job.py
+++ b/web/pgadmin/tools/restore/tests/test_create_restore_job.py
@@ -11,7 +11,7 @@ import time
 import secrets
 import os
 
-import simplejson as json
+import json
 
 from pgadmin.utils.route import BaseTestGenerator
 from regression import parent_node_dict

--- a/web/pgadmin/tools/restore/tests/test_restore_create_job_unit_test.py
+++ b/web/pgadmin/tools/restore/tests/test_restore_create_job_unit_test.py
@@ -7,7 +7,7 @@
 #
 ##########################################################################
 
-import simplejson as json
+import json
 import os
 
 from pgadmin.utils.route import BaseTestGenerator

--- a/web/pgadmin/tools/schema_diff/__init__.py
+++ b/web/pgadmin/tools/schema_diff/__init__.py
@@ -8,7 +8,7 @@
 ##########################################################################
 
 """A blueprint module implementing the schema_diff frame."""
-import simplejson as json
+import json
 import pickle
 import secrets
 import copy

--- a/web/pgadmin/tools/sqleditor/__init__.py
+++ b/web/pgadmin/tools/sqleditor/__init__.py
@@ -15,7 +15,7 @@ import secrets
 from urllib.parse import unquote
 from threading import Lock
 
-import simplejson as json
+import json
 from config import PG_DEFAULT_DRIVER, ON_DEMAND_RECORD_COUNT,\
     ALLOW_SAVE_PASSWORD
 from werkzeug.user_agent import UserAgent
@@ -198,7 +198,7 @@ def initialize_viewdata(trans_id, cmd_type, obj_type, sgid, sid, did, obj_id):
     """
 
     if request.data:
-        filter_sql = json.loads(request.data, encoding='utf-8')
+        filter_sql = json.loads(request.data)
     else:
         filter_sql = request.args or request.form
 
@@ -363,7 +363,7 @@ def initialize_sqleditor(trans_id, sgid, sid, did=None):
     # reset error if data is sent from the client
     data = {}
     if request.data:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
     req_args = request.args
     if ('recreate' in req_args and
@@ -497,7 +497,7 @@ def _init_sqleditor(trans_id, connect, sgid, sid, did, **kwargs):
 def update_sqleditor_connection(trans_id, sgid, sid, did):
     # Remove transaction Id.
     with sqleditor_close_session_lock:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
 
         if 'gridData' not in session:
             return make_json_response(data={'status': True})
@@ -612,7 +612,7 @@ def validate_filter(sid, did, obj_id):
         obj_id: Id of currently selected object
     """
     if request.data:
-        filter_data = json.loads(request.data, encoding='utf-8')
+        filter_data = json.loads(request.data)
     else:
         filter_data = request.args or request.form
 
@@ -836,7 +836,7 @@ def start_query_tool(trans_id):
 def extract_sql_from_network_parameters(request_data, request_arguments,
                                         request_form_data):
     if request_data:
-        sql_parameters = json.loads(request_data, encoding='utf-8')
+        sql_parameters = json.loads(request_data)
 
         if isinstance(sql_parameters, str):
             return dict(sql=str(sql_parameters), explain_plan=None)
@@ -1249,7 +1249,7 @@ def save(trans_id):
         trans_id: unique transaction id
     """
     if request.data:
-        changed_data = json.loads(request.data, encoding='utf-8')
+        changed_data = json.loads(request.data)
     else:
         changed_data = request.args or request.form
 
@@ -1321,7 +1321,7 @@ def append_filter_inclusive(trans_id):
         trans_id: unique transaction id
     """
     if request.data:
-        filter_data = json.loads(request.data, encoding='utf-8')
+        filter_data = json.loads(request.data)
     else:
         filter_data = request.args or request.form
 
@@ -1376,7 +1376,7 @@ def append_filter_exclusive(trans_id):
         trans_id: unique transaction id
     """
     if request.data:
-        filter_data = json.loads(request.data, encoding='utf-8')
+        filter_data = json.loads(request.data)
     else:
         filter_data = request.args or request.form
 
@@ -1472,7 +1472,7 @@ def set_limit(trans_id):
         trans_id: unique transaction id
     """
     if request.data:
-        limit = json.loads(request.data, encoding='utf-8')
+        limit = json.loads(request.data)
     else:
         limit = request.args or request.form
 
@@ -1650,7 +1650,7 @@ def set_auto_commit(trans_id):
         trans_id: unique transaction id
     """
     if request.data:
-        auto_commit = json.loads(request.data, encoding='utf-8')
+        auto_commit = json.loads(request.data)
     else:
         auto_commit = request.args or request.form
 
@@ -1695,7 +1695,7 @@ def set_auto_rollback(trans_id):
         trans_id: unique transaction id
     """
     if request.data:
-        auto_rollback = json.loads(request.data, encoding='utf-8')
+        auto_rollback = json.loads(request.data)
     else:
         auto_rollback = request.args or request.form
 
@@ -1743,7 +1743,7 @@ def auto_complete(trans_id):
     text_before_cursor = ''
 
     if request.data:
-        data = json.loads(request.data, encoding='utf-8')
+        data = json.loads(request.data)
     else:
         data = request.args or request.form
 
@@ -1803,7 +1803,7 @@ def load_file():
     reads the data and sends back in response
     """
     if request.data:
-        file_data = json.loads(request.data, encoding='utf-8')
+        file_data = json.loads(request.data)
 
     file_path = unquote(file_data['file_name'])
 
@@ -1847,7 +1847,7 @@ def save_file():
     and then save the data to the file
     """
     if request.data:
-        file_data = json.loads(request.data, encoding='utf-8')
+        file_data = json.loads(request.data)
 
     # retrieve storage directory path
     storage_manager_path = get_storage_directory()

--- a/web/pgadmin/tools/sqleditor/__init__.py
+++ b/web/pgadmin/tools/sqleditor/__init__.py
@@ -1043,8 +1043,7 @@ def poll(trans_id):
             'oids': oids,
             'transaction_status': transaction_status,
             'data_obj': data_obj,
-        },
-        encoding=conn.python_encoding
+        }
     )
 
 
@@ -1100,8 +1099,7 @@ def fetch(trans_id, fetch_all=None):
             'has_more_rows': has_more_rows,
             'rows_fetched_from': rows_fetched_from,
             'rows_fetched_to': rows_fetched_to
-        },
-        encoding=conn.python_encoding
+        }
     )
 
 
@@ -1303,8 +1301,7 @@ def save(trans_id):
             'query_results': query_results,
             '_rowid': _rowid,
             'transaction_status': transaction_status
-        },
-        encoding=conn.python_encoding
+        }
     )
 
 

--- a/web/pgadmin/tools/sqleditor/utils/filter_dialog.py
+++ b/web/pgadmin/tools/sqleditor/utils/filter_dialog.py
@@ -9,7 +9,7 @@
 
 """Code to handle data sorting in view data mode."""
 import pickle
-import simplejson as json
+import json
 from flask_babel import gettext
 from flask import current_app
 from pgadmin.utils.ajax import make_json_response, internal_server_error
@@ -73,7 +73,7 @@ class FilterDialog():
         request = kwargs['request']
 
         if request.data:
-            data = json.loads(request.data, encoding='utf-8')
+            data = json.loads(request.data)
         else:
             data = request.args or request.form
 

--- a/web/pgadmin/tools/sqleditor/utils/macros.py
+++ b/web/pgadmin/tools/sqleditor/utils/macros.py
@@ -9,7 +9,7 @@
 
 """Handle Macros for SQL Editor."""
 
-import simplejson as json
+import json
 from flask_babel import gettext
 from flask import current_app, request
 from flask_security import login_required, current_user
@@ -100,7 +100,7 @@ def set_macros():
     """
 
     data = request.form if request.form else json.loads(
-        request.data, encoding='utf-8'
+        request.data
     )
 
     if 'changed' not in data:

--- a/web/pgadmin/tools/sqleditor/utils/tests/test_start_running_query.py
+++ b/web/pgadmin/tools/sqleditor/utils/tests/test_start_running_query.py
@@ -8,7 +8,7 @@
 ##########################################################################
 
 from flask import Response
-import simplejson as json
+import json
 
 from pgadmin.tools.sqleditor.utils.start_running_query import StartRunningQuery
 from pgadmin.utils.exception import ConnectionLost, SSHTunnelConnectionLost

--- a/web/pgadmin/tools/user_management/__init__.py
+++ b/web/pgadmin/tools/user_management/__init__.py
@@ -9,7 +9,7 @@
 
 """Implements pgAdmin4 User Management Utility"""
 
-import simplejson as json
+import json
 from flask import render_template, request, \
     Response, abort, current_app, session
 from flask_babel import gettext as _
@@ -181,7 +181,7 @@ def change_owner():
     """
 
     data = request.form if request.form else json.loads(
-        request.data, encoding='utf-8'
+        request.data
     )
     try:
         new_user = User.query.get(data['new_owner'])
@@ -396,7 +396,7 @@ def save():
     This function is used to add/update/delete users.
     """
     data = request.form if request.form else json.loads(
-        request.data, encoding='utf-8'
+        request.data
     )
 
     try:

--- a/web/pgadmin/utils/ajax.py
+++ b/web/pgadmin/utils/ajax.py
@@ -12,7 +12,7 @@
 import datetime
 import decimal
 
-import simplejson as json
+import json
 from flask import Response
 from flask_babel import gettext as _
 
@@ -58,8 +58,7 @@ def get_no_cache_header():
 
 
 def make_json_response(
-        success=1, errormsg='', info='', result=None, data=None, status=200,
-        encoding='utf-8'
+        success=1, errormsg='', info='', result=None, data=None, status=200
 ):
     """Create a HTML response document describing the results of a request and
     containing the data."""
@@ -72,7 +71,7 @@ def make_json_response(
 
     return Response(
         response=json.dumps(doc, cls=DataTypeJSONEncoder,
-                            separators=(',', ':'), encoding=encoding),
+                            separators=(',', ':')),
         status=status,
         mimetype="application/json",
         headers=get_no_cache_header()

--- a/web/pgadmin/utils/preferences.py
+++ b/web/pgadmin/utils/preferences.py
@@ -13,7 +13,7 @@ module within the system.
 """
 
 import decimal
-import simplejson as json
+import json
 
 import dateutil.parser as dateutil_parser
 from flask import current_app


### PR DESCRIPTION
I don't think anybody needs compatiblity with Python 2.6 any more.

The only difference in API of the standard library json methods and the ones from simplejson is attribute `encoding`, which has been removed in the standard library (for good reasons). On the other hand, the standard library now accepts both `str` and `bytes`, so encoding is not necessary that much (and if it is necessary, it should be done in the class specific encoder anyway).

The only change in API is that `web.pgadmin.utils.ajax.make_json_response()` function lost its `encoding` parameter. It is never used in all pgadmin4 anyway and given that `DataTypeJSONEncoder` produces pure Python `str` anyway, I don't think it is a big loss.