### PR TITLE
Fixed issues reported while testing #8901

### DIFF
--- a/web/pgadmin/settings/static/ApplicationStateProvider.jsx
+++ b/web/pgadmin/settings/static/ApplicationStateProvider.jsx
@@ -73,6 +73,8 @@ export function ApplicationStateProvider({children}){
             // file has external chages
             return {loadFile: loadFile, fileName: fileName, data: toolContent, modifiedExternally: true};
           }
+        }else if(connectionInfo.file_deleted){
+          return {loadFile: loadFile, fileName: null, data: toolContent};
         }else{
           loadFile = true;
           return {loadFile: loadFile, fileName: fileName, data: null};

--- a/web/pgadmin/static/js/ToolErrorView.jsx
+++ b/web/pgadmin/static/js/ToolErrorView.jsx
@@ -35,5 +35,4 @@ ToolErrorView.propTypes = {
   error: PropTypes.string,
   panelId: PropTypes.string,
   panelDocker: PropTypes.object,
-  toolDataId: PropTypes.string
 };

--- a/web/pgadmin/static/js/ToolView.jsx
+++ b/web/pgadmin/static/js/ToolView.jsx
@@ -39,6 +39,9 @@ ToolForm.propTypes = {
 };
 
 export function getToolTabParams(panelId, toolUrl, formParams, tabParams, restore=false) {
+  if(tabParams?.internal?.orig_title){
+    tabParams.title = tabParams.internal.title;
+  }
   return {
     id: panelId,
     title: panelId,

--- a/web/pgadmin/tools/erd/static/js/erd_tool/components/ERDTool.jsx
+++ b/web/pgadmin/tools/erd/static/js/erd_tool/components/ERDTool.jsx
@@ -397,6 +397,8 @@ export default class ERDTool extends React.Component {
         this.diagram.clearSelection();
         this.registerModelEvents();
         if(toolContent.fileName)this.setState({current_file: toolContent.fileName});
+        this.setState({dirty: true});
+        this.eventBus.fireEvent(ERD_EVENTS.DIRTY, true, toolContent.data);
       }
     }
   };

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -288,12 +288,13 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
           eventBus.current.fireEvent(QUERY_TOOL_EVENTS.HANDLE_API_ERROR, err);
           setQtStatePartial({ editor_disabled: true });
         });
-    } else if (qtState.params.sql_id) {
+    } else if (qtState.params.sql_id && qtState.params.restore != 'true') {
       let sqlValue = localStorage.getItem(qtState.params.sql_id);
       localStorage.removeItem(qtState.params.sql_id);
       if (sqlValue) {
         eventBus.current.fireEvent(QUERY_TOOL_EVENTS.EDITOR_SET_SQL, sqlValue);
       }
+      setQtStatePartial({ editor_disabled: false });
     } else if (qtState.params.restore == 'true') {
       restoreToolContent();
     } else {

--- a/web/pgadmin/tools/sqleditor/static/js/show_query_tool.js
+++ b/web/pgadmin/tools/sqleditor/static/js/show_query_tool.js
@@ -104,7 +104,7 @@ export function showERDSqlTool(parentData, erdSqlId, queryToolTitle, queryToolMo
     },
     database: {
       _id: parentData.did,
-      label: parentData.database,
+      _label: parentData.database,
     },
   };
 


### PR DESCRIPTION
1.Preserve the updated tab titles when restoring sessions. 2.Ensure that query tools opened via the 'Generate Script' buttons are editable.. 3.On restore, ensure the query content is correctly loaded into the query tool when it is opened from tools like ERD.