### PR TITLE
chore: add print function for firefox

### DIFF
--- a/tools/update_selenoid_browsers.py
+++ b/tools/update_selenoid_browsers.py
@@ -221,6 +221,8 @@ def edit_browsers_json(browser_name, browser_version):
                     'port': '4444', 'path': '/wd/hub'}})
             (existing_data['firefox']['versions']).update(data_to_insert)
             updated_data = existing_data
+            print(updated_data)
+
     else:
         print("Browser version not matched")
         file_edited = False


### PR DESCRIPTION
As for the edit_browsers_json function, when version data is updated, Chrome case has print function to display updated_data. However, Firefox case lacks it. In order for consistency, add the same print function.