### PR TITLE
Fix PGADMIN_CONFIG_* environment vars

### DIFF
--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -31,7 +31,7 @@ EOF
 
     # This is a bit kludgy, but necessary as the container uses BusyBox/ash as
     # it's shell and not bash which would allow a much cleaner implementation
-    for var in $(env | grep PGADMIN_CONFIG_ | cut -d "=" -f 1); do
+    for var in $(env | grep "^PGADMIN_CONFIG_" | cut -d "=" -f 1); do
         # shellcheck disable=SC2086
         # shellcheck disable=SC2046
         echo ${var#PGADMIN_CONFIG_} = $(eval "echo \$$var") >> /pgadmin4/config_distro.py


### PR DESCRIPTION
We are running pgAdmin in a Kubernetes Cluster with the "Reloader" Application, which reloads the application every time the config changes. To track changes, the config is stored in a hash as an environment variable, which can break the application.

The environment variable used to track changes is called `STAKATER_PGADMIN_CONFIG_CONFIGMAP`, which matches the `grep PGADMIN_CONFIG_` used to find all config related environment variables.

This fix changes the `grep` to only use environment variables that **START** with `PGADMIN_CONFIG_`