### PR TITLE
Polish up the system_stats not installed message.

### DIFF
--- a/web/pgadmin/dashboard/static/js/Dashboard.jsx
+++ b/web/pgadmin/dashboard/static/js/Dashboard.jsx
@@ -797,7 +797,7 @@ function Dashboard({
             .then((res) => {
               const data = res.data;
               if(data['ss_present'] == false){
-                setSsMsg(gettext('System stats extension is not installed. You can install the extension in a database using the "CREATE EXTENSION system_stats;" SQL command. Reload the pgAdmin once you installed.'));
+                setSsMsg(gettext('The system_stats extension is not installed. You can install the extension in a database using the "CREATE EXTENSION system_stats;" SQL command. Reload pgAdmin once it is installed.'));
                 setLdid(0);
               } else {
                 setSsMsg('installed');

--- a/web/pgadmin/messages.pot
+++ b/web/pgadmin/messages.pot
@@ -9791,9 +9791,9 @@ msgstr ""
 
 #: pgadmin/dashboard/static/js/Dashboard.jsx:800
 msgid ""
-"The system_stats extension is not installed. You can install the "
-"extension in a database using the \"CREATE EXTENSION system_stats;\" SQL "
-"command. Reload pgAdmin once it is installed."
+"System stats extension is not installed. You can install the extension in"
+" a database using the \"CREATE EXTENSION system_stats;\" SQL command. "
+"Reload the pgAdmin once you installed."
 msgstr ""
 
 #: pgadmin/dashboard/static/js/Dashboard.jsx:808

--- a/web/pgadmin/messages.pot
+++ b/web/pgadmin/messages.pot
@@ -9791,9 +9791,9 @@ msgstr ""
 
 #: pgadmin/dashboard/static/js/Dashboard.jsx:800
 msgid ""
-"System stats extension is not installed. You can install the extension in"
-" a database using the \"CREATE EXTENSION system_stats;\" SQL command. "
-"Reload the pgAdmin once you installed."
+"The system_stats extension is not installed. You can install the "
+"extension in a database using the \"CREATE EXTENSION system_stats;\" SQL "
+"command. Reload pgAdmin once it is installed."
 msgstr ""
 
 #: pgadmin/dashboard/static/js/Dashboard.jsx:808


### PR DESCRIPTION
Suggesting a minor cleanup of the message that tells users that the `system_stats` extension is not installed. If the text needs to be changed in additional files, please let me know and I'll do that as well.