### PR TITLE
Fixed an issue where unique/primary key constraint columns were shown in wrong order in Properties

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/index_constraint/static/js/primary_key.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/index_constraint/static/js/primary_key.ui.js
@@ -125,9 +125,10 @@ export default class PrimaryKeySchema extends BaseUISchema {
           multiple: true,
           formatter: {
             fromRaw: (backendVal, allOptions)=>{
-              /* remove the column key and pass as array */
-              let optValues = (backendVal||[]).map((singleVal)=>singleVal.column);
-              return _.filter(allOptions, (opt)=>optValues.indexOf(opt.value)>-1);
+              /* remove the column key and pass as array preserving constraint column order */
+              return (backendVal||[]).map((singleVal)=>
+                _.find(allOptions, (opt)=>opt.value === singleVal.column)
+              ).filter(Boolean);
             },
             toRaw: (value)=>{
               /* take the array and convert to column key collection */

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/index_constraint/static/js/unique_constraint.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/constraints/index_constraint/static/js/unique_constraint.ui.js
@@ -125,9 +125,10 @@ export default class UniqueConstraintSchema extends BaseUISchema {
           multiple: true,
           formatter: {
             fromRaw: (backendVal, allOptions) => {
-              /* remove the column key and pass as array */
-              let optValues = (backendVal||[]).map((singleVal) => singleVal.column);
-              return _.filter(allOptions, (opt) => optValues.indexOf(opt.value)>-1);
+              /* remove the column key and pass as array preserving constraint column order */
+              return (backendVal||[]).map((singleVal) =>
+                _.find(allOptions, (opt) => opt.value === singleVal.column)
+              ).filter(Boolean);
             },
             toRaw: (value)=>{
               /* take the array and convert to column key collection */

--- a/web/regression/javascript/schema_ui_files/primary_key.ui.spec.js
+++ b/web/regression/javascript/schema_ui_files/primary_key.ui.spec.js
@@ -138,6 +138,53 @@ describe('PrimaryKeySchema', ()=>{
 
   });
 
+  it('columns cell formatter', ()=>{
+    let cellFormatter = _.find(schemaObj.fields, (f)=>f.id=='columns').cell().controlProps.formatter;
+    expect(cellFormatter.fromRaw([{
+      column: 'user_id',
+    },{
+      column: 'client_order_id',
+    }])).toBe('user_id,client_order_id');
+
+    expect(cellFormatter.fromRaw([])).toBe('');
+  });
+
+  it('columns type formatter preserves constraint column order', ()=>{
+    let typeFormatter = _.find(schemaObj.fields, (f)=>f.id=='columns').type().controlProps.formatter;
+
+    /* allOptions are in table column position order (alphabetical here) */
+    let allOptions = [
+      {value: 'alpha', label: 'alpha'},
+      {value: 'beta', label: 'beta'},
+      {value: 'gamma', label: 'gamma'},
+    ];
+
+    /* backendVal comes from the constraint definition in a different order */
+    let backendVal = [{column: 'gamma'}, {column: 'alpha'}];
+
+    let result = typeFormatter.fromRaw(backendVal, allOptions);
+
+    /* result must preserve backendVal order, not allOptions order */
+    expect(result).toEqual([
+      {value: 'gamma', label: 'gamma'},
+      {value: 'alpha', label: 'alpha'},
+    ]);
+
+    /* empty and null values should be handled gracefully */
+    expect(typeFormatter.fromRaw([], allOptions)).toEqual([]);
+    expect(typeFormatter.fromRaw(null, allOptions)).toEqual([]);
+  });
+
+  it('columns type formatter toRaw', ()=>{
+    let typeFormatter = _.find(schemaObj.fields, (f)=>f.id=='columns').type().controlProps.formatter;
+    expect(typeFormatter.toRaw([{value: 'user_id'}, {value: 'client_order_id'}])).toEqual([
+      {column: 'user_id'},
+      {column: 'client_order_id'},
+    ]);
+    expect(typeFormatter.toRaw([])).toEqual([]);
+    expect(typeFormatter.toRaw(null)).toEqual([]);
+  });
+
   it('validate', ()=>{
     let state = {};
     let setError = jest.fn();

--- a/web/regression/javascript/schema_ui_files/unique_constraint.ui.spec.js
+++ b/web/regression/javascript/schema_ui_files/unique_constraint.ui.spec.js
@@ -137,6 +137,53 @@ describe('UniqueConstraintSchema', ()=>{
 
   });
 
+  it('columns cell formatter', ()=>{
+    let cellFormatter = _.find(schemaObj.fields, (f)=>f.id=='columns').cell().controlProps.formatter;
+    expect(cellFormatter.fromRaw([{
+      column: 'user_id',
+    },{
+      column: 'client_order_id',
+    }])).toBe('user_id,client_order_id');
+
+    expect(cellFormatter.fromRaw([])).toBe('');
+  });
+
+  it('columns type formatter preserves constraint column order', ()=>{
+    let typeFormatter = _.find(schemaObj.fields, (f)=>f.id=='columns').type().controlProps.formatter;
+
+    /* allOptions are in table column position order (alphabetical here) */
+    let allOptions = [
+      {value: 'alpha', label: 'alpha'},
+      {value: 'beta', label: 'beta'},
+      {value: 'gamma', label: 'gamma'},
+    ];
+
+    /* backendVal comes from the constraint definition in a different order */
+    let backendVal = [{column: 'gamma'}, {column: 'alpha'}];
+
+    let result = typeFormatter.fromRaw(backendVal, allOptions);
+
+    /* result must preserve backendVal order, not allOptions order */
+    expect(result).toEqual([
+      {value: 'gamma', label: 'gamma'},
+      {value: 'alpha', label: 'alpha'},
+    ]);
+
+    /* empty and null values should be handled gracefully */
+    expect(typeFormatter.fromRaw([], allOptions)).toEqual([]);
+    expect(typeFormatter.fromRaw(null, allOptions)).toEqual([]);
+  });
+
+  it('columns type formatter toRaw', ()=>{
+    let typeFormatter = _.find(schemaObj.fields, (f)=>f.id=='columns').type().controlProps.formatter;
+    expect(typeFormatter.toRaw([{value: 'user_id'}, {value: 'client_order_id'}])).toEqual([
+      {column: 'user_id'},
+      {column: 'client_order_id'},
+    ]);
+    expect(typeFormatter.toRaw([])).toEqual([]);
+    expect(typeFormatter.toRaw(null)).toEqual([]);
+  });
+
   it('validate', ()=>{
     let state = {};
     let setError = jest.fn();


### PR DESCRIPTION
## Bug

When viewing a unique constraint or primary key in the Properties tab,
the Columns field shows columns in table-definition order instead of
the actual constraint-defined column order. For example, a constraint
`UNIQUE (user_id, client_order_id)` displays as `client_order_id, user_id`.

The SQL tab shows the correct order; only the Properties tab is wrong.

## Root Cause

The `fromRaw` formatter in `unique_constraint.ui.js` and
`primary_key.ui.js` used `_.filter(allOptions, ...)`, which iterates
over `allOptions` (table columns) and keeps matches -- preserving
`allOptions` order rather than `backendVal` order. The backend SQL
and Python code correctly return columns in constraint-defined order.

## Fix

Replaced `_.filter(allOptions, ...)` with a `.map(... _.find(...))`
over `backendVal`, preserving the constraint column order from the backend.

## Tests

Added 6 new Jest tests (3 per file) covering:
- Cell formatter display string output
- Type formatter `fromRaw` verifying constraint column order is preserved
- Type formatter `toRaw` round-trip correctness

All 18 tests pass. ESLint clean.

## Related

Related: #6345 (similar column ordering issue for foreign keys, fixed
separately in 7.3). This PR addresses the same class of bug in the
unique constraint and primary key Properties view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Primary key and unique constraint columns now preserve the original constraint order when viewed and edited.

* **Tests**
  * Added tests validating column formatters (display and data conversion) preserve order and handle empty/null inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->