### PR TITLE
Make SectionContainer resizable prop optional to fix Permissions and …

### DIFF
--- a/web/pgadmin/dashboard/static/js/Dashboard.jsx
+++ b/web/pgadmin/dashboard/static/js/Dashboard.jsx
@@ -1064,7 +1064,7 @@ function Dashboard({
                 {!_.isUndefined(preferences) && preferences.show_activity && (
                   <Fragment>
                     <CustomRefresh refresh={refresh} setRefresh={setRefresh}/>
-                    <SectionContainer title={gettext('Sessions')}>
+                    <SectionContainer title={gettext('Sessions')} resizable={true}>
                       <PgTable
                         caveTable={false}
                         tableNoBorder={false}
@@ -1074,7 +1074,7 @@ function Dashboard({
                         schema={activeQSchemaObj}
                       ></PgTable>
                     </SectionContainer>
-                    <SectionContainer title={gettext('Locks')}>
+                    <SectionContainer title={gettext('Locks')} resizable={true}>
                       <PgTable
                         caveTable={false}
                         tableNoBorder={false}
@@ -1082,7 +1082,7 @@ function Dashboard({
                         data={(dashData?.[0]?.['locks']) || []}
                       ></PgTable>
                     </SectionContainer>
-                    <SectionContainer title={gettext('Prepared Transactions')}>
+                    <SectionContainer title={gettext('Prepared Transactions')} resizable={true}>
                       <PgTable
                         caveTable={false}
                         tableNoBorder={false}

--- a/web/pgadmin/dashboard/static/js/components/SectionContainer.jsx
+++ b/web/pgadmin/dashboard/static/js/components/SectionContainer.jsx
@@ -39,28 +39,38 @@ const StyledBox = styled(Box)(({theme}) => ({
   },
 }));
 
-export default function SectionContainer({title, titleExtras, children, style}) {
+export default function SectionContainer({title, titleExtras, children, style, resizable = false, defaultHeight = 200}) {
+  const content = (
+    <>
+      <Box className='SectionContainer-cardHeader' title={title}>
+        <div className='SectionContainer-cardTitle'>{title}</div>
+        <div style={{marginLeft: 'auto'}}>
+          {titleExtras}
+        </div>
+      </Box>
+      <Box height="100%" display="flex" flexDirection="column" minHeight={0}>
+        {children}
+      </Box>
+    </>
+  );
+
   return (
     <StyledBox className='SectionContainer-root' style={style}>
-      <Resizable
-        enable={{ bottom: true }}
-        defaultSize={{ height: 200, width: '100%' }}
-        minHeight={25}
-        style={{
-          display: 'flex',
-          flexDirection: 'column'
-        }}
-      >
-        <Box className='SectionContainer-cardHeader' title={title}>
-          <div className='SectionContainer-cardTitle'>{title}</div>
-          <div style={{marginLeft: 'auto'}}>
-            {titleExtras}
-          </div>
-        </Box>
-        <Box height="100%" display="flex" flexDirection="column" minHeight={0}>
-          {children}
-        </Box>
-      </Resizable>
+      {resizable ? (
+        <Resizable
+          enable={{ bottom: true }}
+          defaultSize={{ height: defaultHeight, width: '100%' }}
+          minHeight={25}
+          style={{
+            display: 'flex',
+            flexDirection: 'column'
+          }}
+        >
+          {content}
+        </Resizable>
+      ) : (
+        content
+      )}
     </StyledBox>
   );
 }
@@ -70,4 +80,6 @@ SectionContainer.propTypes = {
   titleExtras: PropTypes.node,
   children: PropTypes.node.isRequired,
   style: PropTypes.object,
+  resizable: PropTypes.bool,
+  defaultHeight: PropTypes.number,
 };


### PR DESCRIPTION
…other page layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard Activity section tables (Sessions, Locks, Prepared Transactions) are now resizable, letting users adjust table heights.
  * Resizable sections have a configurable initial height (default 200px) to control starting display size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->