### PR TITLE
Add conditional TLS support to Ingress in Helm chart

### DIFF
--- a/pkg/helm/README.md
+++ b/pkg/helm/README.md
@@ -39,3 +39,4 @@ The chart should dump its version and appVersion in the Chart.yaml file every re
 | `service.loadBalancerIP` | Load balancer IP (Only if service.type is LoadBalancer) | `""` |
 | `ingress.enabled` | Ingress resource creation | `false` |
 | `ingress.hostname` | Ingress resource hostname | `"pgadmin4.local"` |
+| `ingress.tlsSecret` | Ingress tls secret name | `""` |

--- a/pkg/helm/templates/ingress.yaml
+++ b/pkg/helm/templates/ingress.yaml
@@ -21,4 +21,10 @@ spec:
               name: http
         path: /
         pathType: Prefix
+  {{- if .Values.ingress.tlsSecret }}
+  tls:
+  - hosts:
+    - {{ tpl .Values.ingress.hostname . }}
+    secretName: {{ .Values.ingress.tlsSecret }}
+  {{- end }}
 {{- end }}

--- a/pkg/helm/values.yaml
+++ b/pkg/helm/values.yaml
@@ -98,6 +98,7 @@ ingress:
   enabled: false
   hostname: pgadmin4.local
   annotations: {}
+  tlsSecret: ""
 
 startupProbe:
   enabled: false


### PR DESCRIPTION
This PR adds conditional TLS support to the Helm chart's Ingress resource. The TLS block is rendered only if the ingress.tlsSecret value is defined, allowing users to enable HTTPS by specifying a Kubernetes TLS secret.

### Motivation:
This enhancement improves flexibility and security for users deploying pgAdmin4 in Kubernetes environments with HTTPS requirements.

Closes #9345