### PR TITLE
Patches for running in a flatpak

### DIFF
--- a/runtime/src/js/misc.js
+++ b/runtime/src/js/misc.js
@@ -26,6 +26,10 @@ const createDir = (dirName) => {
   }
 };
 
+export const insideFlatpak = () => {
+  return platform() === 'linux' && fs.existsSync('/.flatpak-info');
+}
+
 // This function is used to get the python executable path
 // based on the platform. Use this for deployment.
 const getPythonPath = () => {
@@ -37,8 +41,11 @@ const getPythonPath = () => {
   case 'darwin':
     pythonPath = '../../Frameworks/Python.framework/Versions/Current/bin/python3';
     break;
-  case 'linux':
-    pythonPath = '../venv/bin/python3';
+    case 'linux':
+      pythonPath = '../venv/bin/python3';
+      if (insideFlatpak()) {
+        pythonPath = '/usr/bin/python';
+      }
     break;
   default:
     if (platform().startsWith('win')) {

--- a/runtime/src/js/pgadmin.js
+++ b/runtime/src/js/pgadmin.js
@@ -29,6 +29,10 @@ let pythonPath = misc.getPythonPath();
 let pgadminFile = '../web/pgAdmin4.py';
 let configFile = '../web/config.py';
 
+if (insideFlatpak()) {
+  pgadminFile = '/app/pgAdmin4/web/pgAdmin4.py';
+}
+
 // Override the paths above, if a developer needs to
 if (fs.existsSync('dev_config.json')) {
   try {


### PR DESCRIPTION
These are the needed patches we would need to be able to run pgadmin in a flatpak.

They stem of the work in https://github.com/flathub/flathub/pull/5105/files where we're doing this (much) worse with `sed`.

I think there might be a better solution for parts of this, but I'm not sure how to get there. Having this up-streamed at least would help us for the time being.