### PR TITLE
Fixed an issue where, if a database is renamed or deleted, the query …

### DIFF
--- a/web/pgadmin/tools/sqleditor/__init__.py
+++ b/web/pgadmin/tools/sqleditor/__init__.py
@@ -790,7 +790,11 @@ def check_transaction_status(trans_id, auto_comp=False):
         return False, internal_server_error(errormsg=str(e)), None, None, None
 
     if connect and conn and not conn.connected():
-        conn.connect()
+        status, errmsg = conn.connect()
+        if not status:
+            current_app.logger.error(errmsg)
+            return (False, internal_server_error(errormsg=str(errmsg)),
+                    None, None, None)
 
     return True, None, conn, trans_obj, session_obj
 
@@ -817,6 +821,9 @@ def start_view_data(trans_id):
         return make_json_response(success=0, errormsg=error_msg,
                                   info='DATAGRID_TRANSACTION_REQUIRED',
                                   status=404)
+
+    if not status and error_msg and type(error_msg) is Response:
+        return error_msg
 
     # get the default connection as current connection which is attached to
     # trans id holds the cursor which has query result so we cannot use that

--- a/web/pgadmin/tools/sqleditor/utils/query_tool_connection_check.py
+++ b/web/pgadmin/tools/sqleditor/utils/query_tool_connection_check.py
@@ -59,7 +59,7 @@ def query_tool_connection_check(trans_id):
         status, msg = conn.connect()
         if not status:
             current_app.logger.error(msg)
-            return internal_server_error(errormsg=str(msg))
+            return status, msg, None, None, None, None
         return status, None, conn, transaction_object, session_obj, None
     else:
         status = False

--- a/web/pgadmin/tools/sqleditor/utils/start_running_query.py
+++ b/web/pgadmin/tools/sqleditor/utils/start_running_query.py
@@ -84,8 +84,11 @@ class StartRunningQuery:
                 from pgadmin.tools.sqleditor.utils import \
                     query_tool_connection_check
 
-                _, _, _, _, _, response = \
+                status, errmsg, _, _, _, response = \
                     query_tool_connection_check(trans_id)
+                # If database does not exist then show error msg
+                if not status:
+                    result = errmsg
                 # This is required for asking user to enter password
                 # when password is not saved for the server
                 if response is not None:


### PR DESCRIPTION
…tool and view/edit data tool now correctly return a "database does not exist" error when executing a query. #8607