### PR TITLE
fixed #6544. Add Folder issue for adding a sub-folder inside a folder.

### DIFF
--- a/web/pgadmin/misc/file_manager/__init__.py
+++ b/web/pgadmin/misc/file_manager/__init__.py
@@ -947,6 +947,8 @@ class Filemanager():
         new_name = name
         count = 0
         while True:
+            if not (path.endswith("/") or name.startswith("/")):
+                path = path + "/"
             file_path = "{}{}/".format(path, new_name)
             create_path = file_path
             if in_dir != "":


### PR DESCRIPTION
Issue root cause is "/" omitted while `file_path` is making from `path` and `name`. Fixed the issue of sub-folder adding issue by adding a if condition that pre-checking "/" is end of the `path` or start of the `name`.