### PR TITLE
Schema Diff bug when comparing materialized views with indices: key 'indrelid' needs to be ignored.

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
@@ -19,7 +19,8 @@ from pgadmin.tools.schema_diff.node_registry import SchemaDiffRegistry
 
 
 class SchemaDiffViewCompare(SchemaDiffObjectCompare):
-    view_keys_to_ignore = ['oid', 'schema', 'xmin', 'oid-2', 'setting', 'indrelid']
+    view_keys_to_ignore = ['oid', 'schema', 'xmin', 'oid-2', 'setting', 
+                           'indrelid']
 
     trigger_keys_to_ignore = ['xmin', 'tgrelid', 'tgfoid', 'tfunction',
                               'tgqual', 'tgconstraint', 'nspname']

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
@@ -19,7 +19,7 @@ from pgadmin.tools.schema_diff.node_registry import SchemaDiffRegistry
 
 
 class SchemaDiffViewCompare(SchemaDiffObjectCompare):
-    view_keys_to_ignore = ['oid', 'schema', 'xmin', 'oid-2', 'setting']
+    view_keys_to_ignore = ['oid', 'schema', 'xmin', 'oid-2', 'setting', 'indrelid']
 
     trigger_keys_to_ignore = ['xmin', 'tgrelid', 'tgfoid', 'tfunction',
                               'tgqual', 'tgconstraint', 'nspname']


### PR DESCRIPTION
Bug fix:
key 'indrelid' of materialized views need to be ignored in schema diff. It is the reference id of a MV that links the indices of the MV to the MV itself, in index table pg_index.

To reproduce the issue:
1. In two different schema, create two identical MVs (materialized views) with index 
2. do a Schema Diff to compare these two schema. The MVs will be listed as being different. But in the "Difference" textbox, the content is empty.