### PR TITLE
feat: add AWS IAM Database Authentication support for RDS/Aurora PosgreSQL

### DIFF
--- a/docs/en_US/aws_iam_authentication.rst
+++ b/docs/en_US/aws_iam_authentication.rst
@@ -1,0 +1,134 @@
+.. _aws_iam_authentication:
+
+*******************************************
+`AWS IAM Database Authentication`:index:
+*******************************************
+
+**Prerequisite:** AWS account with RDS/Aurora PostgreSQL and IAM configuration
+
+Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html
+
+pgAdmin supports AWS IAM Database Authentication for connecting to Amazon RDS
+and Aurora PostgreSQL databases. This feature allows you to authenticate using
+AWS IAM credentials instead of a database password, providing enhanced security
+through temporary authentication tokens.
+
+How It Works
+============
+
+When IAM authentication is enabled:
+
+1. pgAdmin generates a temporary authentication token using your AWS credentials
+2. The token is valid for 15 minutes and is automatically refreshed as needed
+3. SSL/TLS is automatically enforced (required by AWS for IAM authentication)
+4. No database password needs to be stored or transmitted
+
+Prerequisites
+=============
+
+Before using IAM authentication with pgAdmin, ensure the following:
+
+AWS RDS/Aurora Configuration
+----------------------------
+
+* IAM Database Authentication must be enabled on your RDS instance or Aurora cluster
+* A database user must be created and granted the ``rds_iam`` role:
+
+  .. code-block:: sql
+
+     CREATE USER your_username WITH LOGIN;
+     GRANT rds_iam TO your_username;
+
+* An IAM policy must allow the ``rds-db:connect`` action for the database user
+
+  .. code-block:: json
+
+     {
+       "Version": "2012-10-17",
+       "Statement": [
+         {
+           "Effect": "Allow",
+           "Action": "rds-db:connect",
+           "Resource": "arn:aws:rds-db:region:account-id:dbuser:resource-id/db-user-name"
+         }
+       ]
+     }
+
+Local AWS Configuration
+-----------------------
+
+* AWS credentials must be configured on the machine running pgAdmin
+* Credentials can be provided via:
+
+  * AWS credentials file (``~/.aws/credentials``)
+  * Environment variables (``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``)
+  * IAM role (when running on EC2/ECS/Lambda)
+
+* The ``botocore`` Python package must be installed (included with pgAdmin)
+
+Configuring IAM Authentication in pgAdmin
+=========================================
+
+To connect to a PostgreSQL server using IAM authentication:
+
+1. Open the *Server* dialog (right-click on *Servers* and select *Register* > *Server*)
+2. In the *Connection* tab:
+
+   * Set *Host name/address* to your RDS/Aurora endpoint
+   * Set *Port* to the database port (default: 5432)
+   * Set *Maintenance database* to the database name
+   * Set *Username* to the IAM-enabled database user
+   * Enable *AWS IAM authentication*
+   * Leave the *Password* field empty
+
+3. Configure the AWS-specific fields:
+
+   * *AWS Profile*: (Optional) The AWS profile name from your credentials file.
+     Leave empty to use the default profile or environment credentials.
+   * *AWS Region*: The AWS region where your RDS/Aurora instance is located
+     (e.g., ``us-east-1``, ``eu-west-1``).
+
+4. Click *Save* to store the server configuration
+
+Connection Behavior
+===================
+
+When connecting with IAM authentication:
+
+* pgAdmin automatically generates a fresh IAM authentication token
+* If the connection fails due to an expired token, pgAdmin will automatically
+  retry with a new token
+* SSL mode is automatically set to ``require`` if not explicitly configured
+* You will not be prompted for a password
+
+Troubleshooting
+===============
+
+**Connection fails with "PAM authentication failed"**
+
+* Verify the database user has the ``rds_iam`` role granted
+* Ensure the IAM policy allows the ``rds-db:connect`` action
+* Check that the AWS region is correctly configured
+
+**Token generation fails**
+
+* Verify AWS credentials are properly configured
+* Check that the AWS profile name (if specified) exists in your credentials file
+* Ensure the machine has network access to AWS STS endpoints
+
+**SSL connection required**
+
+* IAM authentication requires SSL. pgAdmin automatically enables SSL mode,
+  but ensure your RDS instance has SSL enabled and the client can establish
+  secure connections.
+
+Limitations
+===========
+
+* IAM authentication tokens expire after 15 minutes. pgAdmin handles token
+  refresh automatically, but very long-running idle connections may need
+  to reconnect.
+* This feature requires the ``botocore`` Python package.
+* IAM authentication is only supported for Amazon RDS and Aurora PostgreSQL,
+  not for self-hosted PostgreSQL servers.
+

