### PR TITLE
add ignore partitions in schema diff

### DIFF
--- a/docs/en_US/preferences.rst
+++ b/docs/en_US/preferences.rst
@@ -562,6 +562,8 @@ Use the *Ignore Tablespace* switch to ignores the tablespace while comparing the
 Use the *Ignore Whitespace* switch to ignores the whitespace while comparing
 the string objects. Whitespace includes space, tabs, and CRLF.
 
+Use the *Ignore Partitions* switch to ignores the partitions while comparing
+the partitions tables. 
 
 The Storage Node
 ****************

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/schema_diff_table_utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/schema_diff_table_utils.py
@@ -59,6 +59,7 @@ class SchemaDiffTableCompare(SchemaDiffObjectCompare):
         ignore_whitespaces = kwargs.get('ignore_whitespaces')
         ignore_tablespace = kwargs.get('ignore_tablespace')
         ignore_grants = kwargs.get('ignore_grants')
+        ignore_partitions = kwargs.get('ignore_partitions')
 
         group_name = kwargs.get('group_name')
         source_schema_name = kwargs.get('source_schema_name', None)
@@ -96,7 +97,8 @@ class SchemaDiffTableCompare(SchemaDiffObjectCompare):
                                     ignore_owner=ignore_owner,
                                     ignore_whitespaces=ignore_whitespaces,
                                     ignore_tablespace=ignore_tablespace,
-                                    ignore_grants=ignore_grants)
+                                    ignore_grants=ignore_grants,
+                                    ignore_partitions=ignore_partitions)
 
     def ddl_compare(self, **kwargs):
         """
@@ -300,6 +302,7 @@ class SchemaDiffTableCompare(SchemaDiffObjectCompare):
         target = kwargs.get('target')
         diff_dict = kwargs.get('diff_dict')
         ignore_whitespaces = kwargs.get('ignore_whitespaces')
+        ignore_partitions = kwargs.get('ignore_partitions')
 
         # Get the difference result for source and target columns
         col_diff = self.table_col_comp(source, target)
@@ -314,7 +317,7 @@ class SchemaDiffTableCompare(SchemaDiffObjectCompare):
         diff = self.get_sql_from_table_diff(**target_params)
 
         ignore_sub_modules = ['column', 'constraints']
-        if self.manager.version < 100000:
+        if self.manager.version < 100000 or ignore_partitions:
             ignore_sub_modules.append('partition')
         if self.manager.server_type == 'pg' or self.manager.version < 120000:
             ignore_sub_modules.append('compound_trigger')

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
@@ -81,7 +81,7 @@ class SchemaDiffViewCompare(SchemaDiffObjectCompare):
                                     ignore_owner=ignore_owner,
                                     ignore_whitespaces=ignore_whitespaces,
                                     ignore_tablespace=ignore_tablespace,
-                                    ignore_grants=ignore_grants
+                                    ignore_grants=ignore_grants,
                                     ignore_partitions=ignore_partitions)
 
     def ddl_compare(self, **kwargs):

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
@@ -127,6 +127,7 @@ class SchemaDiffViewCompare(SchemaDiffObjectCompare):
         target = kwargs.get('target')
         diff_dict = kwargs.get('diff_dict')
         ignore_whitespaces = kwargs.get('ignore_whitespaces')
+        ignore_partitions = kwargs.get('ignore_partitions')
         diff = ''
 
         # Get the difference DDL/DML statements for table
@@ -171,7 +172,8 @@ class SchemaDiffViewCompare(SchemaDiffObjectCompare):
                     "source": source,
                     "target": target,
                     "target_schema": target_schema,
-                    "ignore_whitespaces": ignore_whitespaces
+                    "ignore_whitespaces": ignore_whitespaces,
+                    "ignore_partitions": ignore_partitions
                 }
                 diff = self._compare_source_and_target(
                     intersect_keys, module_view, source_params,

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/schema_diff_view_utils.py
@@ -45,6 +45,7 @@ class SchemaDiffViewCompare(SchemaDiffObjectCompare):
         ignore_whitespaces = kwargs.get('ignore_whitespaces')
         ignore_tablespace = kwargs.get('ignore_tablespace')
         ignore_grants = kwargs.get('ignore_grants')
+        ignore_partitions = kwargs.get('ignore_partitions')
 
         group_name = kwargs.get('group_name')
         source_schema_name = kwargs.get('source_schema_name', None)
@@ -80,7 +81,8 @@ class SchemaDiffViewCompare(SchemaDiffObjectCompare):
                                     ignore_owner=ignore_owner,
                                     ignore_whitespaces=ignore_whitespaces,
                                     ignore_tablespace=ignore_tablespace,
-                                    ignore_grants=ignore_grants)
+                                    ignore_grants=ignore_grants
+                                    ignore_partitions=ignore_partitions)
 
     def ddl_compare(self, **kwargs):
         """

