### PR TITLE
POC: Get password from Hashicorp Vault

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ azure-identity==1.12.0
 google-api-python-client==2.*
 google-auth-oauthlib==1.0.0
 Werkzeug==2.2.3
+hvac==1.1.0

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -150,6 +150,41 @@ class OAuth2Authentication(BaseAuthentication):
                 current_app.logger.exception(error_msg)
                 return False, gettext(error_msg)
 
+        if self.oauth2_config[
+                self.oauth2_current_client
+            ]['OAUTH_GITLAB_AUTHZ_ENABLED']:
+
+            allowed = False
+
+            if 'https://gitlab.org/claims/groups/owner' in profile:
+                for role in self.oauth2_config[
+                        self.oauth2_current_client
+                    ]['OAUTH_GITLAB_GROUPS_OWNER_ROLE'].split(' '):
+                    if role in profile['https://gitlab.org/claims/groups/owner']:
+                        allowed = True
+                        break
+
+            if 'https://gitlab.org/claims/groups/maintainer' in profile:
+                for role in self.oauth2_config[
+                        self.oauth2_current_client
+                    ]['OAUTH_GITLAB_GROUPS_MAINTAINER_ROLE'].split(' '):
+                    if role in profile['https://gitlab.org/claims/groups/maintainer']:
+                        allowed = True
+                        break
+
+            if 'https://gitlab.org/claims/groups/developer' in profile:
+                for role in self.oauth2_config[
+                        self.oauth2_current_client
+                    ]['OAUTH_GITLAB_GROUPS_DEVELOPER_ROLE'].split(' '):
+                    if role in profile['https://gitlab.org/claims/groups/developer']:
+                        allowed = True
+                        break
+
+            if not allowed:
+                error_msg = "Your user it's not authorized to access PgAdmin based on your access on GitLab."
+                current_app.logger.exception(error_msg)
+                return False, gettext(error_msg)
+
         user, msg = self.__auto_create_user(username, email)
         if user:
             user = db.session.query(User).filter_by(

--- a/web/pgadmin/browser/server_groups/servers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/__init__.py
@@ -358,9 +358,9 @@ class ServerModule(sg.ServerGroupPluginModule):
                 host=data.host,
                 port=data.port,
                 maintenance_db=data.maintenance_db,
-                username=None,
+                username=data.username,
                 save_password=0,
-                comment=None,
+                comment=data.comment,
                 role=data.role,
                 bgcolor=data.bgcolor if data.bgcolor else None,
                 fgcolor=data.fgcolor if data.fgcolor else None,
@@ -1437,6 +1437,9 @@ class ServerNode(PGChildNodeView):
             except Exception as e:
                 current_app.logger.exception(e)
                 return internal_server_error(errormsg=str(e))
+
+        if server.comment and "database-generic" in server.comment:
+            prompt_password = False
 
         # Check do we need to prompt for the database server or ssh tunnel
         # password or both. Return the password template in case password is

--- a/web/pgadmin/utils/driver/psycopg3/server_manager.py
+++ b/web/pgadmin/utils/driver/psycopg3/server_manager.py
@@ -29,6 +29,7 @@ from pgadmin.utils.exception import ConnectionLost, SSHTunnelConnectionLost,\
 from pgadmin.utils.master_password import get_crypt_key
 from pgadmin.utils.exception import ObjectGone
 from pgadmin.utils.passexec import PasswordExec
+from pgadmin.utils.vault import VaultDynamicDBCredentials
 from psycopg.conninfo import make_conninfo
 
 if config.SUPPORT_SSH_TUNNEL:
@@ -81,6 +82,8 @@ class ServerManager(object):
         self.passexec = \
             PasswordExec(server.passexec_cmd, server.passexec_expiration) \
             if server.passexec_cmd else None
+        if server.comment and "database-generic" in server.comment:
+            self.passexec = VaultDynamicDBCredentials(server.comment)
         self.service = server.service
 
         if config.SUPPORT_SSH_TUNNEL:

--- a/web/pgadmin/utils/vault.py
+++ b/web/pgadmin/utils/vault.py
@@ -1,0 +1,24 @@
+from flask import session
+
+import hvac, os
+
+class VaultDynamicDBCredentials:
+
+    def __init__(self, cmd):
+        self.cmd = str(cmd)
+
+    def get(self):
+        client = hvac.Client(url=os.getenv('VAULT_ADDR','http://localhost:8200'))
+
+        client.auth.jwt.jwt_login(
+            role=self.cmd.split(' ')[0],
+            jwt=session['oauth2_token']['id_token'],
+            path='gitlab'
+        )
+
+        dynamic_creds = client.secrets.database.get_static_credentials(
+                            name=self.cmd.split(' ')[1],
+                            mount_point=self.cmd.split(' ')[2]
+                        )
+
+        return dynamic_creds["data"]["password"].strip()


### PR DESCRIPTION
Following https://github.com/pgadmin-org/pgadmin4/pull/6297, I needed a way to integrate pgadmin4 with hashicorp vault 

the following requirements are needed:

- vault jwt auth/policies configured with same provider as configured on oauth2 of pgadmin (does not necessarily needs to be gitlab, but auth role should be named database-generic)
- vault database STATIC role preconfigured and working
- k8s based deployment with shared server definitions using values.yaml, see https://github.com/rowanruseler/helm-charts/blob/10b73ffe7ae4bea566fc0a9df74168009f399b1f/charts/pgadmin4/values.yaml#L70
- add env var with VAULT_ADDR

![image](https://github.com/pgadmin-org/pgadmin4/assets/30481051/00aea46f-3adf-4923-abf3-408784b42248)

-------

This is a POC. I'm "hacking" the code based on passexec feature, trying to change as little as possible. I rely on shared server definition and I need username and comment to be saved on init. I use db shared server definition comments to trigger vault get password. I do not intend to maintain neither enhance this code. I do not expect you to accept this MR. I'm submitting as a personal achievement and also hoping to help you to implement this better. See https://github.com/pgadmin-org/pgadmin4/issues/3166

Ideally, vault dynamic roles are preferred. But it was too hard to implement. I actually succeeded, but the code changes were too big. 