### PR TITLE
Removed redundant constraint for Python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ python-dateutil==2.*
 pytz==2025.*
 # pinned for https://github.com/andfoy/pywinpty/issues/545
 pywinpty==2.0.*; sys_platform=="win32"
-qrcode[pil]==8.*; python_version >= '3.9'
+qrcode[pil]==8.*
 setuptools==80.*
 SQLAlchemy==2.*
 sqlparse==0.*


### PR DESCRIPTION
Since the minimum supported Python version is 3.9, from the README:

> ## Prerequisites
> 1. Install Node.js 20 and above (https://nodejs.org/en/download)
> 2. yarn (https://yarnpkg.com/getting-started/install)
> 3. **_Python 3.9_** and above (https://www.python.org/downloads/)
> 4. PostgreSQL server (https://www.postgresql.org/download)

The constraint `python_version >= '3.9'` should be redundant, no?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified QR code library dependency requirements to apply across all supported Python versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->