--- a/web/pgadmin/tools/schema_diff/__init__.py
+++ b/web/pgadmin/tools/schema_diff/__init__.py
@@ -485,6 +485,8 @@ def compare_database(params):
         ignore_whitespaces = bool(params['ignore_whitespaces'])
         ignore_tablespace = bool(params['ignore_tablespace'])
         ignore_grants = bool(params['ignore_grants'])
+        ignore_partitions = bool(params['ignore_partitions'])
+
 
         # Fetch all the schemas of source and target database
         # Compare them and get the status.
@@ -514,7 +516,8 @@ def compare_database(params):
                 node_percent=node_percent, ignore_owner=ignore_owner,
                 ignore_whitespaces=ignore_whitespaces,
                 ignore_tablespace=ignore_tablespace,
-                ignore_grants=ignore_grants)
+                ignore_grants=ignore_grants,
+                ignore_partitions=ignore_partitions)
         comparison_result = \
             comparison_result + comparison_schema_result
 
@@ -538,7 +541,8 @@ def compare_database(params):
                         ignore_owner=ignore_owner,
                         ignore_whitespaces=ignore_whitespaces,
                         ignore_tablespace=ignore_tablespace,
-                        ignore_grants=ignore_grants)
+                        ignore_grants=ignore_grants,
+                        ignore_partitions=ignore_partitions)
 
                 comparison_result = \
                     comparison_result + comparison_schema_result
@@ -561,7 +565,8 @@ def compare_database(params):
                         ignore_owner=ignore_owner,
                         ignore_whitespaces=ignore_whitespaces,
                         ignore_tablespace=ignore_tablespace,
-                        ignore_grants=ignore_grants)
+                        ignore_grants=ignore_grants,
+                        ignore_partitions=ignore_partitions)
 
                 comparison_result = \
                     comparison_result + comparison_schema_result
@@ -586,7 +591,8 @@ def compare_database(params):
                         ignore_owner=ignore_owner,
                         ignore_whitespaces=ignore_whitespaces,
                         ignore_tablespace=ignore_tablespace,
-                        ignore_grants=ignore_grants)
+                        ignore_grants=ignore_grants,
+                        ignore_partitions=ignore_partitions)
 
                 comparison_result = \
                     comparison_result + comparison_schema_result
@@ -631,6 +637,8 @@ def compare_schema(params):
         ignore_whitespaces = bool(params['ignore_whitespaces'])
         ignore_tablespace = bool(params['ignore_tablespace'])
         ignore_grants = bool(params['ignore_grants'])
+        ignore_partitions = bool(params['ignore_partitions']) 
+ 
         all_registered_nodes = SchemaDiffRegistry.get_registered_nodes()
         node_percent = round(100 / len(all_registered_nodes), 2)
         total_percent = 0
@@ -651,7 +659,8 @@ def compare_schema(params):
                 ignore_owner=ignore_owner,
                 ignore_whitespaces=ignore_whitespaces,
                 ignore_tablespace=ignore_tablespace,
-                ignore_grants=ignore_grants)
+                ignore_grants=ignore_grants,
+                ignore_partitions=ignore_partitions)
 
         comparison_result = \
             comparison_result + comparison_schema_result
