### PR TITLE
supports JSON logging for gunicorn process within Docker

### DIFF
--- a/pkg/docker/gunicorn_config.py
+++ b/pkg/docker/gunicorn_config.py
@@ -1,2 +1,45 @@
 import gunicorn
-gunicorn.SERVER_SOFTWARE = 'Python'
+
+# Can be resolved because of how Dockerfile organizes the code during build
+from config import JSON_LOGGER, CONSOLE_LOG_LEVEL, CONSOLE_LOG_FORMAT_JSON
+
+gunicorn.SERVER_SOFTWARE = "Python"
+
+if JSON_LOGGER:
+    logconfig_dict = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "root": {"level": CONSOLE_LOG_LEVEL, "handlers": []},
+        "loggers": {
+            "gunicorn.error": {
+                "level": CONSOLE_LOG_LEVEL,
+                "handlers": ["error_console"],
+                "propagate": True,
+                "qualname": "gunicorn.error",
+            },
+            "gunicorn.access": {
+                "level": CONSOLE_LOG_LEVEL,
+                "handlers": ["console"],
+                "propagate": True,
+                "qualname": "gunicorn.access",
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+                "stream": "ext://sys.stdout",
+            },
+            "error_console": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+                "stream": "ext://sys.stderr",
+            },
+        },
+        "formatters": {
+            "json": {
+                "class": "jsonformatter.JsonFormatter",
+                "format": CONSOLE_LOG_FORMAT_JSON,
+            },
+        },
+    }


### PR DESCRIPTION
For https://github.com/pgadmin-org/pgadmin4/issues/8665

This attempts to bridge the gap between the application and gunicorn config to ensure both are logging in a consistent way.

Before:
```sh
$ grep CONSOLE_LOG_LEVEL web/config_local.py
CONSOLE_LOG_LEVEL = logging.INFO

$ grep JSON_LOGGER web/config.py 
JSON_LOGGER = True

$ ./venv/bin/gunicorn  -c ./pkg/docker/gunicorn_config.py --chdir web pgAdmin4:app                                
[2025-05-21 13:20:52 -0400] [36038] [INFO] Starting gunicorn 23.0.0
[2025-05-21 13:20:52 -0400] [36038] [INFO] Listening at: http://127.0.0.1:8000 (36038)
[2025-05-21 13:20:52 -0400] [36038] [INFO] Using worker: sync
[2025-05-21 13:20:52 -0400] [36039] [INFO] Booting worker with pid: 36039
{"time": "2025-05-21 13:20:53,405", "message": "########################################################", "level": "INFO"}
{"time": "2025-05-21 13:20:53,405", "message": "Starting pgAdmin 4 v9.3...", "level": "INFO"}
{"time": "2025-05-21 13:20:53,405", "message": "########################################################", "level": "INFO"}
...
```

After:
```sh
$ grep CONSOLE_LOG_LEVEL web/config_local.py
CONSOLE_LOG_LEVEL = logging.INFO

$ grep JSON_LOGGER web/config.py 
JSON_LOGGER = True

$ ./venv/bin/gunicorn -c ./pkg/docker/gunicorn_config.py --chdir web pgAdmin4:app
[2025-05-21 13:22:30 -0400] [36080] [INFO] Starting gunicorn 23.0.0
{"time": "2025-05-21 13:22:31,529", "message": "Listening at: http://127.0.0.1:8000 (36080)", "level": "INFO"}
{"time": "2025-05-21 13:22:31,529", "message": "Using worker: sync", "level": "INFO"}
{"time": "2025-05-21 13:22:31,532", "message": "Booting worker with pid: 36081", "level": "INFO"}
{"time": "2025-05-21 13:22:31,609", "message": "########################################################", "level": "INFO"}
{"time": "2025-05-21 13:22:31,609", "message": "Starting pgAdmin 4 v9.3...", "level": "INFO"}
{"time": "2025-05-21 13:22:31,610", "message": "########################################################", "level": "INFO"}
```

And via docker with a locally built image:
```sh
$ docker run -d --name=pgadmin4 --rm \
    -e "PGADMIN_DEFAULT_EMAIL=a@b.co" \
    -e "PGADMIN_DEFAULT_PASSWORD=admin" \
    -e "PGADMIN_CONFIG_JSON_LOGGER=True" \
    -e "PGADMIN_CONFIG_CONSOLE_LOG_LEVEL=10" \
    -p 8080:80 \
    allensh12/pgadmin4

$ docker logs -f pgadmin4
...
[2025-05-21 17:24:38 +0000] [1] [INFO] Starting gunicorn 23.0.0
{"time": "2025-05-21 17:24:40,663", "message": "Listening at: http://[::]:80 (1)", "level": "INFO"}
{"time": "2025-05-21 17:24:40,663", "message": "Using worker: gthread", "level": "INFO"}
{"time": "2025-05-21 17:24:40,667", "message": "Booting worker with pid: 121", "level": "INFO"}
{"time": "2025-05-21 17:24:40,876", "message": "########################################################", "level": "INFO"}
{"time": "2025-05-21 17:24:40,876", "message": "Starting pgAdmin 4 v9.3...", "level": "INFO"}
{"time": "2025-05-21 17:24:40,876", "message": "########################################################", "level": "INFO"}
```

A few outstanding things:
1. The first line from gunicorn ("Starting gunicorn...") does not respect the format, given that this is much less common than access log perhaps that is okay to leave, but I will investigate further.
2. A few other places where printing happens outside of the logger, have marked these with "issues/8665" in the code, can see example below
3. No control over `postfix` logs, the only one I've seen so far is "postfix/postlog: starting the Postfix mail system" but I have not exercised it more than that. IMO an issue that is worth addressing separately.

```sh
$ docker logs -f pgadmin4
email config is {'CHECK_EMAIL_DELIVERABILITY': False, 'ALLOW_SPECIAL_EMAIL_DOMAINS': [], 'GLOBALLY_DELIVERABLE': True}
NOTE: Configuring authentication for SERVER mode.

pgAdmin 4 - Application Initialisation
======================================

postfix/postlog: starting the Postfix mail system
[2025-05-21 17:38:41 +0000] [1] [INFO] Starting gunicorn 23.0.0
{"time": "2025-05-21 17:38:43,326", "message": "Listening at: http://[::]:80 (1)", "level": "INFO"}
{"time": "2025-05-21 17:38:43,327", "message": "Using worker: gthread", "level": "INFO"}
{"time": "2025-05-21 17:38:43,330", "message": "Booting worker with pid: 119", "level": "INFO"}
```


Curious to hear what y'all think!