### PR TITLE
Disabled ERD for catalogs and other fixes.

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/static/js/table.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/static/js/table.js
@@ -125,6 +125,9 @@ define('pgadmin.node.table', [
           name: 'generate_erd', node: 'table', module: this,
           applies: ['object', 'context'], callback: 'generate_erd',
           category: 'erd', priority: 5, label: gettext('ERD For Table'),
+          enable: (_, item) => {
+            return !('catalog' in pgAdmin.Browser.tree.getTreeNodeHierarchy(item));
+          }
         }
         ]);
         pgBrowser.Events.on(

--- a/web/pgadmin/browser/static/js/keyboard.js
+++ b/web/pgadmin/browser/static/js/keyboard.js
@@ -279,9 +279,9 @@ _.extend(pgBrowser.keyboardNavigation, {
     if (!tree.d || (type !== 'function' && type !== 'procedure'))
       return;
 
-    if (pgAdmin.Tools.Debugger.can_debug(tree.d, tree.i, {'debug_type': 'direct'})) {
+    if (pgAdmin.Tools.Debugger.canDebug(tree.d, tree.i, {'debug_type': 'direct'})) {
       // Call debugger callback
-      pgAdmin.Tools.Debugger.get_function_information(pgAdmin.Browser.Nodes[type]);
+      pgAdmin.Tools.Debugger.getFunctionInformation(pgAdmin.Browser.Nodes[type]);
     }
   },
   isPropertyPanelVisible: function() {


### PR DESCRIPTION
1. Disabled ERD for catalogs. #5849 
2. Disabled debugger for catalogs. #6060
3. Fixed an issue where the keyboard shortcut for launching the debugger from Object Explorer was working.