### PR TITLE
Update zstd library link to 1.5.7 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,7 @@ COPY --from=pg17-builder /usr/lib/liblz4.so.1.10.0 /usr/lib/
 
 RUN ln -s libpq.so.5.17 /usr/lib/libpq.so.5 && \
     ln -s libpq.so.5.17 /usr/lib/libpq.so && \
-    ln -s libzstd.so.1.5.6 /usr/lib/libzstd.so.1 && \
+    ln -s libzstd.so.1.5.7 /usr/lib/libzstd.so.1 && \
     ln -s liblz4.so.1.10.0 /usr/lib/liblz4.so.1
 
 WORKDIR /pgadmin4


### PR DESCRIPTION
Currently `pg_restore` fails because it is referencing `/usr/lib/libztd.so.1` which is linked > `libztd.so.1.5.6` which does not exist. This fixes this by correcting the link.

```
Error loading shared library libzstd.so.1: No such file or directory (needed by /usr/local/pgsql-17/pg_restore)
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_CCtx_setParameter: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_CStreamOutSize: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_freeCStream: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_DStreamOutSize: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_maxCLevel: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_DStreamInSize: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_createDStream: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_minCLevel: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_decompressStream: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_createCStream: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_isError: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_freeDStream: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_getErrorName: symbol not found
Error relocating /usr/local/pgsql-17/pg_restore: ZSTD_compressStream2: symbol not found
```

See Alpine linux zstd update from 9/06/2025 https://pkgs.alpinelinux.org/package/edge/main/x86_64/zstd
See https://github.com/pgadmin-org/pgadmin4/commit/12b263c20bcf91e4eb621b2c95b1481344646881