### PR TITLE
POC: Feature/gitlab claim check

### DIFF
--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -150,6 +150,41 @@ class OAuth2Authentication(BaseAuthentication):
                 current_app.logger.exception(error_msg)
                 return False, gettext(error_msg)
 
+        if self.oauth2_config[
+                self.oauth2_current_client
+            ]['OAUTH_GITLAB_AUTHZ_ENABLED']:
+
+            allowed = False
+
+            if 'https://gitlab.org/claims/groups/owner' in profile:
+                for role in self.oauth2_config[
+                        self.oauth2_current_client
+                    ]['OAUTH_GITLAB_GROUPS_OWNER_ROLE'].split(' '):
+                    if role in profile['https://gitlab.org/claims/groups/owner']:
+                        allowed = True
+                        break
+
+            if 'https://gitlab.org/claims/groups/maintainer' in profile:
+                for role in self.oauth2_config[
+                        self.oauth2_current_client
+                    ]['OAUTH_GITLAB_GROUPS_MAINTAINER_ROLE'].split(' '):
+                    if role in profile['https://gitlab.org/claims/groups/maintainer']:
+                        allowed = True
+                        break
+
+            if 'https://gitlab.org/claims/groups/developer' in profile:
+                for role in self.oauth2_config[
+                        self.oauth2_current_client
+                    ]['OAUTH_GITLAB_GROUPS_DEVELOPER_ROLE'].split(' '):
+                    if role in profile['https://gitlab.org/claims/groups/developer']:
+                        allowed = True
+                        break
+
+            if not allowed:
+                error_msg = "Your user it's not authorized to access PgAdmin based on your access on GitLab."
+                current_app.logger.exception(error_msg)
+                return False, gettext(error_msg)
+
         user, msg = self.__auto_create_user(username, email)
         if user:
             user = db.session.query(User).filter_by(


### PR DESCRIPTION
Hi colleagues,

I really like the project you guys are working on but I needed an additional authorization checking based on gitlab "Maintainer", "Developer" and "Owner" roles.

these are the additional oauth2 parameters I'm looking at:

```
          'OAUTH_GITLAB_AUTHZ_ENABLED': True,
          'OAUTH_GITLAB_GROUPS_OWNER_ROLE': '',
          'OAUTH_GITLAB_GROUPS_MAINTAINER_ROLE': '',
          'OAUTH_GITLAB_GROUPS_DEVELOPER_ROLE': '',
```

this way we can check if the user is a maintainer on a certain gitlab namespace and allow dev pgadmin to developer roles and prd pgadmin to maintainer roles.

---

this is a POC, I do not intend to enhance. I'm submitting this as I needed this and it has not been decided what to do with it. See https://github.com/pgadmin-org/pgadmin4/issues/4467