### PR TITLE
Disable persistence by default

### DIFF
--- a/pkg/helm/values.yaml
+++ b/pkg/helm/values.yaml
@@ -78,7 +78,7 @@ resources:
     memory: 512Mi
 
 persistence:
-  enabled: true
+  enabled: false
   size: 1Gi
   storageClass: ""
   accessModes: ["ReadWriteOnce"]
@@ -152,4 +152,5 @@ containerSecurityContext:
   appArmorProfile:
     type: RuntimeDefault
   windowsOptions:
+
     hostProcess: false


### PR DESCRIPTION
Many helm charts leave PVC disabled by default. In addition, the readme states that the default value for persistence is `false`. Therefore, it should also be `false` in the values.