### PR TITLE
Plain SQL restore runs with '\restrict' option to prevent harmful psql meta-commands. #9368

### DIFF
--- a/docs/en_US/restore_dialog.rst
+++ b/docs/en_US/restore_dialog.rst
@@ -29,6 +29,10 @@ restore process:
      copy of the backed-up object.
    * Select *Plain* to restore a plain SQL backup. When selecting this option
      all the other options will not be applicable.
+     **Note:** The plain SQL restore process is executed in the backend using
+     the psql command with the \restrict option. The purpose of \restrict is to
+     enhance security by preventing dangerous commands embedded in a plain text
+     dump file from being executed on a PostgreSQL server.
    * Select *Directory* to restore from a compressed directory-format archive.
 
 * Enter the complete path to the backup file in the *Filename* field.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plain SQL restore now runs with an added backend restriction to block embedded meta-commands, improving security when restoring untrusted plain-text dumps.

* **Documentation**
  * Restore dialog documentation updated to explain the security behavior and how plain SQL restores are handled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->