### PR TITLE
grammar fix - 'exist' to 'exists' RLS Switch Warning

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/static/js/table.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/static/js/table.ui.js
@@ -576,7 +576,7 @@ export default class TableSchema extends BaseUISchema {
         if (state.rlspolicy && this.origData.rlspolicy != state.rlspolicy) {
           Notify.alert(
             gettext('Check Policy?'),
-            gettext('Please check if any policy exist. If no policy exists for the table, a default-deny policy is used, meaning that no rows are visible or can be modified by other users')
+            gettext('Please check if any policy exists. If no policy exists for the table, a default-deny policy is used, meaning that no rows are visible or can be modified by other users')
           );
         }
       }


### PR DESCRIPTION
Grammar fix for table RLS enable switch warning. exist should be 'exists'

![image](https://user-images.githubusercontent.com/3104223/223581515-ff046f37-f667-4bc8-b8c0-4a01bd2b377a.png)
