### PR TITLE
Fix misleading error when _FILE secret is not readable

### DIFF
--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
 #  "$XYZ_DB_PASSWORD" from a file, for Docker's secrets feature)
 function file_env() {
-    local var="$1"
+	local var="$1"
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
 	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then


### PR DESCRIPTION
## Problem

When a \*\_FILE environment variable (e.g. PGADMIN_DEFAULT_PASSWORD_FILE) points to a file that doesn't exist or isn't readable, the file_env() function silently reads an empty string, exports the base variable as empty, and then unsets the \_FILE variable.

This causes the downstream validation to produce a misleading error:

```
You need to define the PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD or
PGADMIN_DEFAULT_PASSWORD_FILE environment variables.
```

...even though PGADMIN_DEFAULT_PASSWORD_FILE was correctly set. This is a common scenario when using Docker secrets with incorrect mount paths or file permissions.

## Proposed Fix

Add an explicit check for file readability before attempting to read it. If it fails, issue an clear error message and exit immidiately. 
```shell
	elif [ "${!fileVar:-}" ] && [ ! -r "${!fileVar}" ]; then
		printf >&2 'error: %s is set to "%s" but the file does not exist or is not readable\n' \
			"$fileVar" "${!fileVar}"
		exit 1
```

## Performed Tests
| Scenario | Test Result  |
|--|--|
|_FILE set, file exists & readable | ✅ Works |
|_FILE set, file doesn't exist| ✅ new,clear error message |
|_FILE set, file exists but not readable| ✅ new, clear error message |
|_FILE not set, base var set| ✅ Works |
|Neither set | ✅ clear error message (same as before |
|Both set | ✅ clear error message (same as before |

## To reproduce the tests

1. Build the Docker Image, e.g. `docker build -t pgadmin-better-error:1 .`
2. Create Password Files
```shell
echo "wontwork" | sudo tee password-wrong-permissions >/dev/null && sudo chown root:root password-wrong-permissions && sudo chmod 600 password-wrong-permissions
echo "pwfromfile" | sudo tee password-right-permissions >/dev/null && sudo chown 5050:5050 password-right-permissions && sudo chmod 600 password-right-permissions 
```
3. Use this compose file to test different secnarios:
```yml
services:
  pgadmin:
    image: pgadmin-better-error:1
    container_name: pgadmin
    secrets:
      - password-wrong-permissions
      - password-right-permissions
    ports:
      - 8080:80
    environment:
      - PGADMIN_DEFAULT_PASSWORD_FILE=/run/secrets/password-wrong-permissions
      # - PGADMIN_DEFAULT_PASSWORD_FILE=/run/secrets/password-non-existing
      # - PGADMIN_DEFAULT_PASSWORD_FILE=/run/secrets/password-right-permissions
      # - PGADMIN_DEFAULT_PASSWORD=pwfromenvvar
      - PGADMIN_DEFAULT_EMAIL=example@pgadmin.org

secrets:
  password-wrong-permissions:
    file: ./password-wrong-permissions
  password-right-permissions:
    file: ./password-right-permissions

```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker startup validation: the system now detects when an environment-variable configuration file is missing or unreadable, reports a clear error message, and exits to prevent misconfiguration.
  * Retains existing checks to prevent simultaneous use of both an environment variable and its corresponding file-based value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->