### PR TITLE
Fix issue with shift + click row range selection in the query tool data output window

### DIFF
--- a/web/pgadmin/static/js/components/PgReactDataGrid.jsx
+++ b/web/pgadmin/static/js/components/PgReactDataGrid.jsx
@@ -119,7 +119,7 @@ export function CustomRow({inTest=false, ...props}) {
 
   return (
     <Row {...props} onKeyDown={handleKeyDown} onCellClick={onCellClick} onCellDoubleClick={onCellDoubleClick}
-      selectCell={(row, column)=>props.selectCell(row, column)} aria-selected={isRowSelected} rangeSelectionMode={true}/>
+      selectCell={(row, column)=>props.selectCell(row, column)} aria-selected={isRowSelected}/>
   );
 }
 CustomRow.propTypes = {
@@ -158,7 +158,6 @@ export default function PgReactDataGrid({gridRef, className, hasSelectColumn=tru
           renderSortStatus,
           noRowsFallback: <Box textAlign="center" gridColumn="1/-1" p={1}>{noRowsIcon}{noRowsText || gettext('No rows found.')}</Box>,
         }}
-        enableRangeSelection={true}
         {...props}
       />
     </GridContextUtils.Provider>

--- a/web/pgadmin/static/js/components/PgReactDataGrid.jsx
+++ b/web/pgadmin/static/js/components/PgReactDataGrid.jsx
@@ -119,7 +119,7 @@ export function CustomRow({inTest=false, ...props}) {
 
   return (
     <Row {...props} onKeyDown={handleKeyDown} onCellClick={onCellClick} onCellDoubleClick={onCellDoubleClick}
-      selectCell={(row, column)=>props.selectCell(row, column)} aria-selected={isRowSelected}/>
+      selectCell={(row, column)=>props.selectCell(row, column)} aria-selected={isRowSelected} rangeSelectionMode={true}/>
   );
 }
 CustomRow.propTypes = {
@@ -158,6 +158,7 @@ export default function PgReactDataGrid({gridRef, className, hasSelectColumn=tru
           renderSortStatus,
           noRowsFallback: <Box textAlign="center" gridColumn="1/-1" p={1}>{noRowsIcon}{noRowsText || gettext('No rows found.')}</Box>,
         }}
+        enableRangeSelection={true}
         {...props}
       />
     </GridContextUtils.Provider>

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/index.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/index.jsx
@@ -116,7 +116,7 @@ function CustomRow(props) {
   };
   return (
     <RowInfoContext.Provider value={rowInfoValue}>
-      <Row ref={rowRef} onKeyDown={handleKeyDown} {...props} rangeSelectionMode={true}/>
+      <Row ref={rowRef} onKeyDown={handleKeyDown} {...props} />
     </RowInfoContext.Provider>
   );
 }

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/index.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/index.jsx
@@ -166,7 +166,7 @@ SelectAllHeaderRenderer.propTypes = {
   isCellSelected: PropTypes.bool,
 };
 
-function SelectableHeaderRenderer({column, selectedColumns, onSelectedColumnsChange, isCellSelected}) {
+function SelectableHeaderRenderer({column, isSelected, onColumnSelected, isCellSelected}) {
   const cellRef = useRef();
   const eventBus = useContext(QueryToolEventsContext);
   const dataGridExtras = useContext(DataGridExtrasContext);
@@ -175,17 +175,9 @@ function SelectableHeaderRenderer({column, selectedColumns, onSelectedColumnsCha
     dataGridExtras.onSelectedCellChange?.(null);
   }
 
-  const onClick = ()=>{
-    const newSelectedCols = new Set(selectedColumns);
-    if (newSelectedCols.has(column.idx)) {
-      newSelectedCols.delete(column.idx);
-    } else {
-      newSelectedCols.add(column.idx);
-    }
-    onSelectedColumnsChange(newSelectedCols);
+  const onClick = (e)=>{
+    onColumnSelected(column.idx, isSelected, (e.nativeEvent).shiftKey);
   };
-
-  const isSelected = selectedColumns.has(column.idx);
 
   useLayoutEffect(() => {
     if (!isCellSelected) return;
@@ -215,8 +207,8 @@ function SelectableHeaderRenderer({column, selectedColumns, onSelectedColumnsCha
 }
 SelectableHeaderRenderer.propTypes = {
   column: PropTypes.object,
-  selectedColumns: PropTypes.objectOf(Set),
-  onSelectedColumnsChange: PropTypes.func,
+  isSelected: PropTypes.bool,
+  onColumnSelected: PropTypes.func,
   isCellSelected: PropTypes.bool,
 };
 
@@ -320,13 +312,16 @@ RowNumColFormatter.propTypes = {
   onSelectedColumnsChange: PropTypes.func,
 };
 
-function formatColumns(columns, dataChangeStore, selectedColumns, onSelectedColumnsChange, rowKeyGetter) {
+function formatColumns(columns, dataChangeStore, selectedColumns, onColumnSelected, onSelectedColumnsChange, rowKeyGetter) {
   let retColumns = [
     ...columns,
   ];
 
-  const HeaderRenderer = (props)=>{
-    return <SelectableHeaderRenderer {...props} selectedColumns={selectedColumns} onSelectedColumnsChange={onSelectedColumnsChange}/>;
+  const HeaderRenderer = ({column, ...props})=>{
+    return <SelectableHeaderRenderer {...props} column={column} isSelected={selectedColumns.has(column.idx)} onColumnSelected={onColumnSelected}/>;
+  };
+  HeaderRenderer.propTypes = {
+    column: PropTypes.object,
   };
 
   for(const [idx, col] of retColumns.entries()) {
@@ -377,7 +372,26 @@ function getColumnWidth(column, rows, canvas, columnWidthBy) {
 export default function QueryToolDataGrid({columns, rows, totalRowCount, dataChangeStore,
   onSelectedCellChange, selectedColumns, onSelectedColumnsChange, columnWidthBy, startRowNum, ...props}) {
   const [readyColumns, setReadyColumns] = useState([]);
+  const [lastSelectedColumn, setLastSelectedColumn] = useState(null);
   const eventBus = useContext(QueryToolEventsContext);
+  const onColumnSelected = (columnIdx, isSelected, isShiftClick)=>{
+    const newSelectedCols = new Set(selectedColumns);
+    const start = isShiftClick && lastSelectedColumn ? Math.min(columnIdx, lastSelectedColumn) : columnIdx;
+    const end = isShiftClick && lastSelectedColumn ? Math.max(columnIdx, lastSelectedColumn) : columnIdx;
+    for (let i = start; i <= end; i++) {
+      if (isSelected) {
+        newSelectedCols.delete(i);
+      }
+      else {
+        newSelectedCols.add(i);
+      }
+    }
+    
+    props.onSelectedRowsChange(new Set());
+    setLastSelectedColumn(columnIdx);
+    onSelectedColumnsChange(newSelectedCols);
+  };
+
   const onSelectedColumnsChangeWrapped = (arg)=>{
     props.onSelectedRowsChange(new Set());
     onSelectedColumnsChange(arg);
@@ -411,12 +425,12 @@ export default function QueryToolDataGrid({columns, rows, totalRowCount, dataCha
 
   useEffect(()=>{
     let initCols = initialiseColumns(columns, rows, totalRowCount, columnWidthBy);
-    setReadyColumns(formatColumns(initCols, dataChangeStore, selectedColumns, onSelectedColumnsChangeWrapped, props.rowKeyGetter));
+    setReadyColumns(formatColumns(initCols, dataChangeStore, selectedColumns, onColumnSelected, onSelectedColumnsChangeWrapped, props.rowKeyGetter));
   }, [columns]);
 
   useEffect(()=>{
     setReadyColumns((prevCols)=>{
-      return formatColumns(prevCols, dataChangeStore, selectedColumns, onSelectedColumnsChangeWrapped, props.rowKeyGetter);
+      return formatColumns(prevCols, dataChangeStore, selectedColumns, onColumnSelected, onSelectedColumnsChangeWrapped, props.rowKeyGetter);
     });
   }, [dataChangeStore, selectedColumns]);
 

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/index.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/index.jsx
@@ -116,7 +116,7 @@ function CustomRow(props) {
   };
   return (
     <RowInfoContext.Provider value={rowInfoValue}>
-      <Row ref={rowRef} onKeyDown={handleKeyDown} {...props} />
+      <Row ref={rowRef} onKeyDown={handleKeyDown} {...props} rangeSelectionMode={true}/>
     </RowInfoContext.Provider>
   );
 }
@@ -305,9 +305,9 @@ function RowNumColFormatter({row, rowKeyGetter, rowIdx, dataChangeStore, onSelec
   } else if(rowKey in (dataChangeStore?.deleted || {})) {
     rownum = rownum+'-';
   }
-  return (<div className='QueryTool-rowNumCell' onClick={()=>{
+  return (<div className='QueryTool-rowNumCell' onClick={(e)=>{
     onSelectedColumnsChange(new Set());
-    onRowSelectionChange({ type: 'ROW', row: row, checked: !isRowSelected, isShiftClick: false});
+    onRowSelectionChange({ type: 'ROW', row: row, checked: !isRowSelected, isShiftClick: (e.nativeEvent).shiftKey});
   }} onKeyDown={()=>{/* already taken care by parent */}}>
     {rownum}
   </div>);


### PR DESCRIPTION
Resolves https://github.com/pgadmin-org/pgadmin4/issues/5266

# What does this PR do?
This PR resolves an apparent regression where selecting a range of rows in the query tool data output window using shift+click was no longer functional in the new pgAdmin (range selection had been recently introduced to the [react-data-grid](https://github.com/adazzle/react-data-grid) repository and the following migration of that functionality to the pgAdmin fork

# Summary of changes
- set `isShiftClick` property to `useRowSelection` react hook update function
- set `rangeSelectionMode` property to data grid components to propagate shift click behaviour to the `selectedRows` react hook under `ResultSet.jsx`