### PR TITLE
Fix Query Tool state restoration for new connections and queries. #8987

### DIFF
--- a/web/pgadmin/settings/static/ApplicationStateProvider.jsx
+++ b/web/pgadmin/settings/static/ApplicationStateProvider.jsx
@@ -71,16 +71,16 @@ export function ApplicationStateProvider({children}){
         if(connectionInfo.is_editor_dirty){
           if(connectionInfo.external_file_changes){
             // file has external chages
-            return {loadFile: loadFile, fileName: fileName, data: toolContent, modifiedExternally: true};
+            return {loadFile: loadFile, fileName: fileName, data: toolContent, modifiedExternally: true, connectionInfo: connectionInfo};
           }
         }else if(connectionInfo.file_deleted){
-          return {loadFile: loadFile, fileName: null, data: toolContent};
+          return {loadFile: loadFile, fileName: null, data: toolContent, connectionInfo: connectionInfo};
         }else{
           loadFile = true;
-          return {loadFile: loadFile, fileName: fileName, data: null};
+          return {loadFile: loadFile, fileName: fileName, data: null, connectionInfo: connectionInfo};
         }
       }
-      return {loadFile: loadFile, fileName: fileName, data: toolContent};
+      return {loadFile: loadFile, fileName: fileName, data: toolContent, connectionInfo: connectionInfo};
 
     } catch (error) {
       let errorMsg = gettext(error?.response?.data?.errormsg || error);

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -305,6 +305,30 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
   const restoreToolContent = async () =>{
     let toolContent = await getToolContent(qtState.params.trans_id);
     if(toolContent){
+      const connList = toolContent.connectionInfo?.connection_list;
+      if (Array.isArray(connList) && connList.length > 0) {
+        // ensure exactly one is_selected
+        if (!connList.some(c => c.is_selected)) {
+          connList[0].is_selected = true;
+        }
+        // pick selected connection to update params (so UI shows correct selected conn)
+        const sel = connList.find(c => c.is_selected) || connList[0];
+
+        setQtStatePartial(prev => ({
+          ...prev,
+          connection_list: connList,
+          params: {
+            ...prev.params,
+            sid: sel.sid,
+            did: sel.did,
+            user: sel.user,
+            role: sel.role,
+            server_name: sel.server_name,
+            database_name: sel.database_name,
+            title: sel.title,
+          },
+        }));
+      }
       if (toolContent?.modifiedExternally) {
         toolContent = await fmUtilsObj.warnFileReload(toolContent?.fileName, toolContent.data, '');
       }


### PR DESCRIPTION
Detail Info:- #8987 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Connection info is now consistently included in tool state returns to avoid missing context.
  - Restore logic enforces exactly one active connection, defaulting sensibly when none are selected.
  - Auto-save now triggers reliably on content changes and when editor content is empty.

* **Improvements**
  - Better synchronization between editor state and active connection details for session restoration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->