### PR TITLE
Fix gravatar wrong default initialization (FORCE_LOWER is False instead of True)

### DIFF
--- a/web/pgadmin/browser/__init__.py
+++ b/web/pgadmin/browser/__init__.py
@@ -374,6 +374,7 @@ def index():
             rating='g',
             default='retro',
             force_default=False,
+            force_lower=True,
             use_ssl=True,
             base_url=None
         )


### PR DESCRIPTION
Fix wrong default for FORCE_LOWER in the FLASK_GRAVATAR module #7175