### PR TITLE
Fixing SonarQube Issues.

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/static/js/function.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/functions/static/js/function.ui.js
@@ -327,19 +327,17 @@ export default class FunctionSchema extends BaseUISchema {
       group: gettext('Options'),
       disabled: obj.inCatalog() ? true : obj.isLessThan95ORNonSPL,
       deps: ['lanname'],
-      depChange: (state, source) => (
-        (source[source.length - 1] !== 'lanname') ? undefined : (
-          obj.isLessThan95ORNonSPL(state)
-        ) ? {
+      depChange: (state, source) => {
+        if (source[source.length - 1] === 'lanname' && obj.isLessThan95ORNonSPL(state)) {
+          return {
             provolatile: null,
             proisstrict: false,
             procost: null,
             proleakproof: false,
             proparallel: null,
-          } : (
-            obj.isLessThan95ORNonSPL(state) ? { proparallel: null } : undefined
-          )
-      ),
+          };
+        }
+      },
     },{
       id: 'prosecdef', label: gettext('Security of definer?'),
       group: gettext('Options'), type: 'switch',

--- a/web/pgadmin/static/js/SchemaView/utils/createFieldControls.jsx
+++ b/web/pgadmin/static/js/SchemaView/utils/createFieldControls.jsx
@@ -154,33 +154,37 @@ export const createFieldControls = ({
           isPropertyMode ? 'Properties-controlRow' : 'FormView-controlRow';
       break;
     default:
-      {
-        control = (
-          hasView(field.type) ? View(field.type) : (
-            field.id ? MappedFormControl : StaticMappedFormControl
-          )
-        );
+      if (hasView(field.type)) {
+        control = View(field.type);
+      } else if (field.id) {
+        control = MappedFormControl;
+      } else {
+        control = StaticMappedFormControl;
+      }
 
-        if (inlineGroup) {
-          controlProps['withContainer'] = false;
-          controlProps['controlGridBasis'] = 3;
-        }
+      if (inlineGroup) {
+        controlProps['withContainer'] = false;
+        controlProps['controlGridBasis'] = 3;
+      }
 
-        controlProps['className'] = field.isFullTab ? '' : (
-          isPropertyMode ? 'Properties-controlRow' : 'FormView-controlRow'
-        );
+      if (field.isFullTab) {
+        controlProps['className'] = '';
+      } else if (isPropertyMode) {
+        controlProps['className'] = 'Properties-controlRow';
+      } else {
+        controlProps['className'] = 'FormView-controlRow';
+      }
 
-        if (field.id) {
-          controlProps['id'] = field.id;
-          controlProps['onChange'] = (changeValue) => {
-            // Get the changes on dependent fields as well.
-            dataDispatch?.({
-              type: SCHEMA_STATE_ACTIONS.SET_VALUE,
-              path: controlProps.accessPath,
-              value: changeValue,
-            });
-          };
-        }
+      if (field.id) {
+        controlProps['id'] = field.id;
+        controlProps['onChange'] = (changeValue) => {
+          // Get the changes on dependent fields as well.
+          dataDispatch?.({
+            type: SCHEMA_STATE_ACTIONS.SET_VALUE,
+            path: controlProps.accessPath,
+            value: changeValue,
+          });
+        };
       }
       break;
     }

--- a/web/pgadmin/utils/__init__.py
+++ b/web/pgadmin/utils/__init__.py
@@ -380,7 +380,7 @@ def get_binary_path_versions(binary_path: str) -> dict:
             # if path doesn't exist raise exception
             if not os.path.isdir(binary_path):
                 current_app.logger.warning('Invalid binary path.')
-                raise Exception()
+                raise FileNotFoundError()
             # Get the output of the '--version' command
             cmd = subprocess.run(
                 [full_path, '--version'],
@@ -390,8 +390,6 @@ def get_binary_path_versions(binary_path: str) -> dict:
             )
             if cmd.returncode == 0:
                 ret[utility] = cmd.stdout.split(") ", 1)[1].strip()
-            else:
-                raise Exception()
         except Exception as _:
             continue
 


### PR DESCRIPTION
1. Ternary operators should not be nested.
2. "Exception" and "BaseException" should not be raised.