### PR TITLE
Fixed a variable quoting issue in the Docker entrypoint script

### DIFF
--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -67,10 +67,30 @@ EOF
     done
 fi
 
+# Ensures the variable starts and ends in quotes after trimming
+ensure_quoted() {
+    local var="$1"
+
+    # Trim whitespaces
+    var="${var#"${var%%[![:space:]]*}"}"
+    var="${var%"${var##*[![:space:]]}"}"
+
+    # Check if the variable is already double or single quoted
+    if [[ ! $var =~ ^\"(.*)\"$ && ! $var =~ ^\'(.*)\'$ ]]; then
+        # Use docstrings in case the value contains quote characters inside
+        var="'''${var}'''"
+    fi
+
+    echo "${var}"
+}
+
 # Check whether the external configuration database exists if it is being used.
 external_config_db_exists="False"
 if [ -n "${PGADMIN_CONFIG_CONFIG_DATABASE_URI}" ]; then
-     external_config_db_exists=$(cd /pgadmin4/pgadmin/utils && /venv/bin/python3 -c "from check_external_config_db import check_external_config_db; val = check_external_config_db("${PGADMIN_CONFIG_CONFIG_DATABASE_URI}"); print(val)")
+    # Support both quoted and unquoted URIs for backwards compatibility
+    PGADMIN_CONFIG_CONFIG_DATABASE_URI=$(ensure_quoted "${PGADMIN_CONFIG_CONFIG_DATABASE_URI}")
+
+    external_config_db_exists=$(cd /pgadmin4/pgadmin/utils && /venv/bin/python3 -c "from check_external_config_db import check_external_config_db; val = check_external_config_db(${PGADMIN_CONFIG_CONFIG_DATABASE_URI}); print(val)")
 fi
 
 # DRY of the code to load the PGADMIN_SERVER_JSON_FILE


### PR DESCRIPTION
In the following line:

```bash
external_config_db_exists=$(cd /pgadmin4/pgadmin/utils && /venv/bin/python3 -c "from check_external_config_db import check_external_config_db; val = check_external_config_db("${PGADMIN_CONFIG_CONFIG_DATABASE_URI}"); print(val)")
```

We pass this to the Python interpreter:

```shell
python3 -c "from check_external_config_db import check_external_config_db; val = check_external_config_db("${PGADMIN_CONFIG_CONFIG_DATABASE_URI}"); print(val)"
```

Removing the noise we get:

```shell
python3 -c "something...; func("${PGADMIN_CONFIG_CONFIG_DATABASE_URI}"); print(val)"
```

I am assuming the value of the `PGADMIN_CONFIG_CONFIG_DATABASE_URI` variable was meant to be surrounded by quotes inside Python code, but since the Python code is passed to the interpreter as a double quoted shell argument, this resulted in the quotes being lost, moreover, if the variable contained any spaces, this would result in an error since those wouldn't be escaped.

This has been reported in #8529, however it was marked as won't fix. Just in case you decide to revisit, here's one possible solution. Instead of just blindly adding the quotes, I added a function `ensure_quoted` to check whether the value of the variable is already single/double quoted (I am assuming no one is using docstrings `"""string"""` since that would complicate the function). This is for backwards compatibility to support the already existing configurations that had to manually add the quotes for it to work previously.

Edit: Coderabbitai made an interesting suggestion to move the parsing of the environmental variable inside Python itself, in other words, write Pyhton code instead of Bash code. I think that's a better approach. Let me know if you agree and I'll rewrite this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker initialization to sanitize database URIs, handling both quoted and unquoted formats to prevent syntax errors during startup and ensure reliable configuration processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->