### PR TITLE
Fixed issue of query tool shortcuts not working. #6065

### DIFF
--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -724,7 +724,8 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
     modal: modal,
     params: qtState.params,
     preferences: qtState.preferences,
-  }), [qtState.params, qtState.preferences]);
+    mainContainerRef: containerRef
+  }), [qtState.params, qtState.preferences, containerRef.current]);
 
   const queryToolConnContextValue = React.useMemo(()=>({
     connected: qtState.connected,

--- a/web/pgadmin/tools/sqleditor/static/js/components/sections/ResultSetToolbar.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/sections/ResultSetToolbar.jsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme)=>({
   },
 }));
 
-export function ResultSetToolbar({containerRef, canEdit, totalRowCount}) {
+export function ResultSetToolbar({canEdit, totalRowCount}) {
   const classes = useStyles();
   const eventBus = useContext(QueryToolEventsContext);
   const queryToolCtx = useContext(QueryToolContext);
@@ -150,7 +150,7 @@ export function ResultSetToolbar({containerRef, canEdit, totalRowCount}) {
         callback: (e)=>{e.preventDefault(); downloadResult();}
       }
     },
-  ], containerRef);
+  ], queryToolCtx.mainContainerRef);
 
   return (
     <>

--- a/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
+++ b/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
@@ -629,21 +629,8 @@ def register_query_tool_preferences(self):
     )
 
     self.preference.register(
-        'keyboard_shortcuts', 'btn_conn_status',
-        gettext('Accesskey (Connection status)'), 'keyboardshortcut',
-        {
-            'key': {
-                'key_code': 84,
-                'char': 't'
-            }
-        },
-        category_label=PREF_LABEL_KEYBOARD_SHORTCUTS,
-        fields=accesskey_fields
-    )
-
-    self.preference.register(
-        'keyboard_shortcuts', 'btn_find_options',
-        gettext('Accesskey (Find options)'), 'keyboardshortcut',
+        'keyboard_shortcuts', 'btn_edit_options',
+        gettext('Accesskey (Edit options)'), 'keyboardshortcut',
         {
             'key': {
                 'key_code': 78,


### PR DESCRIPTION
- Few shortcuts of query tool were not working that have been fixed in this PR. 
- Removed connection status shortcut from preferences as per discussion with team as it was not required.
- Renamed the `Find option` shortcut to `Edit options` and using this shortcut will open edit menu in query tool.
- Point 6 (Shift panel does not give focus to scratch pad) has not been fixed tried few things to fix it but did not work.

**Impact area** - All  shortcuts in query tool should function properly including shortcuts of result grid.