### PR TITLE
[pgadmin] Changing USER in Dockerfile to 5050 instead of pgadmin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,7 +222,7 @@ RUN apk add --no-cache \
     echo "pgadmin ALL = NOPASSWD: /usr/sbin/postfix start" > /etc/sudoers.d/postfix && \
     echo "pgadminr ALL = NOPASSWD: /usr/sbin/postfix start" >> /etc/sudoers.d/postfix
 
-USER pgadmin
+USER 5050
 
 # Finish up
 VOLUME /var/lib/pgadmin


### PR DESCRIPTION
The USER in the Dockerfile is pgadmin
Changing it to 5050
pgadmin UID == 5050 UID

Im changing the usage of the USER keyword from the name of the user to the UID of the user because k8s deployments reads this USER metadata to determine if its a root user when its enforcing its pod security admission validation webhook.
In a case where we define securityContext.runAsNonRoot=true and does not specify securityContext.runAsUser the creation of the pod will fail.
This PR will prevent it and also will help in multiple k8s distribution support such as OpenShift, RKE2, EKS and more. Thanks.

![Untitled](https://github.com/user-attachments/assets/42308045-eb82-48cb-9708-ddd145b975a0)
