### PR TITLE
fix: copyright updater skips folders like 'modules'

### DIFF
--- a/tools/copyright_updater.py
+++ b/tools/copyright_updater.py
@@ -23,7 +23,7 @@ ALLOWED_FILE_EXTENSIONS = (
     "LICENSE", "Dockerfile", "Makefile", ".ts", ".tsx"
 )
 
-EXCLUDE_DIR = ("node_modules")
+EXCLUDE_DIR = ("node_modules",)
 
 
 # Filter the files by its extension


### PR DESCRIPTION
Python treats the parentheses as grouping for an expression instead of defining a tuple, for code define a single item tuple as below:
```
t = ("node_modules")
print(t)          
print(type(t))
print("module" in t)
...
node_modules
<class 'str'>
True
```
We need to add a trailing comma to get a real tuple, as below:
```
t = ("node_modules",)
print(t)          
print(type(t))
print("module" in t)
...
('node_modules',)
<class 'tuple'>
False
```
