### PR TITLE
Fix: User Management email column closure bug

### DIFF
--- a/web/pgadmin/tools/user_management/static/js/Users.jsx
+++ b/web/pgadmin/tools/user_management/static/js/Users.jsx
@@ -208,7 +208,7 @@ export default function Users({roles}) {
     },
     {
       header: gettext('Email'),
-      accessorKey: 'email',
+      accessorFn: (row) => row.email ?? '',
       enableSorting: true,
       enableResizing: true,
       size: 200,


### PR DESCRIPTION
The email column in User Management was using accessorKey which gets converted to accessorFn in PgTable.jsx. This caused a closure bug where all columns captured the same accessorKey value, resulting in all users displaying the logged-in user's email address.

Fix by explicitly using accessorFn to avoid the closure issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing email addresses in the Users list to display correctly when email data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->