@@ -787,6 +796,7 @@ def compare_database_objects(**kwargs):
     ignore_whitespaces = kwargs.get('ignore_whitespaces')
     ignore_tablespace = kwargs.get('ignore_tablespace')
     ignore_grants = kwargs.get('ignore_grants')
+    ignore_partitions = kwargs.get('ignore_partitions')
     comparison_result = []
 
     all_registered_nodes = SchemaDiffRegistry.get_registered_nodes(None,
@@ -812,7 +822,8 @@ def compare_database_objects(**kwargs):
                                ignore_owner=ignore_owner,
                                ignore_whitespaces=ignore_whitespaces,
                                ignore_tablespace=ignore_tablespace,
-                               ignore_grants=ignore_grants)
+                               ignore_grants=ignore_grants,
+                               ignore_partitions=ignore_partitions)
 
             if res is not None:
                 comparison_result = comparison_result + res
@@ -845,6 +856,7 @@ def compare_schema_objects(**kwargs):
     ignore_whitespaces = kwargs.get('ignore_whitespaces')
     ignore_tablespace = kwargs.get('ignore_tablespace')
     ignore_grants = kwargs.get('ignore_grants')
+    ignore_partitions = kwargs.get('ignore_partitions')
 
     source_schema_name = None
     if is_schema_source_only:
@@ -883,7 +895,8 @@ def compare_schema_objects(**kwargs):
                                ignore_owner=ignore_owner,
                                ignore_whitespaces=ignore_whitespaces,
                                ignore_tablespace=ignore_tablespace,
-                               ignore_grants=ignore_grants)
+                               ignore_grants=ignore_grants,
+                               ignore_partitions=ignore_partitions)
 
             if res is not None:
                 comparison_result = comparison_result + res

--- a/web/pgadmin/tools/schema_diff/__init__.py
+++ b/web/pgadmin/tools/schema_diff/__init__.py
@@ -106,6 +106,14 @@ class SchemaDiffModule(PgAdminModule):
                              'in the Schema Diff tab.')
         )
 
+        self.preference.register(
+            'display', 'ignore_partitioons',
+            gettext("Ignore Partitions"), 'boolean', False,
+            category_label=PREF_LABEL_DISPLAY,
+            help_str=gettext('Set ignore partitions on or off by default '
+                             'in the drop-down menu near the Compare button '
+                             'in the Schema Diff tab.')
+        )
 
 blueprint = SchemaDiffModule(MODULE_NAME, __name__, static_url_path='/static')
 

--- a/web/pgadmin/tools/schema_diff/compare.py
+++ b/web/pgadmin/tools/schema_diff/compare.py
@@ -61,6 +61,7 @@ class SchemaDiffObjectCompare:
         ignore_whitespaces = kwargs.get('ignore_whitespaces', False)
         ignore_tablespace = kwargs.get('ignore_tablespace', False)
         ignore_grants = kwargs.get('ignore_grants', False)
+        ignore_partitions = kwargs.get('ignore_partitions', False)
 
         group_name = kwargs.get('group_name')
         source_schema_name = kwargs.get('source_schema_name', None)
@@ -106,7 +107,8 @@ class SchemaDiffObjectCompare:
                                     ignore_owner=ignore_owner,
                                     ignore_whitespaces=ignore_whitespaces,
                                     ignore_tablespace=ignore_tablespace,
