### PR TITLE
1) Fixed an issue where refreshing the Schema Diff tool opened in a new tab caused an error. #7499

### DIFF
--- a/docs/en_US/release_notes_8_11.rst
+++ b/docs/en_US/release_notes_8_11.rst
@@ -24,12 +24,16 @@ New features
 Housekeeping
 ************
 
+  | `Issue #7776 <https://github.com/pgadmin-org/pgadmin4/issues/7776>`_ -  Introduce custom React Hook useSchemaState to simplify SchemaView component.
 
 Bug fixes
 *********
 
+  | `Issue #7499 <https://github.com/pgadmin-org/pgadmin4/issues/7499>`_ -  Fixed an issue where refreshing the Schema Diff tool opened in a new tab caused an error.
   | `Issue #7540 <https://github.com/pgadmin-org/pgadmin4/issues/7540>`_ -  Fix server heartbeat logging error after deleting the server.
+  | `Issue #7682 <https://github.com/pgadmin-org/pgadmin4/issues/7682>`_ -  Fixed an issue where the Generate Script ignored filter conditions when a parent node was selected.
   | `Issue #7683 <https://github.com/pgadmin-org/pgadmin4/issues/7683>`_ -  Fixed an issue where delete object(shortcut key) affecting both text and Object Explorer items.
   | `Issue #7728 <https://github.com/pgadmin-org/pgadmin4/issues/7728>`_ -  Updated the documentation for web server authentication.
   | `Issue #7737 <https://github.com/pgadmin-org/pgadmin4/issues/7737>`_ -  Fixed an issue where the REVOKE statement in the create script was throwing an error if the role contained special characters.
-
+  | `Issue #7754 <https://github.com/pgadmin-org/pgadmin4/issues/7754>`_ -  Fix an issue where the wheel package is not getting installed on the arm64-based macOS version < 14.
+  | `Issue #7775 <https://github.com/pgadmin-org/pgadmin4/issues/7775>`_ -  Fixed an issue where the value in the find box is not updating with selected text in editor if find is already open and re-triggered.

--- a/web/pgadmin/tools/schema_diff/__init__.py
+++ b/web/pgadmin/tools/schema_diff/__init__.py
@@ -191,21 +191,17 @@ def update_session_diff_transaction(trans_id, session_obj, diff_model_obj):
 
 
 @blueprint.route(
-    '/initialize',
+    '/initialize/<int:trans_id>',
     methods=["GET"],
     endpoint="initialize"
 )
 @pga_login_required
-def initialize():
+def initialize(trans_id):
     """
     This function will initialize the schema diff and return the list
     of all the server's.
     """
-    trans_id = None
     try:
-        # Create a unique id for the transaction
-        trans_id = str(secrets.choice(range(1, 9999999)))
-
         if 'schemaDiff' not in session:
             schema_diff_data = dict()
         else:
@@ -213,7 +209,7 @@ def initialize():
 
         # Use pickle to store the Schema Diff Model which will be used
         # later by the diff module.
-        schema_diff_data[trans_id] = {
+        schema_diff_data[str(trans_id)] = {
             'diff_model_obj': pickle.dumps(SchemaDiffModel(), -1)
         }
 
@@ -223,8 +219,7 @@ def initialize():
     except Exception as e:
         app.logger.exception(e)
 
-    return make_json_response(
-        data={'schemaDiffTransId': trans_id})
+    return make_json_response()
 
 
 @blueprint.route('/close/<int:trans_id>',

--- a/web/pgadmin/tools/schema_diff/static/js/SchemaDiffModule.js
+++ b/web/pgadmin/tools/schema_diff/static/js/SchemaDiffModule.js
@@ -13,6 +13,7 @@ import ReactDOM from 'react-dom/client';
 import gettext from 'sources/gettext';
 import url_for from 'sources/url_for';
 import pgWindow from 'sources/window';
+import * as commonUtils from 'sources/utils';
 
 import getApiInstance from '../../../../static/js/api_instance';
 import Theme from '../../../../static/js/Theme';
@@ -50,7 +51,7 @@ export default class SchemaDiff {
       name: 'schema_diff',
       module: self,
       applies: ['tools'],
-      callback: 'showSchemaDiffTool',
+      callback: 'launchSchemaDiff',
       priority: 1,
       label: gettext('Schema Diff'),
       enable: true,
@@ -58,26 +59,9 @@ export default class SchemaDiff {
     }]);
   }
 
