### PR TITLE
 Fixed an issue introduced due to reloading of the tree due to changes in particular preferences

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_configurations/static/js/fts_configuration.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_configurations/static/js/fts_configuration.ui.js
@@ -16,15 +16,15 @@ class TokenHeaderSchema extends BaseUISchema {
   constructor(tokenOptions) {
     super({
       token: undefined,
-      isNew: false,
+      isNew: true,
     });
 
     this.tokenOptions = tokenOptions;
   }
 
   set isNewFTSConf(flag) {
-    if (!this.state) return;
-    this.state.data = {...this.state.data, isNew: flag};
+    if (this.state)
+      this.state.data = {...this.state.data, isNew: flag};
   }
 
   getNewData(data) {
@@ -42,9 +42,11 @@ class TokenHeaderSchema extends BaseUISchema {
         type: 'select',
         options: this.tokenOptions,
       }),
-      disabled: function() { return obj.isNewFTSConf; }
-    }, {
-      id: 'isNew', visible: false, type: 'text',
+      disabled: function(state) {
+        return this.state ? this.state.data.isNew : true;
+      }
+    },{
+      id: 'isNew', visible: false, type: 'text', exclude: true,
     }];
   }
 }
@@ -160,12 +162,15 @@ export default class FTSConfigurationSchema extends BaseUISchema {
       }, {
         id: 'tokens', label: '', type: 'collection',
         group: gettext('Tokens'), mode: ['create','edit'],
-        editable: false, schema: this.tokColumnSchema,
+        schema: this.tokColumnSchema,
         headerSchema: this.tokHeaderSchema,
         headerFormVisible: true,
         GridHeader: DataGridFormHeader,
         uniqueCol : ['token'],
-        canAdd: true, canEdit: false, canDelete: true,
+        canAdd: (state, viewHelpderProps) => {
+          return viewHelpderProps.mode !== 'create'
+        },
+        canDelete: true,
       }
     ];
   }

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_configurations/static/js/fts_configuration.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/fts_configurations/static/js/fts_configuration.ui.js
@@ -35,14 +35,13 @@ class TokenHeaderSchema extends BaseUISchema {
   }
 
   get baseFields() {
-    let obj = this;
     return [{
       id: 'token', label: gettext('Tokens'), deps: ['isNew'],
       type: () => ({
         type: 'select',
         options: this.tokenOptions,
       }),
-      disabled: function(state) {
+      disabled: function() {
         return this.state ? this.state.data.isNew : true;
       }
     },{
@@ -167,9 +166,7 @@ export default class FTSConfigurationSchema extends BaseUISchema {
         headerFormVisible: true,
         GridHeader: DataGridFormHeader,
         uniqueCol : ['token'],
-        canAdd: (state, viewHelpderProps) => {
-          return viewHelpderProps.mode !== 'create'
-        },
+        canAdd: (state, helpderProps) => (helpderProps.mode !== 'create'),
         canDelete: true,
       }
     ];

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/static/js/function.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/static/js/function.ui.js
@@ -331,14 +331,14 @@ export default class FunctionSchema extends BaseUISchema {
         (source[source.length - 1] !== 'lanname') ? undefined : (
           obj.isLessThan95ORNonSPL(state)
         ) ? {
-          provolatile: null,
-          proisstrict: false,
-          procost: null,
-          proleakproof: false,
-          proparallel: null,
-        } : (
-          obj.isLessThan95ORNonSPL(state) ? { proparallel: null } : undefined
-        )
+            provolatile: null,
+            proisstrict: false,
+            procost: null,
+            proleakproof: false,
+            proparallel: null,
+          } : (
+            obj.isLessThan95ORNonSPL(state) ? { proparallel: null } : undefined
+          )
       ),
     },{
       id: 'prosecdef', label: gettext('Security of definer?'),

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/static/js/trigger_function.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/static/js/trigger_function.ui.js
@@ -161,10 +161,7 @@ export default class TriggerFunctionSchema extends BaseUISchema {
         type: 'sql', isFullTab: true,
         mode: ['properties', 'create', 'edit'],
         group: gettext('Code'), deps: ['lanname'],
-        visible: (state) => {
-          return state.lanname !== 'c';
-        },
-        disabled: obj.isDisabled, readonly: obj.isReadonly,
+        readonly: (state) => (obj.isDisabled() || state.lanname === 'c'),
       },{
         id: 'probin', label: gettext('Object file'), cell: 'string',
         type: 'text', group: gettext('Definition'), deps: ['lanname'],
@@ -260,8 +257,8 @@ export default class TriggerFunctionSchema extends BaseUISchema {
 
     if (isEmptyString(state.service)) {
 
-      /* code validation*/
-      if (isEmptyString(state.prosrc)) {
+      /* code validation */
+      if (isEmptyString(state.prosrc) && state.lanname !== 'c') {
         errmsg = gettext('Code cannot be empty.');
         setError('prosrc', errmsg);
         return true;

--- a/web/pgadmin/static/js/SchemaView/DataGridView/formHeader.jsx
+++ b/web/pgadmin/static/js/SchemaView/DataGridView/formHeader.jsx
@@ -77,7 +77,7 @@ export function DataGridFormHeader({tableEleRef}) {
     viewHelperProps,
   } = useContext(DataGridContext);
   const {
-    addOnTop, canAddRow, canEdit, expandEditOnAdd, headerFormVisible
+    canAdd, addOnTop, canAddRow, canEdit, expandEditOnAdd, headerFormVisible
   } = options;
   const rows = table.getRowModel().rows;
 
@@ -85,8 +85,12 @@ export function DataGridFormHeader({tableEleRef}) {
   const newRowIndex = useRef(-1);
   const schemaState = useContext(SchemaStateContext);
   const headerFormData = useRef({});
-  const [addDisabled, setAddDisabled] = useState(canAddRow);
+  const [addDisabled, setAddDisabled] = useState(!canAdd || !canAddRow);
   const {headerSchema} = field;
+  const disableAddButton = (flag) => {
+    if (!canAdd || !canAddRow) return;
+    setAddDisabled(flag);
+  };
 
   const onAddClick = useCallback(() => {
 
@@ -154,8 +158,8 @@ export function DataGridFormHeader({tableEleRef}) {
             showFooter={false}
             onDataChange={(isDataChanged, dataChanged)=>{
               headerFormData.current = dataChanged;
-              setAddDisabled(
-                canAddRow && headerSchema.addDisabled(headerFormData.current)
+              disableAddButton(
+                headerSchema.addDisabled(headerFormData.current)
               );
             }}
             hasSQL={false}

--- a/web/pgadmin/static/js/SchemaView/SchemaState/reducer.js
+++ b/web/pgadmin/static/js/SchemaView/SchemaState/reducer.js
@@ -114,7 +114,7 @@ export const sessDataReducer = (state, action) => {
     return data;
 
   case SCHEMA_STATE_ACTIONS.DEFERRED_DEPCHANGE:
-    data = getDepChange(action.path, data, state, action);
+    data = getDepChange(action.path, _.cloneDeep(data), state, action);
     break;
   }
 

--- a/web/pgadmin/static/js/SchemaView/hooks/useFieldError.js
+++ b/web/pgadmin/static/js/SchemaView/hooks/useFieldError.js
@@ -9,9 +9,7 @@
 
 import { useEffect } from 'react';
 
-const convertKeysToString = (arr) => {
-  return (arr||[]).map((key) => String(key))
-};
+const convertKeysToString = (arr) => (arr||[]).map((key) => String(key));
 const isPathEqual = (path1, path2) => (
   Array.isArray(path1) &&
   Array.isArray(path2) &&

--- a/web/pgadmin/static/js/SchemaView/hooks/useFieldError.js
+++ b/web/pgadmin/static/js/SchemaView/hooks/useFieldError.js
@@ -9,10 +9,11 @@
 
 import { useEffect } from 'react';
 
+const convertKeysToString = (arr) => (arr||[]).map((key) => String(key));
 const isPathEqual = (path1, path2) => (
-  JSON.stringify(path1) === JSON.stringify(path2)
+  JSON.stringify(convertKeysToString(path1)) ===
+  JSON.stringify(convertKeysToString(path2))
 );
-
 
 export const useFieldError = (path, schemaState, subscriberManager) => {
 

--- a/web/pgadmin/static/js/SchemaView/hooks/useFieldError.js
+++ b/web/pgadmin/static/js/SchemaView/hooks/useFieldError.js
@@ -9,8 +9,12 @@
 
 import { useEffect } from 'react';
 
-const convertKeysToString = (arr) => (arr||[]).map((key) => String(key));
+const convertKeysToString = (arr) => {
+  return (arr||[]).map((key) => String(key))
+};
 const isPathEqual = (path1, path2) => (
+  Array.isArray(path1) &&
+  Array.isArray(path2) &&
   JSON.stringify(convertKeysToString(path1)) ===
   JSON.stringify(convertKeysToString(path2))
 );
@@ -39,7 +43,9 @@ export const useFieldError = (path, schemaState, subscriberManager) => {
   });
 
   const errors = schemaState?.errors || {};
-  const error = isPathEqual(errors.name, path) ? errors.message : null;
+  const error = (
+    Array.isArray(errors.name) && isPathEqual(errors.name, path)
+  ) ? errors.message : null;
 
   return {hasError: !_.isNull(error), error};
 };

--- a/web/pgadmin/static/js/helpers/withStandardTabInfo.jsx
+++ b/web/pgadmin/static/js/helpers/withStandardTabInfo.jsx
@@ -67,13 +67,23 @@ export default function withStandardTabInfo(Component, tabId) {
       };
     }, []);
 
+    ////////
+    // Special case:
+    //
+    // When the tree is being recreated during reloading on changes of some
+    // preferences, it is possible that the tree returns 'selected' node, but -
+    // it does not have the 'treeNodeInfo' as it was actually part of the
+    // previous instance of the tree.
+    //
+    // In that case - we consider that there is no node selected in the tree.
+    ///////
     return (
       <ErrorBoundary>
         <Component
           {...props}
-          nodeItem={nodeItem}
-          nodeData={nodeData}
-          node={node}
+          nodeItem={treeNodeInfo ? nodeItem : undefined}
+          nodeData={treeNodeInfo ? nodeData : undefined}
+          node={treeNodeInfo ? node : undefined}
           treeNodeInfo={treeNodeInfo}
           isActive={isActive}
           isStale={isStale}

--- a/web/pgadmin/tools/sqleditor/static/js/components/dialogs/NewConnectionDialog.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/dialogs/NewConnectionDialog.jsx
@@ -52,7 +52,7 @@ class NewConnectionSchema extends BaseUISchema {
     if(this.groupedServers?.length != 0) {
       return Promise.resolve(this.groupedServers);
     }
-    return new Promise((resolve, reject)=>{
+    return new Promise((resolve, reject) => {
       this.api.get(url_for('sqleditor.get_new_connection_servers'))
         .then(({data: respData})=>{
           let groupedOptions = [];
@@ -61,7 +61,7 @@ class NewConnectionSchema extends BaseUISchema {
               return;
             }
             /* initial selection */
-            let foundServer = _.find(v, (o)=>o.value==obj.params.sid);
+            let foundServer = _.find(v, (o) => o.value == obj.params.sid);
             foundServer && (foundServer.selected = true);
             groupedOptions.push({
               label: k,
@@ -69,7 +69,7 @@ class NewConnectionSchema extends BaseUISchema {
             });
           });
           /* Will be re-used for changing icon when connected */
-          this.groupedServers = groupedOptions.map((group)=>{
+          this.groupedServers = groupedOptions.map((group) => {
             return {
               label: group.label,
               options: group.options.map((o)=>({...o, selected: false})),
@@ -118,18 +118,19 @@ class NewConnectionSchema extends BaseUISchema {
           optionsLoaded: (res) => self.flatServers = flattenSelectOptions(res),
           optionsReloadBasis: self.flatServers.map((s) => s.connected).join(''),
         }),
-        depChange: (state)=>{
+        depChange: (state) => {
           /* Once the option is selected get the name */
           /* Force sid to null, and set only if connected */
           let selectedServer = _.find(
             self.flatServers, (s) => s.value == state.sid
           );
+
           return {
             server_name: selectedServer?.label,
             did: null,
             user: null,
             role: null,
-            sid: null,
+            sid: state.sid,
             fgcolor: selectedServer?.fgcolor,
             bgcolor: selectedServer?.bgcolor,
             connected: selectedServer?.connected,
@@ -138,6 +139,7 @@ class NewConnectionSchema extends BaseUISchema {
         deferredDepChange: (state, source, topState, actionObj) => {
           return new Promise((resolve) => {
             let sid = actionObj.value;
+
             if(!_.find(self.flatServers, (s) => s.value == sid)?.connected) {
               this.connectServer(sid, state.user, null, (data) => {
                 self.setServerConnected(sid, data.icon);


### PR DESCRIPTION
Fix an issue - when object browser tree is being recreated due to reloading for changes in some of the preferences. Tree object returns object from the previous instance as 'selected', but - it does not have the 'treeNodeInfo' available. In this special case - we would consider that there is no node selected at that particular moment, and pass information accordingly.