-                                    ignore_grants=ignore_grants)
+                                    ignore_grants=ignore_grants
+                                    ignore_partitions=ignore_partitions)
 
     def ddl_compare(self, **kwargs):
         """

--- a/web/pgadmin/tools/schema_diff/compare.py
+++ b/web/pgadmin/tools/schema_diff/compare.py
@@ -107,7 +107,7 @@ class SchemaDiffObjectCompare:
                                     ignore_owner=ignore_owner,
                                     ignore_whitespaces=ignore_whitespaces,
                                     ignore_tablespace=ignore_tablespace,
-                                    ignore_grants=ignore_grants
+                                    ignore_grants=ignore_grants,
                                     ignore_partitions=ignore_partitions)
 
     def ddl_compare(self, **kwargs):

--- a/web/pgadmin/tools/schema_diff/directory_compare.py
+++ b/web/pgadmin/tools/schema_diff/directory_compare.py
@@ -277,6 +277,7 @@ def _get_identical_and_different_list(intersect_keys, source_dict, target_dict,
     target_schema = kwargs.get('target_schema')
     ignore_whitespaces = kwargs.get('ignore_whitespaces')
     ignore_grants = kwargs.get('ignore_grants', False)
+    ignore_partitions = kwargs.get('ignore_partitions', False)
 
     for key in intersect_keys:
         source_object_id, target_object_id = \
@@ -431,6 +432,7 @@ def compare_dictionaries(**kwargs):
     ignore_whitespaces = kwargs.get('ignore_whitespaces')
     ignore_tablespace = kwargs.get('ignore_tablespace')
     ignore_grants = kwargs.get('ignore_grants')
+    ignore_partitions = kwargs.get('ignore_partitions')
 
     dict1 = copy.deepcopy(source_dict)
     dict2 = copy.deepcopy(target_dict)
@@ -492,6 +494,7 @@ def compare_dictionaries(**kwargs):
         "target_schema": target_schema,
         "ignore_whitespaces": ignore_whitespaces,
         "ignore_grants": ignore_grants
+        "ignore_partitions": ignore_partitions
     }
 
     identical, different = _get_identical_and_different_list(

--- a/web/pgadmin/tools/schema_diff/directory_compare.py
+++ b/web/pgadmin/tools/schema_diff/directory_compare.py
@@ -358,7 +358,8 @@ def _get_identical_and_different_list(intersect_keys, source_dict, target_dict,
                     target_params=temp_tgt_params,
                     source=dict1[key], target=dict2[key], diff_dict=diff_dict,
                     target_schema=target_schema,
-                    ignore_whitespaces=ignore_whitespaces)
+                    ignore_whitespaces=ignore_whitespaces,
+                    ignore_partitions=ignore_partitions)
             else:
                 temp_src_params = copy.deepcopy(source_params)
                 temp_tgt_params = copy.deepcopy(target_params)

--- a/web/pgadmin/tools/schema_diff/directory_compare.py
+++ b/web/pgadmin/tools/schema_diff/directory_compare.py
@@ -493,7 +493,7 @@ def compare_dictionaries(**kwargs):
         "group_name": group_name,
         "target_schema": target_schema,
         "ignore_whitespaces": ignore_whitespaces,
-        "ignore_grants": ignore_grants
+        "ignore_grants": ignore_grants,
         "ignore_partitions": ignore_partitions
     }
 

--- a/web/pgadmin/tools/schema_diff/static/js/SchemaDiffConstants.js
+++ b/web/pgadmin/tools/schema_diff/static/js/SchemaDiffConstants.js
@@ -36,7 +36,8 @@ export const MENUS_COMPARE_CONSTANT = {
   COMPARE_IGNORE_OWNER: 1,
   COMPARE_IGNORE_WHITESPACE: 2,
   COMPARE_IGNORE_TABLESPACE: 3,
-  COMPARE_IGNORE_GRANTS: 4
+  COMPARE_IGNORE_GRANTS: 4,
+  COMPARE_IGNORE_PARTITIONS: 5
 };
 
 export const MENUS_FILTER_CONSTANT = {
@@ -70,5 +71,6 @@ export const IGNORE_OPTION = {
   OWNER : gettext('Ignore Owner'),
   WHITESPACE : gettext('Ignore Whitespace'),
   TABLESPACE: gettext('Ignore Tablespace'),
-  GRANTS: gettext('Ignore Grant/Revoke')
+  GRANTS: gettext('Ignore Grant/Revoke'),
+  PARTITIONS: gettext('Ignore Partitions')
 };

--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffButtonComponent.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffButtonComponent.jsx
@@ -93,12 +93,14 @@ export function SchemaDiffButtonComponent({ sourceData, targetData, selectedRowI
       compareParams.ignoreWhitespaces && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_WHITESPACE);
       compareParams.ignoreTablespace && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_TABLESPACE);
       compareParams.ignoreGrants && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_GRANTS);
+      compareParams.ignorePartitions && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_PARTITIONS);
       setSelectedCompare(prefCompareOptions);
     } else {
       schemaDiffCtx?.preferences_schema_diff?.ignore_owner && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_OWNER);
       schemaDiffCtx?.preferences_schema_diff?.ignore_whitespaces && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_WHITESPACE);
       schemaDiffCtx?.preferences_schema_diff?.ignore_tablespace && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_TABLESPACE);
       schemaDiffCtx?.preferences_schema_diff?.ignore_grants && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_GRANTS);
+      schemaDiffCtx?.preferences_schema_diff?.ignore_partitions && prefCompareOptions.push(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_PARTITIONS);
       setSelectedCompare(prefCompareOptions);
     }
   }, [schemaDiffCtx.preferences_schema_diff]);
@@ -141,6 +143,7 @@ export function SchemaDiffButtonComponent({ sourceData, targetData, selectedRowI
       'ignoreWhitespaces': selectedCompare.includes(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_WHITESPACE) ? 1 : 0,
       'ignoreTablespace': selectedCompare.includes(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_TABLESPACE) ? 1 : 0,
       'ignoreGrants': selectedCompare.includes(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_GRANTS) ? 1 : 0,
+      'ignorePartitions': selectedCompare.includes(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_PARTITIONS) ? 1 : 0,
     };
     let filterParam = selectedFilters;
     eventBus.fireEvent(SCHEMA_DIFF_EVENT.TRIGGER_COMPARE_DIFF, { sourceData, targetData, compareParams: compareParam, filterParams: filterParam });
@@ -194,6 +197,8 @@ export function SchemaDiffButtonComponent({ sourceData, targetData, selectedRowI
           onClick={() => { selectCompareOption(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_TABLESPACE); }}>{IGNORE_OPTION.TABLESPACE}</PgMenuItem>
         <PgMenuItem hasCheck checked={selectedCompare.includes(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_GRANTS)}
           onClick={() => { selectCompareOption(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_GRANTS); }}>{IGNORE_OPTION.GRANTS}</PgMenuItem>
+        <PgMenuItem hasCheck checked={selectedCompare.includes(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_PARTITIONS)}
+          onClick={() => { selectCompareOption(MENUS_COMPARE_CONSTANT.COMPARE_IGNORE_PARTITIONS); }}>{IGNORE_OPTION.PARTITIONS}</PgMenuItem>
       </PgMenu>
       <PgMenu
         anchorRef={filterRef}

--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffCompare.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffCompare.jsx
@@ -275,6 +275,7 @@ export function SchemaDiffCompare({ params }) {
         'ignore_whitespaces': compareParams['ignoreWhitespaces'],
         'ignore_tablespace': compareParams['ignoreTablespace'],
         'ignore_grants': compareParams['ignoreGrants'],
+        'ignore_partitions': compareParams['ignorePartitions'],
       };
       let socketEndpoint = 'compare_database';
       if (sourceData['scid'] != null && targetData['scid'] != null) {

--- a/web/pgadmin/tools/schema_diff/tests/test_schema_diff_comp.py
+++ b/web/pgadmin/tools/schema_diff/tests/test_schema_diff_comp.py
@@ -119,7 +119,8 @@ class SchemaDiffTestCase(BaseSocketTestGenerator):
             'ignore_owner': 0,
             'ignore_whitespaces': 0,
             'ignore_tablespace': 0,
-            'ignore_grants': 0
+            'ignore_grants': 0,
+            "ignore_partitions": 0
         }
         self.socket_client.emit('compare_database', data,
                                 namespace=self.SOCKET_NAMESPACE)


### PR DESCRIPTION
Often there is a situation when the only difference in the schemes is the number of partitions. It would be convenient to have an option to ignore this