### PR TITLE
Ensure that when execute_scalar is run for multiple queries in single…

### DIFF
--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -987,6 +987,11 @@ WHERE db.datname = current_database()""")
         except Exception:
             print("EXCEPTION.....")
 
+        # If multiple queries are run, make sure to reach
+        # the last query result
+        while cur.nextset():
+            pass
+
         self.row_count = cur.get_rowcount()
         if cur.get_rowcount() > 0:
             res = cur.fetchone()


### PR DESCRIPTION
… SQL then the last query result is returned.