### PR TITLE
Bump psycopg, revert 6b01219

### DIFF
--- a/pkg/pip/setup_pip.py
+++ b/pkg/pip/setup_pip.py
@@ -10,7 +10,6 @@
 import builtins
 import os
 import sys
-import platform
 from codecs import open
 from importlib.machinery import SourceFileLoader
 
@@ -41,17 +40,7 @@ kerberos_extras = []
 # gssapi in it's own list
 for index, req in enumerate(all_requires):
     if 'psycopg[c]' in req:
-        # Starting from Psycopg 3.1.20, ARM64 macOS binary packages are no
-        # longer available for macOS versions before 14.0.
-        _req = req.replace('psycopg[c]', 'psycopg[binary]')
-        req = "psycopg[binary] == 3.1.19; sys_platform == 'darwin' and" \
-              " platform_machine == 'arm64' and platform_release < '23.0' \n"\
-              + _req + ";  (sys_platform == 'darwin' and" \
-                       " platform_machine == 'arm64' and" \
-                       " platform_release >= '23.0') or" \
-                       " (sys_platform == 'darwin' and" \
-                       " platform_machine != 'arm64'" \
-                       ") or sys_platform != 'darwin'"
+        req = req.replace('psycopg[c]', 'psycopg[binary]')
 
     if 'gssapi' in req:
         kerberos_extras.append(req)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytz==2024.*
 speaklater3==1.*
 sqlparse==0.*
 psutil==6.1.*
-psycopg[c]==3.2.3
+psycopg[c]==3.2.4
 python-dateutil==2.*
 SQLAlchemy==2.*
 bcrypt==4.2.*


### PR DESCRIPTION
psycopg/psycopg#858 is now resolved, meaning binaries are available for macOS 11.0+ on Apple Silicon (macOS 10.13+ on Intel).