### PR TITLE
Fix an issue in the Query Tool where running EXPLAIN [ANALYZE] on a s…

### DIFF
--- a/docs/en_US/query_tool.rst
+++ b/docs/en_US/query_tool.rst
@@ -275,6 +275,8 @@ the drop down on the right side of *Explain Analyze* button in the toolbar.
 
 Please note that pgAdmin generates the *Explain [Analyze]* plan in JSON format.
 
+**Note**: If multiple queries are present and none is selected, *Explain [Analyze]* runs the query located at the cursor position.
+
 On successful generation of *Explain* plan, it will create three tabs/panels
 under the Explain panel.
 

--- a/web/pgadmin/tools/sqleditor/static/js/components/sections/Query.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/sections/Query.jsx
@@ -146,8 +146,8 @@ export default function Query({onTextSelect, setQtStatePartial}) {
         const regex = /\$SELECTION\$/gi;
         query =  macroSQL.replace(regex, query);
         external = true;
-      } else if(executeCursor) {
-        /* Execute query at cursor position */
+      } else if(executeCursor || explainObject) {
+        /* Execute query at cursor position or explain query at cursor position */
         query = query || editor.current?.getQueryAt(editor.current?.state.selection.head).value || '';
       } else {
         /* Normal execution */


### PR DESCRIPTION
…cript containing multiple queries causes the Data Output panel to appear. #9297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Explain Analyze now executes the query at cursor position when multiple queries exist and none is selected.

* **Documentation**
  * Updated query tool documentation to clarify Explain Analyze behavior with multiple queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->