### PR TITLE
Force LF line endings on text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and normalize end of lines to LF (\n)
+* text=auto eol=lf


### PR DESCRIPTION
Depending on how git is configured on Windows (for example mine), git may attempt to normalize text file line endings to CRLF (\r\n), which results in broken Docker containers being built, as, for example, the entry point shell script fails to execute if it has CRLF line endings.

This PR adds the `.gitattributes` file instructing git to force LF (`\n`) line endings on text files.

Demonstration of the `entrypoint.sh` script having Windows CRLF line endings:

<img width="318" height="94" alt="image" src="https://github.com/user-attachments/assets/faa9a4bd-d53a-41a7-8ae8-dc916a2edbc4" />

Demonstration of the `entrypoint.sh` script having Unix LF line endings after applying this PR (and resetting files by executing `git rm --cached -r . && git reset --hard HEAD` to force git to apply the rules, since they are applied lazily when a file is modified):

<img width="244" height="109" alt="image" src="https://github.com/user-attachments/assets/82cdabfe-a50d-4e83-ba53-84616008e489" />

Demonstration of the Docker build and run on a Windows machine:

```console
> ver

Microsoft Windows [Version 10.0.19045.6575]

> docker version
Client:
 Version:           28.4.0
 API version:       1.51
 Go version:        go1.24.7
 Git commit:        d8eb465
 Built:             Wed Sep  3 20:59:40 2025
 OS/Arch:           windows/amd64
 Context:           desktop-linux

Server: Docker Desktop 4.47.0 (206054)
 Engine:
  Version:          28.4.0
  API version:      1.51 (minimum version 1.24)
  Go version:       go1.24.7
  Git commit:       249d679
  Built:            Wed Sep  3 20:57:37 2025
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.27
  GitCommit:        05044ec0a9a75232cad458027ca83437aae3f4da
 runc:
  Version:          1.2.5
  GitCommit:        v1.2.5-0-g59923ef
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0

> docker build --tag "pgadmin4:latest" .
...
=> exporting to image                                                                           9.1s
 => => exporting layers                                                                          9.0s
 => => writing image sha256:d0795b07892ecd1d58d3707da73094dbd8b0bb57c3ede384866d22e1bbd64da8     0.0s
 => => naming to docker.io/library/pgadmin4:latest                                               0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/uwm2g1ptmf8azdewr07zqy91b

> docker run --rm -p 8080:80 -e PGADMIN_DEFAULT_EMAIL=admin@example.com -e PGADMIN_DEFAULT_PASSWORD=admin pgadmin4:latest
email config is {'CHECK_EMAIL_DELIVERABILITY': False, 'ALLOW_SPECIAL_EMAIL_DOMAINS': [], 'GLOBALLY_DELIVERABLE': True}
/venv/lib/python3.12/site-packages/passlib/pwd.py:16: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
NOTE: Configuring authentication for SERVER mode.

pgAdmin 4 - Application Initialisation
======================================

postfix/postlog: starting the Postfix mail system
/venv/lib/python3.12/site-packages/passlib/pwd.py:16: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
/venv/lib/python3.12/site-packages/passlib/pwd.py:16: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
[2025-11-14 12:31:57 +0000] [1] [INFO] Starting gunicorn 23.0.0
[2025-11-14 12:31:57 +0000] [1] [INFO] Listening at: http://[::]:80 (1)
[2025-11-14 12:31:57 +0000] [1] [INFO] Using worker: gthread
[2025-11-14 12:31:57 +0000] [123] [INFO] Booting worker with pid: 123
::ffff:172.17.0.1 - - [14/Nov/2025:12:32:20 +0000] "GET / HTTP/1.1" 302 213 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:144.0) Gecko/20100101 Firefox/144.0"
...
```

The page `localhost:8080` responded:

<img width="460" height="331" alt="image" src="https://github.com/user-attachments/assets/8e92ce57-f643-47c9-bc23-2e4a079dbb92" />

So the image builds and runs successfully on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository configuration for consistent line ending handling across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->