### PR TITLE
Add metainfo file for pgadmin4

### DIFF
--- a/pkg/linux/org.pgadmin.pgadmin4.metainfo.xml
+++ b/pkg/linux/org.pgadmin.pgadmin4.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.pgadmin.pgadmin4</id>
+  <name>pgAdmin 4</name>
+  <project_license>PostgreSQL</project_license>
+  <developer_name>The pgAdmin Development Team</developer_name>
+  <summary>Administration and development platform for PostgreSQL</summary>
+   <description>
+    <p>pgAdmin is the most popular and feature rich Open Source administration and development platform for PostgreSQL, the most advanced Open Source database in the world.</p>
+  </description>
+  <launchable type="desktop-id">org.pgadmin.pgadmin4.desktop</launchable>
+  <content_rating type="oars-1.1"/>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://pgAdmin.org/</url>
+  <screenshots>
+    <screenshot>
+      <caption>Welcome screen, standard theme</caption>
+      <image type="source">https://www.pgadmin.org/static/COMPILED/assets/img/screenshots/pgadmin4-welcome-light.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Server dashboard</caption>
+      <image type="source">https://www.pgadmin.org/static/COMPILED/assets/img/screenshots/pgadmin4-dashboard.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="8.4.0" date="2024-03-07"><url>https://www.pgadmin.org/docs/pgadmin4/8.4/release_notes_8_4.html</url></release>
+    <release version="8.2.0" date="2024-01-11"><url>https://www.pgadmin.org/docs/pgadmin4/8.4/release_notes_8_2.html</url></release>
+  </releases>
+</component>


### PR DESCRIPTION
This is just a basic version of a metainfo file, it could be improved in various aspects, but having something basic already in tree would already be helpful.

Mostly done for https://github.com/pgadmin-org/pgadmin4/issues/4378#issuecomment-1913611551 but can be used by any linux distro and I also heared there are non linux appstores using the format. (not sure if relevant in pgadmins usergroups)

Flathub asked if we can have this file upstream https://github.com/flathub/flathub/pull/5105#discussion_r1545472650

Ideally, your release process would also add a release in this file.