### PR TITLE
Fix Font Awesome icons not showing for oauth2 integration

### DIFF
--- a/web/pgadmin/static/js/SecurityPages/LoginPage.jsx
+++ b/web/pgadmin/static/js/SecurityPages/LoginPage.jsx
@@ -48,7 +48,7 @@ export default function LoginPage({userLanguage, langOptions, forgotPassUrl, csr
           oauth2Config.map((oauth)=>{
             return (
               <SecurityButton key={oauth.OAUTH2_NAME} name="oauth2_button" value={oauth.OAUTH2_NAME} style={{backgroundColor: oauth.OAUTH2_BUTTON_COLOR}}>
-                <Icon className={'fab '+oauth.OAUTH2_ICON} style={{ fontSize: '1.5em', marginRight: '8px' }} />{gettext('Login with %s', oauth.OAUTH2_DISPLAY_NAME)}
+                <Icon className={'fa '+oauth.OAUTH2_ICON} style={{ fontSize: '1.5em', marginRight: '8px' }} />{gettext('Login with %s', oauth.OAUTH2_DISPLAY_NAME)}
               </SecurityButton>
             );
           })


### PR DESCRIPTION
Specified Font Awesome icons would show a cross unless the class attribute```fab``` is changed to ```fa```.

Before:
<img width="511" height="461" alt="image" src="https://github.com/user-attachments/assets/3e6254c7-db18-4ea4-984b-865b492281a0" />

After:
<img width="484" height="393" alt="image" src="https://github.com/user-attachments/assets/1b8993e5-7f23-443f-b51c-f85501f71066" />
