### PR TITLE
Introduced a 'exclude' option in the 'Field' to exclude it from the change. (Fixes #7884)

### DIFF
--- a/web/pgadmin/static/js/SchemaView/SchemaState/common.js
+++ b/web/pgadmin/static/js/SchemaView/SchemaState/common.js
@@ -149,6 +149,9 @@ export function getSchemaDataDiff(
     };
 
     schema.fields.forEach((field) => {
+      // Never include data from the field in the changes, marked as
+      // 'excluded'.
+      if (field.exclude) return;
       /*
        * If skipChange is true, then field will not be considered for changed
        * data. This is helpful when 'Save' or 'Reset' should not be enabled on

--- a/web/pgadmin/tools/import_export/static/js/import_export.ui.js
+++ b/web/pgadmin/tools/import_export/static/js/import_export.ui.js
@@ -220,7 +220,7 @@ export default class ImportExportSchema extends BaseUISchema {
             multiple: true, allowClear: false,
             placeholder:
               this._type === 'i' ? gettext('Columns for importing...') :
-              gettext('Columns for exporting...'),
+                gettext('Columns for exporting...'),
           },
         }),
         deps:['is_import'],

--- a/web/pgadmin/tools/import_export/static/js/import_export.ui.js
+++ b/web/pgadmin/tools/import_export/static/js/import_export.ui.js
@@ -200,16 +200,29 @@ export default class ImportExportSchema extends BaseUISchema {
         id: 'columns',
         label: gettext(this.colums_selection_label[this._type]),
         group: gettext('Columns'),
-        type: 'select',
-        options: obj.fieldOptions.columns,
-        optionsLoaded: (options) => {
-          obj.notNullColOptions = options.map((o) => {
-            return { ...o, selected: false };
-          });
-        },
-        controlProps:{multiple: true, allowClear: false,
-          placeholder: this._type === 'i' ? gettext('Columns for importing...') : gettext('Columns for exporting...'),
-        },
+        type: () => ({
+          type: 'select',
+          options: obj.fieldOptions.columns,
+          optionsLoaded: (options) => {
+            obj.notNullColOptions = options.map((o) => {
+              return { ...o, selected: false };
+            });
+
+            if (!obj.state) return;
+
+            const data = obj.state.data;
+            obj.state.data = {
+              ...data,
+              notNullColOptions: obj.notNullColOptions,
+            };
+          },
+          controlProps:{
+            multiple: true, allowClear: false,
+            placeholder:
+              this._type === 'i' ? gettext('Columns for importing...') :
+              gettext('Columns for exporting...'),
+          },
+        }),
         deps:['is_import'],
         depChange:(state)=>{
           this._type = state.is_import? 'i' : 'e';
@@ -220,19 +233,23 @@ export default class ImportExportSchema extends BaseUISchema {
         id: 'icolumns',
         label: gettext('NOT NULL columns'),
         group: gettext('Columns'),
-        deps: ['format', 'is_import'],
+        deps: ['format', 'is_import', 'notNullColOptions'],
         type: () => ({
           type: 'select',
           options: obj.notNullColOptions,
           optionsReloadBasis: obj.notNullColOptions.length,
           controlProps: {
-            multiple: true, allowClear: true, placeholder: gettext('Not null columns...'),
+            multiple: true, allowClear: true,
+            placeholder: gettext('Not null columns...'),
           },
         }),
         disabled:function(state){
           return (state?.format != 'csv' || !state?.is_import);
         },
         helpMessage: gettext('Do not match the specified column values against the null string. In the default case where the null string is empty, this means that empty values will be read as zero-length strings rather than nulls, even when they are not quoted. This option is allowed only in import, and only when using CSV format.'),
+      },
+      {
+        id: 'notNullColOptions', exclude: true, visible: false, type: 'text',
       }
     ];
   }


### PR DESCRIPTION
Use the option 'exclude' to add field 'notNullColumns', which will be excluded from the data, in the 'Import/Export' UI Schema. It will help to force re-render the 'Not Null Columns' select control on change of 'notNullColumns' data availability.