--- a/docs/en_US/getting_started.rst
+++ b/docs/en_US/getting_started.rst
@@ -40,6 +40,7 @@ Mode is pre-configured for security.
    restore_locked_user
    ldap
    kerberos
+   aws_iam_authentication
    oauth2
    webserver
 

--- a/docs/en_US/server_dialog.rst
+++ b/docs/en_US/server_dialog.rst
@@ -70,6 +70,13 @@ Use the fields in the *Connection* tab to configure a connection:
   authenticating with the server.
 * When *Kerberos authentication?* is set to *True*, pgAdmin will try to connect
   the PostgreSQL server using Kerberos authentication.
+* When *AWS IAM authentication?* is set to *True*, pgAdmin will use AWS IAM
+  Database Authentication to connect to Amazon RDS or Aurora PostgreSQL.
+  For more information, see :ref:`AWS IAM Database Authentication <aws_iam_authentication>`.
+
+  * *AWS Profile*: (Optional) The AWS profile name from your credentials file.
+  * *AWS Region*: The AWS region where your RDS/Aurora instance is located.
+
 * Use the *Password* field to provide a password that will be supplied when
   authenticating with the server.
 * Check the box next to *Save password?* to instruct pgAdmin to save the

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ azure-mgmt-resource==24.0.0
 azure-mgmt-subscription==3.1.1
 bcrypt==5.0.*
 boto3==1.42.*
+botocore>=1.31.0
 certifi==2026.1.4
 cryptography==46.0.*
 Flask-Babel==4.0.*

