### PR TITLE
Fixed an issue where Geometry Viewer was showing stale data and not a…

### DIFF
--- a/web/pgadmin/tools/sqleditor/static/js/components/sections/GeometryViewer.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/sections/GeometryViewer.jsx
@@ -18,6 +18,7 @@ import gettext from 'sources/gettext';
 import Theme from 'sources/Theme';
 import PropTypes from 'prop-types';
 import { Box } from '@mui/material';
+import EmptyPanelMessage from '../../../../../../static/js/components/EmptyPanelMessage';
 import { PANELS } from '../QueryToolConstants';
 import { QueryToolContext } from '../QueryToolComponent';
 
@@ -351,23 +352,15 @@ function TheMap({data}) {
   return (
     <>
       {data.infoList.length > 0 && (
-        <div style={{
+        <EmptyPanelMessage text={data.infoList.join(' ')} style={{
           position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
           zIndex: 1000,
-          maxWidth: '80%',
-          textAlign: 'center',
-          whiteSpace: 'normal',
-          wordWrap: 'break-word',
-          fontSize: '16px',
           pointerEvents: 'none',
-        }}>
-          {data.infoList.map((info, idx) => (
-            <div key={idx}>{info}</div>
-          ))}
-        </div>
+        }} />
       )}
       {data.selectedSRID === 4326 &&
       <LayersControl position="topright">

--- a/web/pgadmin/tools/sqleditor/static/js/components/sections/ResultSet.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/sections/ResultSet.jsx
@@ -1537,28 +1537,32 @@ export function ResultSet() {
         const lastSel = lastGvSelectionRef.current;
         let selRowsData = rows;
 
+        // Re-apply row selection — plot only previously selected rows if indices are still valid
         if(lastSel.type === 'rows' && lastSel.rowIndices.length > 0) {
           if(lastSel.rowIndices.every(idx => idx < rows.length)) {
             selRowsData = lastSel.rowIndices.map(idx => rows[idx]);
           }
+        // Re-apply column selection — filter each row to only the previously selected columns
         } else if(lastSel.type === 'columns' && lastSel.columnIndices.size > 0) {
           let selectedCols = _.filter(columns, (_c, i) => lastSel.columnIndices.has(i + 1));
           if(selectedCols.length > 0) {
             selRowsData = _.map(rows, (r) => _.pick(r, _.map(selectedCols, (c) => c.key)));
           }
+        // Re-apply range selection — plot the previously selected row range if bounds are still valid
         } else if(lastSel.type === 'range' && lastSel.rangeStartIdx != null) {
           if(lastSel.rangeStartIdx < rows.length && lastSel.rangeEndIdx < rows.length) {
             selRowsData = rows.slice(lastSel.rangeStartIdx, lastSel.rangeEndIdx + 1);
           }
+        // Re-apply single cell selection — plot the row of the previously selected cell if still valid
         } else if(lastSel.type === 'cell' && lastSel.cellIdx != null) {
           if(lastSel.cellIdx < rows.length) {
             selRowsData = [rows[lastSel.cellIdx]];
           }
         }
-
+        // If any validation fails above, selRowsData remains as all rows (default)
         openGeometryViewerTab(matchedGeomCol, selRowsData);
       } else {
-        // Previously plotted geometry column not found → clear GV
+        // Previously plotted geometry column not found - clear GV
         openGeometryViewerTab(null, []);
       }
     }


### PR DESCRIPTION
…uto-updating on query reruns or new query runs with new data or different geometry columns in Query tool. #9392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geometry Viewer auto-refreshes and can open/update automatically when result rows or columns change.
  * Viewer fully reloads when CRS or geometry context changes to ensure correct rendering.

* **Improvements**
  * Selection persistence so previously selected geometries remain matched after data updates.
  * Geometry parsing deferred until a geometry column is selected to reduce work.
  * Safer tab-visibility checks, resize handling, and cleanup for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->