### PR TITLE
Fix #9572: Deployment of helm chart crashing with operation not permitted

### DIFF
--- a/pkg/helm/templates/deployment.yaml
+++ b/pkg/helm/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
               mountPath: /pgadmin4/config_distro.py
               subPath: config_distro.py
             - name: empty-dir
-              mountPath: /usr/bin/python3
+              mountPath: /usr/local/bin/python3
               subPath: python3
             - name: empty-dir
               mountPath: /tmp
@@ -205,7 +205,7 @@ spec:
           image: {{ template "pgadmin4.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-x", "-c"]
-          args: ['ls /usr/bin/python3.* | sort -V -r | head -n 1 | xargs -i cp {} python3']
+          args: ['ls /venv/bin/python3.* | sort -V -r | head -n 1 | xargs -i cp {} python3']
           workingDir: /emptyDir
           volumeMounts:
             - name: empty-dir


### PR DESCRIPTION
The root cause appears to be that the base image has moved the location of python from `/usr/bin/` to `/usr/local/bin/`. This prevented the workaround done by the init containers copying out the binary with the users permissions from working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved container configuration issues to improve application stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->