-  showSchemaDiffTool() {
-    let self = this;
-
-    self.api({
-      url: url_for('schema_diff.initialize', null),
-      method: 'GET',
-    })
-      .then(function (res) {
-        self.trans_id = res.data.data.schemaDiffTransId;
-        res.data.data.panel_title = gettext('Schema Diff');
-        self.launchSchemaDiff(res.data.data);
-      })
-      .catch(function (error) {
-        pgAdmin.Browser.notifier.error(gettext(`Error in schema diff initialize ${error.response.data}`));
-      });
-  }
-
-  launchSchemaDiff(data) {
-    let panelTitle = data.panel_title,
-      trans_id = data.schemaDiffTransId;
+  launchSchemaDiff() {
+    let panelTitle = gettext('Schema Diff');
+    const trans_id = commonUtils.getRandomInt(1, 9999999);
 
     let url_params = {
         'trans_id': trans_id,
@@ -114,5 +98,4 @@ export default class SchemaDiff {
       </Theme>
     );
   }
-
 }

--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffButtonComponent.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffButtonComponent.jsx
@@ -153,7 +153,7 @@ export function SchemaDiffButtonComponent({ sourceData, targetData, selectedRowI
   };
 
   const generateScript = () => {
-    eventBus.fireEvent(SCHEMA_DIFF_EVENT.TRIGGER_GENERATE_SCRIPT, { sid: targetData.sid, did: targetData.did, selectedIds: selectedRowIds, rows: rows });
+    eventBus.fireEvent(SCHEMA_DIFF_EVENT.TRIGGER_GENERATE_SCRIPT, { sid: targetData.sid, did: targetData.did, selectedIds: selectedRowIds, rows: rows, selectedFilters: selectedFilters });
   };
 
   return (

--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffCompare.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffCompare.jsx
@@ -56,11 +56,11 @@ function checkAndGetSchemaQuery(data, script_array) {
   }
 }
 
-function getGenerateScriptData(rows, selectedIds, script_array) {
+function getGenerateScriptData(rows, selectedIds, script_array, selectedFilters) {
   for (let selRowVal of rows) {
     if (selectedIds.includes(`${selRowVal.id}`)) {
       let data = selRowVal;
-      if (!_.isUndefined(data.diff_ddl)) {
+      if (!_.isUndefined(data.diff_ddl) && selectedFilters.indexOf(data.status) > -1) {
         if (!(data.dependLevel in script_array)) script_array[data.dependLevel] = [];
         checkAndGetSchemaQuery(data, script_array);
         script_array[data.dependLevel].push(data.diff_ddl);
@@ -314,7 +314,7 @@ export function SchemaDiffCompare({ params }) {
     setFilterOptions(filterParams);
   };
 
-  const triggerGenerateScript = ({ sid, did, selectedIds, rows }) => {
+  const triggerGenerateScript = ({ sid, did, selectedIds, rows, selectedFilters }) => {
     setLoaderText(gettext('Generating script...'));
     let generatedScript, scriptHeader;
 
@@ -326,7 +326,7 @@ export function SchemaDiffCompare({ params }) {
     if (selectedIds.length > 0) {
       let script_array = { 1: [], 2: [], 3: [], 4: [], 5: [] },
         script_body = '';
-      getGenerateScriptData(rows, selectedIds, script_array);
+      getGenerateScriptData(rows, selectedIds, script_array, selectedFilters);
 
       generatedScript = generateFinalScript(script_array, scriptHeader, script_body);
       openQueryTool({ sid: sid, did: did, generatedScript: generatedScript, scriptHeader: scriptHeader });

--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffComponent.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffComponent.jsx
@@ -8,15 +8,16 @@
 //////////////////////////////////////////////////////////////
 
 
-import React, { createContext, useMemo, useRef } from 'react';
+import React, { createContext, useMemo, useRef, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import {DividerBox} from 'rc-dock';
 
 import url_for from 'sources/url_for';
+import pgAdmin from 'sources/pgadmin';
+import gettext from 'sources/gettext';
 
 import { Box } from '@mui/material';
-
 import { Results } from './Results';
 import { SchemaDiffCompare } from './SchemaDiffCompare';
 import EventBus from '../../../../../static/js/helpers/EventBus';
@@ -64,6 +65,15 @@ export default function SchemaDiffComponent({params}) {
 
   registerUnload();
 
+  const initializeSchemaDiff = ()=>{
+    api.get(url_for('schema_diff.initialize', {
+      'trans_id': params.transId})
+    )
+      .catch((err) => {
+        pgAdmin.Browser.notifier.error(gettext(`Error in schema diff initialize ${err.response.data}`));
+      });
+  };
+
   function registerUnload() {
     window.addEventListener('unload', ()=>{
       /* Using fetch with keepalive as the browser may
@@ -81,6 +91,10 @@ export default function SchemaDiffComponent({params}) {
         .catch((err)=>console.error(err));
     });
   }
+
+  useEffect(()=>{
+    initializeSchemaDiff();
+  }, []);
 
   return (
     <SchemaDiffContext.Provider value={schemaDiffContextValue}>

--- a/web/pgadmin/tools/schema_diff/tests/test_schema_diff_comp.py
+++ b/web/pgadmin/tools/schema_diff/tests/test_schema_diff_comp.py
@@ -132,10 +132,10 @@ class SchemaDiffTestCase(BaseSocketTestGenerator):
     def runTest(self):
         """ This function will test the schema diff."""
         self.assertEqual(True, self.restored_backup)
-        response = self.tester.get("schema_diff/initialize")
+        self.trans_id = str(secrets.choice(range(1, 99999)))
+        init_url = 'schema_diff/initialize/{}'.format(self.trans_id)
+        response = self.tester.get(init_url)
         self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data.decode('utf-8'))
-        self.trans_id = response_data['data']['schemaDiffTransId']
 
         received = self.socket_client.get_received(self.SOCKET_NAMESPACE)
         assert received[0]['name'] == 'connected'


### PR DESCRIPTION
2) Fixed an issue where the Generate Script ignored filter conditions when a parent node was selected. #7682