### PR TITLE
Fix PgAdmin not launching on Win32

### DIFF
--- a/runtime/src/js/pgadmin.js
+++ b/runtime/src/js/pgadmin.js
@@ -80,7 +80,7 @@ function startDesktopMode() {
       process.env[key] = updated_path;
     }
 
-    if (platform() === 'win32' && (key === 'PATH' || key == 'Path')) {
+    if (platform() === 'win32' && key.toUpperCase() === 'PATH') {
       let _libpq_path = path.join(path.dirname(path.dirname(path.resolve(pgadminFile))), 'runtime');
       process.env[key] = _libpq_path + ';' + process.env[key];
     }


### PR DESCRIPTION
Fixes https://github.com/pgadmin-org/pgadmin4/issues/7153
Fixes https://github.com/pgadmin-org/pgadmin4/issues/7125

Relates to https://github.com/pgadmin-org/pgadmin4/issues/6296

This will not fix another issue in Linux: https://github.com/pgadmin-org/pgadmin4/issues/7153#issuecomment-1911616554. For that we'll need to add a Linux case.

How does this fix the bug?

Environment variables are not consistent on Windows and are case insensitive.

On a clean machine, the user env `PATH` is spelled `Path`. The system env var is spelled `path`.

I've removed the second check which used the outdated `==` (idea for a lint?).

Then I uppercase the `key` to ensure that we catch `Path`, `path`, `PATH`, `pAtH` and all other variations.

Some output in PowerShell to prove they're case insensitive: 

```
❯ $env:VAR_NAME = "UPPER_CASE"

~
❯ $env:var_name = "lower_case"

~
❯ echo $ENV:VAR_NAME
lower_case

~
❯ echo $ENV:VaR_nAmE
lower_case
```
