### PR TITLE
fix email validation in entrypoint.sh

### DIFF
--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -87,11 +87,16 @@ if [ ! -f /var/lib/pgadmin/pgadmin4.db ] && [ "${external_config_db_exists}" = "
     if [ -n "${PGADMIN_CONFIG_ALLOW_SPECIAL_EMAIL_DOMAINS}" ]; then
         ALLOW_SPECIAL_EMAIL_DOMAINS=${PGADMIN_CONFIG_ALLOW_SPECIAL_EMAIL_DOMAINS}
     fi
-     email_config="{'CHECK_EMAIL_DELIVERABILITY': ${CHECK_EMAIL_DELIVERABILITY}, 'ALLOW_SPECIAL_EMAIL_DOMAINS': ${ALLOW_SPECIAL_EMAIL_DOMAINS}}"
-    echo "email config is ${email_config}"
+    GLOBALLY_DELIVERABLE="True"
+    if [ -n "${PGADMIN_CONFIG_GLOBALLY_DELIVERABLE}" ]; then
+        GLOBALLY_DELIVERABLE=${PGADMIN_CONFIG_GLOBALLY_DELIVERABLE}
+    fi
+     email_config="{'CHECK_EMAIL_DELIVERABILITY': ${CHECK_EMAIL_DELIVERABILITY}, 'ALLOW_SPECIAL_EMAIL_DOMAINS': ${ALLOW_SPECIAL_EMAIL_DOMAINS}, 'GLOBALLY_DELIVERABLE': ${GLOBALLY_DELIVERABLE}}"
+     echo "email config is ${email_config}"
      is_valid_email=$(cd /pgadmin4/pgadmin/utils && /venv/bin/python3 -c "from validation_utils import validate_email; val = validate_email('${PGADMIN_DEFAULT_EMAIL}', ${email_config}); print(val)")
      if echo "${is_valid_email}" | grep "False" > /dev/null; then
          echo "'${PGADMIN_DEFAULT_EMAIL}' does not appear to be a valid email address. Please reset the PGADMIN_DEFAULT_EMAIL environment variable and try again."
+         echo "Validation output: ${is_valid_email}"
          exit 1
      fi
     # Switch back to root directory for further process

--- a/web/pgadmin/utils/validation_utils.py
+++ b/web/pgadmin/utils/validation_utils.py
@@ -21,6 +21,8 @@ def validate_email(email, email_config=None):
                 config.CHECK_EMAIL_DELIVERABILITY
             email_config['ALLOW_SPECIAL_EMAIL_DOMAINS'] = \
                 config.ALLOW_SPECIAL_EMAIL_DOMAINS
+            email_config["GLOBALLY_DELIVERABLE"] = \
+                config.GLOBALLY_DELIVERABLE
 
         # Allow special email domains
         if isinstance(email_config['ALLOW_SPECIAL_EMAIL_DOMAINS'], str):
@@ -34,6 +36,9 @@ def validate_email(email, email_config=None):
             ]
         except Exception:
             pass
+
+        email_validator.GLOBALLY_DELIVERABLE = \
+            email_config["GLOBALLY_DELIVERABLE"]
 
         # Validate.
         _ = email_validate(


### PR DESCRIPTION
Introduces a `GLOBALLY_DELIVERABLE` variable so that it can be passed to the email validator library and ultimately allowing the email `admin@localhost` to be valid, as long as `False` is passed in.

Also:
* adjusted the indentation of a command above it in the `entrypoint.sh`
* added printing out the output of the validation library so that we can better find what the actual issue is

Fixes #8410