### PR TITLE
Handle cases when psycopg returns bytes instead of a string.

### DIFF
--- a/web/regression/python_test_utils/test_utils.py
+++ b/web/regression/python_test_utils/test_utils.py
@@ -1186,6 +1186,12 @@ def get_server_type(server):
     if isinstance(version_string, tuple):
         version_string = version_string[0]
 
+    # Handle https://github.com/psycopg/psycopg/issues/561
+    try:
+        version_string = version_string.decode()
+    except (UnicodeDecodeError, AttributeError):
+        pass
+
     if "EnterpriseDB" in version_string:
         return 'ppas'
 


### PR DESCRIPTION
This will happen if the test database was initialised using SQL_ASCII encoding.

See https://github.com/psycopg/psycopg/issues/561