### PR TITLE
(docs) fixes venv notations for web build

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ simple - adapt as required for your distribution:
    so update that to the latest:
 
    ```bash
-   $ pip install --upgrade pip
+   (venv) $ pip install --upgrade pip
    ```
 
 4. Ensure that a PostgreSQL installation's bin/ directory is in the path (so

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ installed. Then, you can run the following commands on a *nix system to
 download the required packages and build the bundle:
 
 ```bash
-(venv) $ cd $PGADMIN4_SRC
-(venv) $ make install-node
-(venv) $ make bundle
+$ cd $PGADMIN4_SRC
+$ make install-node
+$ make bundle
 ```
 
 On Windows systems (where "make" is not available), the following commands


### PR DESCRIPTION
Thank you for making and supporting this, it is a super useful tool to work with postgres.

I am proposing these changes in the hopes of streamlining the setup process for others hoping to contribute. AFAICT the `install-node` and `bundle` targets don't require venv, so it seems better to omit that to avoid any confusion. To test this I ran those two commands before setting up the venv, proceeded through the rest of the instructions and confirmed I was able to view the UI in the browser after running `pgAdmin4.py`.

If there is any other testing or cleanup of the PR needed I'm happy to do so, thanks again!