### PR TITLE
Prevent Ctrl/cmd+A from selecting all rows when editing a cell. #8572

### DIFF
--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/Editors.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolDataGrid/Editors.jsx
@@ -251,6 +251,10 @@ export function TextEditor({row, column, onRowChange, onClose}) {
     if(e.keyCode == 13 && !e.shiftKey) {
       onOK();
     }
+    // Handle "Ctrl + A" or "Cmd + A".
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 65) {
+      e.stopPropagation();
+    }
   };
 
   return (


### PR DESCRIPTION
Detail info :- #8572 