### PR TITLE
Fixed an issue where all rows and filter rows buttons were disabled for views and other supported nodes. #7011

### DIFF
--- a/web/pgadmin/static/js/UtilityView.jsx
+++ b/web/pgadmin/static/js/UtilityView.jsx
@@ -69,7 +69,6 @@ function UtilityViewContent({panelId, schema, treeNodeInfo, actionType, formType
   const pgAdmin = usePgAdmin();
   const serverInfo = treeNodeInfo && ('server' in treeNodeInfo) &&
   pgAdmin.Browser.serverInfo && pgAdmin.Browser.serverInfo[treeNodeInfo.server._id];
-  const inCatalog = treeNodeInfo && ('catalog' in treeNodeInfo);
   const api = getApiInstance();
   const url = ()=>{
     return urlBase;
@@ -144,7 +143,7 @@ function UtilityViewContent({panelId, schema, treeNodeInfo, actionType, formType
       type: serverInfo.server_type,
       version: serverInfo.version,
     }: undefined,
-    inCatalog: inCatalog,
+    inCatalog: false,
   };
 
   let initData = ()=>new Promise((resolve, reject)=>{

--- a/web/pgadmin/static/js/helpers/ObjectExplorerToolbar.jsx
+++ b/web/pgadmin/static/js/helpers/ObjectExplorerToolbar.jsx
@@ -23,8 +23,8 @@ ToolbarButton.propTypes = {
 export default function ObjectExplorerToolbar() {
   const [menus, setMenus] = useState({
     'query_tool': undefined,
-    'view_all_rows_context_table': undefined,
-    'view_filtered_rows_context_table': undefined,
+    'view_all_rows_context': undefined,
+    'view_filtered_rows_context': undefined,
     'search_objects': undefined,
     'psql': undefined,
   });
@@ -42,8 +42,8 @@ export default function ObjectExplorerToolbar() {
 
     setMenus({
       'query_tool': toolsMenus?.find((m)=>(m.name=='query_tool')),
-      'view_all_rows_context_table': viewMenus?.find((m)=>(m.name=='view_all_rows_context_table')),
-      'view_filtered_rows_context_table': viewMenus?.find((m)=>(m.name=='view_filtered_rows_context_table')),
+      'view_all_rows_context': viewMenus?.find((m)=>(m.name=='view_all_rows_context_' + m.node)),
+      'view_filtered_rows_context': viewMenus?.find((m)=>(m.name=='view_filtered_rows_context_' + m.node)),
       'search_objects': toolsMenus?.find((m)=>(m.name=='search_objects')),
       'psql': toolsMenus?.find((m)=>(m.name=='psql'))
     });
@@ -61,8 +61,8 @@ export default function ObjectExplorerToolbar() {
     <Box display="flex" alignItems="center" gridGap={'2px'}>
       <PgButtonGroup size="small">
         <ToolbarButton icon={<QueryToolIcon />} menuItem={menus['query_tool']} />
-        <ToolbarButton icon={<ViewDataIcon />} menuItem={menus['view_all_rows_context_table']} />
-        <ToolbarButton icon={<RowFilterIcon />} menuItem={menus['view_filtered_rows_context_table']} />
+        <ToolbarButton icon={<ViewDataIcon />} menuItem={menus['view_all_rows_context']} />
+        <ToolbarButton icon={<RowFilterIcon />} menuItem={menus['view_filtered_rows_context']} />
         <ToolbarButton icon={<SearchOutlinedIcon style={{height: '1.4rem'}} />} menuItem={menus['search_objects']} />
         {!_.isUndefined(menus['psql']) && <ToolbarButton icon={<TerminalIcon />} menuItem={menus['psql']} />}
       </PgButtonGroup>


### PR DESCRIPTION
1. Fixed an issue where all rows and filter rows buttons were disabled for views and other supported nodes. #7011
2. Fixed an issue where filter dialog was not editable for catalog objects.