### PR TITLE
Documentation: Fix wrong parameter description for Password Exec Command

### DIFF
--- a/docs/en_US/server_dialog.rst
+++ b/docs/en_US/server_dialog.rst
@@ -206,8 +206,8 @@ Use the fields in the *Advanced* tab to configure a connection:
   should be generated as a transient authorization token instead of providing a
   password when connecting in `PAM authentication <https://www.postgresql.org/docs/current/auth-pam.html>`_ scenarios.
   You can pass server hostname, port and DB username to the password exec command as variable by providing placeholders
-  like ``%HOST%``, ``%PORT%`` and ``%USERNAME%`` which will be replace with the server connection information.
-  Example: ``/path/to/script --hostnmae %HOST% --port %PORT% --username %USERNAME%``
+  like ``%HOSTNAME%``, ``%PORT%`` and ``%USERNAME%`` which will be replace with the server connection information.
+  Example: ``/path/to/script --hostname %HOSTNAME% --port %PORT% --username %USERNAME%``
 * Use the *Password exec expiration* field to specify a maximum age, in seconds,
   of the password generated with a *Password exec command*. If not specified,
   the password will not expire until your pgAdmin session does.


### PR DESCRIPTION
The documentation mentions that `%HOST%` can be used as a replacement parameter for the Password Exec Field in the Advanced tab of the Server Dialog, but the parameter is actually called `%HOSTNAME%`:

https://github.com/pgadmin-org/pgadmin4/blob/58bb14253e9c135ccdf871408600b85c2a44641b/web/pgadmin/utils/passexec.py#L42