### PR TITLE
Handle SQL_ASCII databases when running test cases.

### DIFF
--- a/web/regression/python_test_utils/test_utils.py
+++ b/web/regression/python_test_utils/test_utils.py
@@ -1186,11 +1186,9 @@ def get_server_type(server):
     if isinstance(version_string, tuple):
         version_string = version_string[0]
 
-    # Handle https://github.com/psycopg/psycopg/issues/561
-    try:
+    # Handle SQL_ASCII (https://github.com/psycopg/psycopg/issues/561)
+    if connection.info.encoding == 'ascii'
         version_string = version_string.decode()
-    except (UnicodeDecodeError, AttributeError):
-        pass
 
     if "EnterpriseDB" in version_string:
         return 'ppas'

--- a/web/regression/python_test_utils/test_utils.py
+++ b/web/regression/python_test_utils/test_utils.py
@@ -1187,7 +1187,7 @@ def get_server_type(server):
         version_string = version_string[0]
 
     # Handle SQL_ASCII (https://github.com/psycopg/psycopg/issues/561)
-    if connection.info.encoding == 'ascii'
+    if connection.info.encoding == 'ascii':
         version_string = version_string.decode()
 
     if "EnterpriseDB" in version_string:

--- a/web/regression/python_test_utils/test_utils.py
+++ b/web/regression/python_test_utils/test_utils.py
@@ -1186,6 +1186,12 @@ def get_server_type(server):
     if isinstance(version_string, tuple):
         version_string = version_string[0]
 
+    # Handle https://github.com/psycopg/psycopg/issues/561
+    try:
+        version_string = version_string.decode()
+    except (UnicodeDecodeError, AttributeError):
+        pass
+
     if "EnterpriseDB" in version_string:
         return 'ppas'
 

--- a/web/regression/python_test_utils/test_utils.py
+++ b/web/regression/python_test_utils/test_utils.py
@@ -1187,8 +1187,8 @@ def get_server_type(server):
         version_string = version_string[0]
 
     # Handle SQL_ASCII (https://github.com/psycopg/psycopg/issues/561)
-    if connection.info.encoding == 'ascii':
-        version_string = version_string.decode()
+    version_string = version_string.decode() if \
+        hasattr(version_string, 'decode') else version_string
 
     if "EnterpriseDB" in version_string:
         return 'ppas'


### PR DESCRIPTION
If the database is SQL_ASCII, psycopg will return bytes instead of a string.

See https://github.com/psycopg/psycopg/issues/561, with thanks to the psycopg devs.