### PR TITLE
Make Plain SQL restore configurable, disabled by default in server mode. #9368

### DIFF
--- a/docs/en_US/restore_dialog.rst
+++ b/docs/en_US/restore_dialog.rst
@@ -28,7 +28,9 @@ restore process:
    * Select *Custom or tar* to restore from a custom archive file to create a
      copy of the backed-up object.
    * Select *Plain* to restore a plain SQL backup. When selecting this option
-     all the other options will not be applicable.
+     all the other options will not be applicable. **Note:** This option is
+     disabled by default when running in server mode. To allow this functionality,
+     you must set the configuration setting ENABLE_PLAIN_SQL_RESTORE to True.
    * Select *Directory* to restore from a compressed directory-format archive.
 
 * Enter the complete path to the backup file in the *Filename* field.

--- a/web/.editorconfig
+++ b/web/.editorconfig
@@ -19,6 +19,9 @@ indent_size = 4
 [*.js]
 indent_size = 2
 
+[*.jsx]
+indent_size = 2
+
 [*.css]
 indent_size = 2
 

--- a/web/config.py
+++ b/web/config.py
@@ -967,8 +967,17 @@ MAX_SERVER_TAGS_ALLOWED = 5
 #############################################################################
 # Number of records to fetch in one batch for server logs.
 ##############################################################################
-
 ON_DEMAND_LOG_COUNT = 10000
+
+############################################################################
+# PLAIN SQL RESTORE
+############################################################################
+# This will enable plain SQL restore in pgAdmin when running in server mode.
+# PLAIN SQL Restore is always enabled in Desktop mode; however, in
+# server mode it is disabled by default for security reasons. The
+# selected PLAIN SQL file may contain meta-commands (such as \\! or \\i)
+# or is considered unsafe to execute on the database server.
+ENABLE_PLAIN_SQL_RESTORE = False
 
 #############################################################################
 # Patch the default config with custom config and other manipulations

--- a/web/pgadmin/browser/__init__.py
+++ b/web/pgadmin/browser/__init__.py
@@ -524,6 +524,7 @@ def utils():
             qt_default_placeholder=QT_DEFAULT_PLACEHOLDER,
             vw_edt_default_placeholder=VW_EDT_DEFAULT_PLACEHOLDER,
             enable_psql=config.ENABLE_PSQL,
+            enable_plain_sql_restore=config.ENABLE_PLAIN_SQL_RESTORE,
             _=gettext,
             auth_only_internal=auth_only_internal,
             mfa_enabled=is_mfa_enabled(),

--- a/web/pgadmin/browser/templates/browser/js/utils.js
+++ b/web/pgadmin/browser/templates/browser/js/utils.js
@@ -72,6 +72,9 @@ define('pgadmin.browser.utils',
   /* Enable server password exec command */
   pgAdmin['enable_server_passexec_cmd'] = '{{enable_server_passexec_cmd}}';
 
+  /* Plain SQL restore */
+  pgAdmin['enable_plain_sql_restore'] =  '{{enable_plain_sql_restore}}' == 'True';
+
   // Define list of nodes on which Query tool option doesn't appears
   let unsupported_nodes = pgAdmin.unsupported_nodes = [
      'server_group', 'server', 'coll-tablespace', 'tablespace',

--- a/web/pgadmin/evaluate_config.py
+++ b/web/pgadmin/evaluate_config.py
@@ -131,6 +131,8 @@ def evaluate_and_patch_config(config: dict) -> dict:
         config['USER_INACTIVITY_TIMEOUT'] = 0
         # Enable PSQL in Desktop Mode.
         config['ENABLE_PSQL'] = True
+        # Enable Plain SQL Restore in Desktop Mode.
+        config['ENABLE_PLAIN_SQL_RESTORE'] = True
 
     if config.get('SERVER_MODE'):
         config.setdefault('USE_OS_SECRET_STORAGE', False)

--- a/web/pgadmin/static/js/UtilityView.jsx
+++ b/web/pgadmin/static/js/UtilityView.jsx
@@ -100,11 +100,22 @@ function UtilityViewContent({schema, treeNodeInfo, actionType, formType, onClose
       data: {...data, ...extraData},
     }).then((res)=>{
       /* Don't warn the user before closing dialog */
-      resolve(res.data);
-      onSave?.(res.data, data);
-      onClose();
+      if (res.data?.data?.confirmation_msg) {
+        pgAdmin.Browser.notifier.confirm(
+          gettext('Warning'),
+          res.data.data.confirmation_msg,
+          function() {
+            resolve(onSaveClick(isNew, {...data, confirmed: true}));
+          },
+          reject
+        );
+      } else {
+        resolve(res.data);
+        onSave?.(res.data, data);
+        onClose();
+      }
     }).catch((err)=>{
-      reject(err instanceof Error ? err : Error(gettext('Something went wrong')));
+      reject(err instanceof Error ? err : new Error(gettext('Something went wrong')));
     });
   });
 