--- a/web/migrations/versions/7ce2161fb957_add_iam_auth.py
+++ b/web/migrations/versions/7ce2161fb957_add_iam_auth.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+"""Add AWS IAM authentication support
+
+Added use_iam_auth, aws_profile, aws_region, and aws_role_arn columns
+to server configuration for AWS RDS/Aurora IAM authentication.
+
+Revision ID: 7ce2161fb957
+Revises: 018e16dad6aa
+Create Date: 2026-01-30 11:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '7ce2161fb957'
+down_revision = '018e16dad6aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('server', sa.Column('use_iam_auth', sa.Boolean(),
+                                       server_default='0', nullable=False))
+    op.add_column('server', sa.Column('aws_profile', sa.String(length=64)))
+    op.add_column('server', sa.Column('aws_region', sa.String(length=32)))
+    op.add_column('server', sa.Column('aws_role_arn', sa.String(length=256)))
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # pgAdmin only upgrades, downgrade not implemented.
+    pass

--- a/web/pgadmin/model/__init__.py
+++ b/web/pgadmin/model/__init__.py
@@ -33,7 +33,7 @@ import config
 #
 ##########################################################################
 
-SCHEMA_VERSION = 49
+SCHEMA_VERSION = 50
 
 ##########################################################################
 #
@@ -256,6 +256,11 @@ class Server(db.Model):
     shared = db.Column(db.Boolean(), nullable=False)
     shared_username = db.Column(db.String(64), nullable=True)
     kerberos_conn = db.Column(db.Boolean(), nullable=False, default=0)
+    # AWS IAM Authentication
+    use_iam_auth = db.Column(db.Boolean(), nullable=False, default=False)
+    aws_profile = db.Column(db.String(64), nullable=True)
+    aws_region = db.Column(db.String(32), nullable=True)
+    aws_role_arn = db.Column(db.String(256), nullable=True)
     cloud_status = db.Column(db.Integer(), nullable=False, default=0)
     connection_params = db.Column(MutableDict.as_mutable(types.JSON))
     prepare_threshold = db.Column(db.Integer(), nullable=True)

--- a/web/pgadmin/utils/aws_iam.py
+++ b/web/pgadmin/utils/aws_iam.py
@@ -1,0 +1,110 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+"""AWS IAM Authentication Module
+
+This module provides functionality for generating AWS RDS/Aurora IAM
+authentication tokens for database connections.
+"""
+
+import logging
+from flask_babel import gettext
+
+try:
+    import botocore.session
+    from botocore.exceptions import BotoCoreError, ClientError, \
+        NoCredentialsError, PartialCredentialsError
+    BOTOCORE_AVAILABLE = True
+except ImportError:
+    BOTOCORE_AVAILABLE = False
+
+_ = gettext
+
+
+def generate_rds_auth_token(host, port, username, region, profile=None,
+                              role_arn=None):
+    """
+    Generate an AWS RDS IAM authentication token.
+
+    Args:
+        host (str): The hostname of the database server
+        port (int): The port number of the database server
+        username (str): The database username to authenticate as
+        region (str): The AWS region where the database is located
+        profile (str, optional): The AWS profile name to use for credentials
+        role_arn (str, optional): The ARN of an IAM role to assume (future)
+
+    Returns:
+        str: The generated authentication token (valid for 15 minutes)
+
+    Raises:
+        Exception: If botocore is not available or token generation fails
+    """
+    if not BOTOCORE_AVAILABLE:
+        raise Exception(
+            _("AWS IAM authentication requires the 'botocore' package. "
+              "Please install it with: pip install botocore")
+        )
+
+    try:
+        # Create a botocore session with the specified profile (if any)
+        session = botocore.session.Session(profile=profile)
+
+        # TODO: Future enhancement - support role assumption via STS
+        # if role_arn:
+        #     sts_client = session.create_client('sts', region_name=region)
+        #     assumed_role = sts_client.assume_role(
+        #         RoleArn=role_arn,
+        #         RoleSessionName='pgAdmin4-IAM-Session'
+        #     )
+        #     # Use temporary credentials from assumed role
+        #     ...
+
+        # Create RDS client
+        rds_client = session.create_client('rds', region_name=region)
+
+        # Generate the authentication token
+        token = rds_client.generate_db_auth_token(
+            DBHostname=host,
+            Port=port,
+            DBUsername=username,
+            Region=region
+        )
+
+        logging.info(
+            f"Successfully generated IAM auth token for {username}@{host}"
+        )
+
+        return token
+
+    except NoCredentialsError:
+        raise Exception(
+            _("AWS credentials not found. Please configure your AWS "
+              "credentials using 'aws configure' or ensure your "
+              "environment has valid credentials.")
+        )
+    except PartialCredentialsError:
+        raise Exception(
+            _("Incomplete AWS credentials found. Please check your "
+              "AWS configuration.")
+        )
+    except (BotoCoreError, ClientError) as e:
+        error_msg = str(e)
+        logging.error(f"AWS IAM token generation failed: {error_msg}")
+        raise Exception(
+            _("AWS IAM token generation failed: {error}").format(
+                error=error_msg
+            )
+        )
+    except Exception as e:
+        error_msg = str(e)
+        logging.error(f"Unexpected error during IAM auth: {error_msg}")
+        raise Exception(
+            _("IAM authentication error: {error}").format(error=error_msg)
+        )


### PR DESCRIPTION
This adds support for AWS IAM Database Authentication, allowing users to connect to Amazon RDS and Aurora PostgreSQL databases using IAM credentials instead of traditional passwords.

Features:
- New "AWS IAM authentication" toggle in the Server Connection tab
- AWS Profile and Region configuration fields
- Automatic IAM token generation using botocore
- Automatic SSL enforcement (required by IAM auth)
- Token refresh retry on authentication failures
- No password prompt when IAM auth is enabled

Implementation:
- Database migration for new server fields (use_iam_auth, aws_profile, aws_region, aws_role_arn)
- AWS IAM token generator module (web/pgadmin/utils/aws_iam.py)
- Integration with ServerManager connection string generation
- Connection retry logic for expired tokens
- UI fields in server dialog
- RST documentation

Prerequisites for users:
- AWS credentials configured (profile or environment variables)
- RDS/Aurora instance with IAM auth enabled
- Database user with rds_iam role granted
- IAM policy allowing rds-db:connect action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AWS IAM Database Authentication support for RDS and Aurora PostgreSQL instances. Users can now configure IAM authentication in the server connection dialog with AWS profile and region settings.
  * Implemented automatic IAM token generation and refresh with built-in retry logic for connection resilience.
  * SSL connections are automatically enforced when using IAM authentication.

* **Documentation**
  * Added comprehensive AWS IAM authentication guide covering prerequisites, configuration, troubleshooting, and limitations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->