### PR TITLE
Mitigate RCE version lookup

### DIFF
--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -287,7 +287,7 @@ def validate_binary_path():
                 # Get the version number by splitting the result string
                 version_string.split(") ", 1)[1].split('.', 1)[0]
             except Exception:
-                version_str += "<b>" + utility + ":</b> " + \
+                version_string += "<b>" + utility + ":</b> " + \
                                "not found on the specified binary path.<br/>"
                 continue
 

--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -278,14 +278,14 @@ def validate_binary_path():
                     text=True
                 )
                 if cmd.returncode == 0:
-                    version_string = cmd.stdout
+                    # Get the version number by splitting the result string
+                    version_string = \
+                        cmd.stdout.split(") ", 1)[1].split('.', 1)[0]
                 else:
                     current_app.logger.warning(
                         'Invalid version command return code'
                     )
                     raise Exception()
-                # Get the version number by splitting the result string
-                version_string.split(") ", 1)[1].split('.', 1)[0]
             except Exception:
                 version_string += "<b>" + utility + ":</b> " + \
                                "not found on the specified binary path.<br/>"


### PR DESCRIPTION
Fixes a Remote Code Execution vulnerability in Postgres version lookup.

The previous pull-request #6764 is insufficient to mitigate the vulnerability. Command substitution does not require double-quotes for instance:

```python
 >>> subprocess.getoutput(r'echo "{0}"'.format("Hello $(whoami)").replace('"', '""'))
Hello gronke
```

Instead we use Popen and resolve the binary path. Execution occurs without shell context.