### PR TITLE
Fixed an issue where the upgrade_check API returned an unexpected key…

### DIFF
--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -357,9 +357,16 @@ def upgrade_check():
                 # Do not wait for more than 5 seconds.
                 # It stuck on rendering the browser.html, while working in the
                 # broken network.
-                if os.path.exists(config.CA_FILE):
-                    response = urlopen_with_ssl(
-                        url, data, 5, config.CA_FILE)
+                if os.path.exists(config.CA_FILE) and sys.version_info >= (
+                    3, 13):
+                    # Use SSL context for Python 3.13+
+                    context = ssl.create_default_context(cafile=config.CA_FILE)
+                    response = urlopen(url, data=data, timeout=5,
+                                       context=context)
+                elif os.path.exists(config.CA_FILE):
+                    # Use cafile parameter for older versions
+                    response = urlopen(url, data=data, timeout=5,
+                                       cafile=config.CA_FILE)
                 else:
                     response = urlopen(url, data, 5)
                 current_app.logger.debug(

--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -29,6 +29,8 @@ import threading
 import time
 import json
 import os
+import sys
+import ssl
 from urllib.request import urlopen
 from pgadmin.settings import get_setting, store_setting
 
@@ -324,6 +326,16 @@ def validate_binary_path():
     return make_json_response(data=gettext(version_str), status=200)
 
 
+def urlopen_with_ssl(url, data, timeout, cafile):
+    context = ssl.create_default_context(cafile=cafile)
+    if sys.version_info >= (3, 13):
+        # Use SSL context for Python 3.13+
+        return urlopen(url, data=data, timeout=timeout, context=context)
+    else:
+        # Use cafile parameter for older versions
+        return urlopen(url, data=data, timeout=timeout, cafile=cafile)
+
+
 @blueprint.route("/upgrade_check", endpoint="upgrade_check",
                  methods=['GET'])
 @pga_login_required
@@ -346,7 +358,8 @@ def upgrade_check():
                 # It stuck on rendering the browser.html, while working in the
                 # broken network.
                 if os.path.exists(config.CA_FILE):
-                    response = urlopen(url, data, 5, cafile=config.CA_FILE)
+                    response = urlopen_with_ssl(
+                        url, data, 5, config.CA_FILE)
                 else:
                     response = urlopen(url, data, 5)
                 current_app.logger.debug(

--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -326,16 +326,6 @@ def validate_binary_path():
     return make_json_response(data=gettext(version_str), status=200)
 
 
-def urlopen_with_ssl(url, data, timeout, cafile):
-    context = ssl.create_default_context(cafile=cafile)
-    if sys.version_info >= (3, 13):
-        # Use SSL context for Python 3.13+
-        return urlopen(url, data=data, timeout=timeout, context=context)
-    else:
-        # Use cafile parameter for older versions
-        return urlopen(url, data=data, timeout=timeout, cafile=cafile)
-
-
 @blueprint.route("/upgrade_check", endpoint="upgrade_check",
                  methods=['GET'])
 @pga_login_required

--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -358,7 +358,7 @@ def upgrade_check():
                 # It stuck on rendering the browser.html, while working in the
                 # broken network.
                 if os.path.exists(config.CA_FILE) and sys.version_info >= (
-                    3, 13):
+                        3, 13):
                     # Use SSL context for Python 3.13+
                     context = ssl.create_default_context(cafile=config.CA_FILE)
                     response = urlopen(url, data=data, timeout=5,


### PR DESCRIPTION
…word argument 'cafile' due to changes in the urllib package supporting Python v3.13. #8577