### PR TITLE
add support for oauth2 profile arrays, empty email error log

### DIFF
--- a/docs/en_US/oauth2.rst
+++ b/docs/en_US/oauth2.rst
@@ -34,12 +34,12 @@ and modify the values for the following parameters:
     "OAUTH2_AUTHORIZATION_URL", "Endpoint for user authorization"
     "OAUTH2_SERVER_METADATA_URL", "Server metadata url for your OAuth2 provider"
     "OAUTH2_API_BASE_URL", "Oauth2 base URL endpoint to make requests simple, ex: *https://api.github.com/*"
-    "OAUTH2_USERINFO_ENDPOINT", "User Endpoint, ex: *user* (for github) and *userinfo* (for google)"
+    "OAUTH2_USERINFO_ENDPOINT", "User Endpoint, ex: *user* (for github, or *user/emails* if the user's email address is private) and *userinfo* (for google),"
     "OAUTH2_SCOPE", "Oauth scope, ex: 'openid email profile'. Note that an 'email' claim is required in the resulting profile."
     "OAUTH2_ICON", "The Font-awesome icon to be placed on the oauth2 button,  ex: fa-github"
     "OAUTH2_BUTTON_COLOR", "Oauth2 button color"
     "OAUTH2_USERNAME_CLAIM", "The claim which is used for the username. If the value is empty
-    the email is used as username, but if a value is provided, the claim has to exist. Ex: *oid* (for AzureAD)"
+    the email is used as username, but if a value is provided, the claim has to exist. Ex: *oid* (for AzureAD), *email* (for Github)"
     "OAUTH2_AUTO_CREATE_USER", "Set the value to *True* if you want to automatically
     create a pgAdmin user corresponding to a successfully authenticated Oauth2 user.
     Please note that password is not stored in the pgAdmin database."

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -135,11 +135,38 @@ class OAuth2Authentication(BaseAuthentication):
     def validate(self, form):
         return True, None
 
+    def get_profile_dict(self, profile):
+        """
+        Returns the dictionary from profile whether it's a list or dictionary.
+        Includes additional type checking.
+        """
+        if isinstance(profile, list):
+            return profile[0] if profile else {}
+        elif isinstance(profile, dict):
+            return profile
+        else:
+            return {}
+
     def login(self, form):
         profile = self.get_user_profile()
+        profile_dict = self.get_profile_dict(profile)
+        
+        current_app.logger.debug(f"profile: {profile}")
+        current_app.logger.debug(f"profile_dict: {profile_dict}")
+        
+        if not profile_dict:
+            error_msg = "No profile data found."
+            current_app.logger.exception(error_msg)
+            return False, gettext(error_msg)
+        
         email_key = \
-            [value for value in self.email_keys if value in profile.keys()]
-        email = profile[email_key[0]] if (len(email_key) > 0) else None
+            [value for value in self.email_keys if value in profile_dict.keys()]
+        email = profile_dict[email_key[0]] if (len(email_key) > 0) else None
+
+        if not email:
+            error_msg = "No email found in profile data."
+            current_app.logger.exception(error_msg)
+            return False, gettext(error_msg)
 
         username = email
         username_claim = None

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -137,7 +137,7 @@ class OAuth2Authentication(BaseAuthentication):
 
     def get_profile_dict(self, profile):
         """
-        Returns the dictionary from profile 
+        Returns the dictionary from profile
         whether it's a list or dictionary.
         Includes additional type checking.
         """
@@ -151,15 +151,15 @@ class OAuth2Authentication(BaseAuthentication):
     def login(self, form):
         profile = self.get_user_profile()
         profile_dict = self.get_profile_dict(profile)
-        
+
         current_app.logger.debug(f"profile: {profile}")
         current_app.logger.debug(f"profile_dict: {profile_dict}")
-        
+
         if not profile_dict:
             error_msg = "No profile data found."
             current_app.logger.exception(error_msg)
             return False, gettext(error_msg)
-        
+
         email_key =[
             value for value in self.email_keys 
             if value in profile_dict.keys()

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -160,8 +160,10 @@ class OAuth2Authentication(BaseAuthentication):
             current_app.logger.exception(error_msg)
             return False, gettext(error_msg)
         
-        email_key = \
-            [value for value in self.email_keys if value in profile_dict.keys()]
+        email_key =[
+            value for value in self.email_keys 
+            if value in profile_dict.keys()
+        ]
         email = profile_dict[email_key[0]] if (len(email_key) > 0) else None
 
         if not email:

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -160,7 +160,7 @@ class OAuth2Authentication(BaseAuthentication):
             current_app.logger.exception(error_msg)
             return False, gettext(error_msg)
 
-        email_key =[
+        email_key = [
             value for value in self.email_keys 
             if value in profile_dict.keys()
         ]

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -161,7 +161,7 @@ class OAuth2Authentication(BaseAuthentication):
             return False, gettext(error_msg)
 
         email_key = [
-            value for value in self.email_keys 
+            value for value in self.email_keys
             if value in profile_dict.keys()
         ]
         email = profile_dict[email_key[0]] if (len(email_key) > 0) else None

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -137,7 +137,8 @@ class OAuth2Authentication(BaseAuthentication):
 
     def get_profile_dict(self, profile):
         """
-        Returns the dictionary from profile whether it's a list or dictionary.
+        Returns the dictionary from profile 
+        whether it's a list or dictionary.
         Includes additional type checking.
         """
         if isinstance(profile, list):


### PR DESCRIPTION
Details are covered in #8391 

TLDR; enable handling of JSON array return types on `OAUTH2_USERINFO_ENDPOINT`s, like github's `user/emails` for supporting private email addresses.