### PR TITLE
More Dockerfile optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN --mount=type=bind,source=.git,target=/pgadmin4/.git \
 FROM python:3-alpine AS env-builder
 
 # Install dependencies
-COPY requirements.txt /
 RUN apk add --no-cache \
         make && \
     apk add --no-cache --virtual build-deps \
@@ -77,8 +76,9 @@ RUN apk add --no-cache \
         cargo \
         zlib-dev \
         libjpeg-turbo-dev \
-        libpng-dev && \
-    python3 -m venv --system-site-packages --without-pip /venv && \
+        libpng-dev
+COPY requirements.txt /
+RUN python3 -m venv --system-site-packages --without-pip /venv && \
     /venv/bin/python3 -m pip install --no-cache-dir -r requirements.txt && \
     apk del --no-cache build-deps
 


### PR DESCRIPTION
3 things changed by this PR (separated into 3 commits):

1. Instead of copying the `.git` directory and then deleting it, we should use [RUN --mount=type=bind](https://docs.docker.com/reference/dockerfile/#run---mounttypebind) to temporarily mount the directory from the host in read-only mode visible to the commands in that `RUN` instruction. This avoids the needless copy and removal of `.git`, which will only grow in size as the repo ages (currently around 352 MB).
2. Instead of deleting the build cache directories after building, use [RUN --mount=type=tmpfs](https://docs.docker.com/reference/dockerfile/#run---mounttypetmpfs) to mount the build directories as tmpfs, which will be faster (since RAM is used) and automatically released at the end of the `RUN` instruction.
3. Split a `RUN` instruction to avoid redownlaoding and installing `apk` packages when the `requirements.txt` files is modified. Now only `pip` packages are redownloaded (assuming the `apk` stage is still cached) improving build time during development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Docker build process and dependency installation workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->