### PR TITLE
User- Application name

### DIFF
--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -18,6 +18,7 @@ import secrets
 import datetime
 import asyncio
 import copy
+import getpass
 from collections import deque
 import psycopg
 from flask import g, current_app
@@ -330,7 +331,7 @@ class Connection(BaseConnection):
 
             import os
             os.environ['PGAPPNAME'] = '{0} - {1}'.format(
-                config.APP_NAME, conn_id)
+                getpass.getuser(), conn_id)
 
             ssl_key = get_complete_file_path(
                 manager.get_connection_param_value('sslkey'))

--- a/web/pgadmin/utils/driver/psycopg3/server_manager.py
+++ b/web/pgadmin/utils/driver/psycopg3/server_manager.py
@@ -14,6 +14,7 @@ import os
 import datetime
 import config
 import logging
+import getpass
 from flask import current_app, session
 from flask_security import current_user
 from flask_babel import gettext
@@ -34,8 +35,8 @@ from psycopg.conninfo import make_conninfo
 if config.SUPPORT_SSH_TUNNEL:
     from sshtunnel import SSHTunnelForwarder, BaseSSHTunnelForwarderError
 
-CONN_STRING = 'CONN:{0}'
-DB_STRING = 'DB:{0}'
+CONN_STRING = getpass.getuser() + ':{0}'
+DB_STRING = getpass.getuser() + ':{0}'
 
 
 class ServerManager(object):


### PR DESCRIPTION
These changes will now use the current user's username instead of the application name for PostgreSQL application names and connection string prefixes, providing better identification of who is making the database connections.