### PR TITLE
Fix SSL direct mode connection failure with sslsni parameter

### DIFF
--- a/web/pgadmin/utils/driver/psycopg3/server_manager.py
+++ b/web/pgadmin/utils/driver/psycopg3/server_manager.py
@@ -690,6 +690,10 @@ WHERE db.oid = {0}""".format(did))
                 if key == 'hostaddr' and self.use_ssh_tunnel:
                     continue
 
+                # Convert boolean connection parameters to integer for libpq compatibility
+                if key in ('sslcompression', 'sslsni'):
+                    value = 1 if value else 0
+
                 dsn_args[key] = value
                 display_dsn_args[key] = orig_value if with_complete_path else \
                     value


### PR DESCRIPTION
## 🚨 Impact

**SSL direct mode is completely broken** when using the `sslsni` parameter with PostgreSQL 14+ servers. Connections fail with `SSL error: unexpected eof while reading`.

This affects any user attempting to use `PGSSLSNI=1` (Server Name Indication) with direct SSL negotiation mode.

## Summary

Fixes the `sslsni` connection parameter handling by converting boolean values to integers before passing to libpq.

## Problem

The `sslsni` parameter is stored as a boolean (`true`/`false`) in the UI and database, but libpq requires integer values (`1`/`0`) for this parameter. When a boolean value is passed to libpq, it results in SSL connection failures.

**Error:**
```
connection to server at "host", port 5432 failed: SSL error: unexpected eof while reading
```

## Solution

Added boolean-to-integer conversion in `web/pgadmin/utils/driver/psycopg3/server_manager.py` when creating the connection string. This ensures libpq receives the expected integer format.

The conversion happens in `create_connection_string()` method, right before parameters are passed to `make_conninfo()`:

```python
# Convert boolean connection parameters to integer for libpq compatibility
if key in ('sslcompression', 'sslsni'):
    value = 1 if value else 0
```

## Changes

- **Modified:** `web/pgadmin/utils/driver/psycopg3/server_manager.py` (+4 lines)
- Converts boolean connection parameters to integers when building the connection string
- Handles both `sslcompression` and `sslsni` parameters consistently

## Testing

✅ Tested locally with pgAdmin 4 v9.11 on macOS
✅ Verified connection succeeds with `PGSSLSNI=1` after fix
✅ Applied as hotfix and confirmed working in production environment

**Test case:**
- PostgreSQL 14+ server requiring SNI
- Connection parameters: `sslmode=require`, `sslnegotiation=direct`, `sslsni=1`
- Result: Connection succeeds ✓

## Related

- Affects PostgreSQL 14+ servers (sslsni requires `min_server_version: '14'`)
- Aligns with libpq's expectation of integer values for boolean SSL parameters
- Low risk change: 4 lines, narrow scope, well-tested

## Request for Expedited Review

This is a **minimal, critical fix** (4 lines) that unblocks SSL direct mode functionality. Given the severity and low risk, requesting inclusion in pgAdmin 9.12.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSL compression and SNI parameter handling for PostgreSQL connections using the psycopg3 driver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->