@@ -120,7 +131,7 @@ function UtilityViewContent({schema, treeNodeInfo, actionType, formType, onClose
         resolve(res.data.data);
       }).catch((err)=>{
         onError(err);
-        reject(err instanceof Error ? err : Error(gettext('Something went wrong')));
+        reject(err instanceof Error ? err : new Error(gettext('Something went wrong')));
       });
     });
   };
@@ -170,7 +181,7 @@ function UtilityViewContent({schema, treeNodeInfo, actionType, formType, onClose
           } else if(err.message){
             console.error('error msg', err.message);
           }
-          reject(err instanceof Error ? err : Error(gettext('Something went wrong')));
+          reject(err instanceof Error ? err : new Error(gettext('Something went wrong')));
         });
     }
 

--- a/web/pgadmin/tools/backup/static/js/backup.js
+++ b/web/pgadmin/tools/backup/static/js/backup.js
@@ -157,17 +157,6 @@ define([
       let extraData = this.setExtraParameters(typeOfDialog);
       this.showBackupDialog(gettext('Backup Server'), schema, treeItem, typeOfDialog, extraData);
     },
-    saveCallBack: function(data) {
-      if(data.errormsg) {
-        pgAdmin.Browser.notifier.alert(
-          gettext('Error'),
-          gettext(data.errormsg)
-        );
-      } else {
-
-        pgBrowser.BgProcessManager.startProcess(data.data.job_id, data.data.desc);
-      }
-    },
     url_for_utility_exists(id, params){
       return url_for('backup.utility_exists', {
         'sid': id,

--- a/web/pgadmin/tools/maintenance/static/js/maintenance.js
+++ b/web/pgadmin/tools/maintenance/static/js/maintenance.js
@@ -92,16 +92,6 @@ define([
         }
       );
     },
-    saveCallBack: function(data) {
-      if(data.errormsg) {
-        pgAdmin.Browser.notifier.alert(
-          gettext('Error'),
-          gettext(data.errormsg)
-        );
-      } else {
-        pgBrowser.BgProcessManager.startProcess(data.data.job_id, data.data.desc);
-      }
-    },
     setExtraParameters(treeInfo) {
       let extraData = {};
       extraData['database'] = treeInfo.database._label;

--- a/web/pgadmin/tools/restore/static/js/restore.js
+++ b/web/pgadmin/tools/restore/static/js/restore.js
@@ -91,16 +91,6 @@ define('tools.restore', [
         pgBrowser
       );
     },
-    saveCallBack: function(data) {
-      if(data.errormsg) {
-        pgAdmin.Browser.notifier.alert(
-          gettext('Error'),
-          gettext(data.errormsg)
-        );
-      } else {
-        pgBrowser.BgProcessManager.startProcess(data.data.job_id, data.data.desc);
-      }
-    },
     setExtraParameters: function(treeInfo, nodeData) {
       let extraData = {};
       extraData['database'] = treeInfo.database._label;

--- a/web/pgadmin/tools/restore/static/js/restore.ui.js
+++ b/web/pgadmin/tools/restore/static/js/restore.ui.js
@@ -9,6 +9,7 @@
 
 import BaseUISchema from 'sources/SchemaView/base_schema.ui';
 import gettext from 'sources/gettext';
+import pgAdmin from 'sources/pgadmin';
 import { isEmptyString } from 'sources/validators';
 
 export class RestoreSectionSchema extends BaseUISchema {
@@ -364,7 +365,7 @@ export default class RestoreSchema extends BaseUISchema {
       value: 'directory',
     }];
 
-    if(this.fieldOptions.nodeType == 'database') {
+    if(pgAdmin['enable_plain_sql_restore'] && this.fieldOptions.nodeType == 'database') {
       options.splice(1, 0, {
         label: gettext('Plain'),
         value: 'plain',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable Plain SQL restore option gated by a new server-mode setting (disabled by default).

* **Documentation**
  * Restore dialog docs updated with instructions to enable Plain restore in server mode.

* **Security / Behavior**
  * Added file-safety checks and confirmation/blocking flows for plain SQL restores; Plain option is only offered when enabled and targeting databases.

* **Bug Fixes**
  * Standardized error handling and confirmation flows in utility dialogs.

* **Behavior Changes**
  * Post-save callbacks for backup/maintenance/restore removed, changing post-save alerts and automatic background job starts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->