### PR TITLE
Disable Membership and parameter fields when object is not new for Login and Group Roles. #9350

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/static/js/membership.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/static/js/membership.ui.js
@@ -29,6 +29,7 @@ export default class MembershipSchema extends BaseUISchema {
   }
 
   get baseFields() {
+    let obj = this;
     return [{
       id: 'role', label: gettext('User/Role'), type:'text',
       editable: true,
@@ -38,6 +39,9 @@ export default class MembershipSchema extends BaseUISchema {
           allowClear: false,
         }
       }),
+      disabled: function (state) {
+        return !obj.isNew(state);
+      },
       noEmpty: true,
       minWidth: 300
     },

--- a/web/pgadmin/browser/server_groups/servers/static/js/variable.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/static/js/variable.ui.js
@@ -169,6 +169,9 @@ export default class VariableSchema extends BaseUISchema {
           options: obj.vnameOptions,
           controlProps: { allowClear: false },
         }),
+        disabled: function (state) {
+          return !obj.isNew(state);
+        },
       },
       {
         id: 'keyword', label: gettext('Keyword'), type: '', cell: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role field is now read-only when editing existing memberships, preventing changes to role after creation.
  * Name field is now read-only when editing existing variables, preventing renaming of existing parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->