### PR TITLE
Fix tree view checkbox selection for backup dialog. #9649

### DIFF
--- a/web/pgadmin/static/js/PgTreeView/index.jsx
+++ b/web/pgadmin/static/js/PgTreeView/index.jsx
@@ -88,7 +88,7 @@ export default function PgTreeView({ data = [], hasCheckbox = false,
     // Update the clicked node and all its descendants with the new checked value
     const updateDescendants = (n, val) => {
       newState[n.id] = val;
-      n.children?.forEach(child => updateDescendants(child, val));
+      n.children?.forEach(child => { updateDescendants(child, val); });
     };
     updateDescendants(node, isChecked);
 
@@ -118,19 +118,22 @@ export default function PgTreeView({ data = [], hasCheckbox = false,
     setCheckedState(newState);
 
     // Collect all checked/indeterminate nodes from the entire tree
-    // to provide complete selection state to selectionChange callback. 
+    // to provide complete selection state to selectionChange callback.
+    // We use wrapper objects to avoid mutating the original node data.
     const allCheckedNodes = [];
     const collectAllCheckedNodes = (n) => {
       if (!n) return;
       const state = newState[n.id];
       if (state === true || state === 'indeterminate') {
-        // Set isIndeterminate flag to differentiate full schema selection                                                                                                                                                                   
-        // from partial selection (only specific tables) in backup dialog
-        n.data.isIndeterminate = (state === 'indeterminate');
-        allCheckedNodes.push(n);
+        // Pass wrapper object with isIndeterminate flag to differentiate
+        // full schema selection from partial selection in backup dialog
+        allCheckedNodes.push({
+          node: n,
+          isIndeterminate: state === 'indeterminate'
+        });
       }
       // Recursively check all children
-      n.children?.forEach(child => collectAllCheckedNodes(child));
+      n.children?.forEach(child => { collectAllCheckedNodes(child); });
     };
 
     // Navigate up to find the root level of the tree (parent of root nodes is '__root__')
@@ -143,7 +146,7 @@ export default function PgTreeView({ data = [], hasCheckbox = false,
     const rootParent = rootNode.parent;
     if (rootParent && rootParent.children) {
       // Iterate through all sibling root nodes to collect all checked nodes
-      rootParent.children.forEach(root => collectAllCheckedNodes(root));
+      rootParent.children.forEach(root => { collectAllCheckedNodes(root); });
     } else {
       // Fallback: if we can't find siblings, just traverse from the found root
       collectAllCheckedNodes(rootNode);

--- a/web/pgadmin/tools/backup/static/js/backup.ui.js
+++ b/web/pgadmin/tools/backup/static/js/backup.ui.js
@@ -758,8 +758,8 @@ export default class BackupSchema extends BaseUISchema {
           'foreign table': [],
           'materialized view': [],
         };
-        state?.objects?.forEach((node)=> {
-          if(node.data.is_schema && !node.data?.isIndeterminate) {
+        state?.objects?.forEach(({ node, isIndeterminate })=> {
+          if(node.data.is_schema && !isIndeterminate) {
             selectedNodeCollection['schema'].push(node.data.name);
           } else if(['table', 'view', 'materialized view', 'foreign table', 'sequence'].includes(node.data.type) &&
               !node.data.is_collection && !selectedNodeCollection['schema'].includes(node.data.schema)) {


### PR DESCRIPTION
 - Modified toggleCheck to collect all checked/indeterminate nodes from the
    entire tree, not just the clicked node's subtree
  - Fixed ancestor state calculation to properly distinguish between fully
    checked (state === true) and indeterminate states
  - Added the isIndeterminate flag to node data to help the backup dialog differentiate
    between full schema selection and partial table selection
  - Added traversal logic to find root nodes and iterate through all siblings
    to collect a complete selection state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree selection so toggling an item updates its descendants and parents correctly; callbacks now receive a complete snapshot of checked and partially-selected items.
* **Chores**
  * Minor internal cleanup in the backup UI code for clearer handling of selection state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->