### PR TITLE
Corrected erroneous comment in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,8 @@ RUN apk add --no-cache \
     yarn \
     zlib-dev
 
-# Create the /pgadmin4 directory and copy the source into it. Explicitly
-# remove the node_modules directory as we'll recreate a clean version, as well
-# as various other files we don't want
+# Create the /pgadmin4 directory and copy the source into it
 COPY web /pgadmin4/web
-
 WORKDIR /pgadmin4/web
 
 # Build the JS vendor code in the app-builder, and then remove the vendor source.


### PR DESCRIPTION
The following comment is wrong:

```Dockerfile
# Create the /pgadmin4 directory and copy the source into it. Explicitly
# remove the node_modules directory as we'll recreate a clean version, as well
# as various other files we don't want
```

It was left after a merge conflict resolution after merging #9377. As mentioned there, `Explicitly remove the node_modules directory` is wrong, since those files aren't even copied due to the use of the `.dockerignore` file.

~~Also, since I didn't get the answer, I'll try asking again, are we 100% sure we neet to copy the `.git` directory into the container during the build stage?~~

Edit: I found the use of .git inside `web/package.json`:

```json
"bundle": "cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=3072 yarn run bundle:dev && yarn run git:hash",
"git:hash": "git log -1 --format=\"%H %as\" > commit_hash",
```

Still this is suboptimal. I'll see what I can do in another PR.

Edit: Rebased to fix the merge conflict after #9497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the Docker image build by consolidating multiple copy steps into a single operation, reducing Dockerfile complexity and streamlining what gets packaged into the image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->