### PR TITLE
Ensure we have the tools to configure SELinux policies

### DIFF
--- a/pkg/redhat/build.sh
+++ b/pkg/redhat/build.sh
@@ -163,7 +163,7 @@ BuildArch:	noarch
 Summary:	The web interface for pgAdmin, hosted under Apache HTTPD.
 License:	PostgreSQL
 URL:		https://www.pgadmin.org/
-Requires:	${APP_NAME}-server = ${RPM_VERSION}, httpd, ${PYTHON_BINARY_WITHOUT_DOTS}-mod_wsgi
+Requires:	${APP_NAME}-server = ${RPM_VERSION}, httpd, ${PYTHON_BINARY_WITHOUT_DOTS}-mod_wsgi, policycoreutils-python-utils
 
 %description
 The web interface for pgAdmin, hosted under Apache HTTPD. pgAdmin is the most popular and feature rich Open Source administration and development platform for PostgreSQL, the most advanced Open Source database in the world.


### PR DESCRIPTION
The semanage utility is required to configure the policy for the  pgAdmin log/lib directories in server mode, but it may not always be installed on a system.