### PR TITLE
fix TypeError Exception in session.py

### DIFF
--- a/web/pgadmin/utils/session.py
+++ b/web/pgadmin/utils/session.py
@@ -123,7 +123,7 @@ class CachingSessionManager(SessionManager):
         # or None if it hasn't been set yet.
         try:
             return _session['_id'] is not None
-        except (AssertionError, RuntimeError, KeyError):
+        except (AssertionError, RuntimeError, KeyError, TypeError):
             return False
 
     def new_session(self):


### PR DESCRIPTION
Due to #9229 and https://github.com/pgadmin-org/pgadmin4/commit/bcd48a92b9e3478694c2dd3156773b223323cf24 the regression test started to fail in nixpkgs. It seems `TypeError` should also be excepted:

```
pgadmin-x86_64-linux> NOTE: Configuring authentication for DESKTOP mode.
pgadmin-x86_64-linux> pgAdmin 4 - Application Initialisation
pgadmin-x86_64-linux> ======================================
pgadmin-x86_64-linux>
pgadmin-x86_64-linux> Traceback (most recent call last):
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/runtests.py", line 813, in <module>
pgadmin-x86_64-linux>     test_utils.login_tester_account(test_client)
pgadmin-x86_64-linux>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/python_test_utils/test_utils.py", line 105, in login_tester_account
pgadmin-x86_64-linux>     tester.login(email, password)
pgadmin-x86_64-linux>     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/python_test_utils/csrf_test_client.py", line 133, in login
pgadmin-x86_64-linux>     res = self.post(
pgadmin-x86_64-linux>         '/authenticate/login', data=form_data,
pgadmin-x86_64-linux>         follow_redirects=_follow_redirects,
pgadmin-x86_64-linux>         headers=headers
pgadmin-x86_64-linux>     )
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 1167, in post
pgadmin-x86_64-linux>     return self.open(*args, **kw)
pgadmin-x86_64-linux>            ~~~~~~~~~^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/python_test_utils/csrf_test_client.py", line 74, in open
pgadmin-x86_64-linux>     return super().open(*args, **kwargs)
pgadmin-x86_64-linux>            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/testing.py", line 235, in open
pgadmin-x86_64-linux>     response = super().open(
pgadmin-x86_64-linux>         request,
pgadmin-x86_64-linux>         buffered=buffered,
pgadmin-x86_64-linux>         follow_redirects=follow_redirects,
pgadmin-x86_64-linux>     )
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 1116, in open
pgadmin-x86_64-linux>     response_parts = self.run_wsgi_app(request.environ, buffered=buffered)
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 988, in run_wsgi_app
pgadmin-x86_64-linux>     rv = run_wsgi_app(self.application, environ, buffered=buffered)
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 1264, in run_wsgi_app
pgadmin-x86_64-linux>     app_rv = app(environ, start_response)
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/app.py", line 1536, in __call__
pgadmin-x86_64-linux>     return self.wsgi_app(environ, start_response)
pgadmin-x86_64-linux>            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgAdmin4.py", line 76, in __call__
pgadmin-x86_64-linux>     return self.app(environ, start_response)
pgadmin-x86_64-linux>            ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/middleware/proxy_fix.py", line 183, in __call__
pgadmin-x86_64-linux>     return self.app(environ, start_response)
pgadmin-x86_64-linux>            ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/nix/store/6j74rgh92k1ib77q5c7vd0rk3d4qnx7c-python3.13-flask-socketio-5.6.0/lib/python3.13/site-packages/flask_socketio/__init__.py", line 42, in __call__
pgadmin-x86_64-linux>     return super().__call__(environ, start_response)
pgadmin-x86_64-linux>            ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/nix/store/409xjmxrqnxrzx32bxnp5042mganbrwf-python3.13-python-engineio-4.13.1/lib/python3.13/site-packages/engineio/middleware.py", line 74, in __call__
pgadmin-x86_64-linux>     return self.wsgi_app(environ, start_response)
pgadmin-x86_64-linux>            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/app.py", line 1514, in wsgi_app
pgadmin-x86_64-linux>     response = self.handle_exception(e)
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/app.py", line 1510, in wsgi_app
pgadmin-x86_64-linux>     ctx.push()
pgadmin-x86_64-linux>     ~~~~~~~~^^
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/ctx.py", line 386, in push
pgadmin-x86_64-linux>     self.session = session_interface.open_session(self.app, self.request)
pgadmin-x86_64-linux>                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgadmin/utils/session.py", line 314, in open_session
pgadmin-x86_64-linux>     return self.manager.get(sid, digest)
pgadmin-x86_64-linux>            ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgadmin/utils/session.py", line 160, in get
pgadmin-x86_64-linux>     if self.is_session_ready(session) and\
pgadmin-x86_64-linux>        ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgadmin/utils/session.py", line 125, in is_session_ready
pgadmin-x86_64-linux>     return _session['_id'] is not None
pgadmin-x86_64-linux>            ~~~~~~~~^^^^^^^
pgadmin-x86_64-linux> TypeError: 'NoneType' object is not subscriptable
pgadmin-x86_64-linux> Exception ignored in atexit callback functools.partial(<function _cleanup at 0x7ffff1be8680>, <TestClient <PgAdmin 'pgadmin'>>, None):
pgadmin-x86_64-linux> Traceback (most recent call last):
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/python_test_utils/test_utils.py", line 1074, in _cleanup
pgadmin-x86_64-linux>     tester.logout()
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/python_test_utils/csrf_test_client.py", line 143, in logout
pgadmin-x86_64-linux>     self.get('/logout?next=/browser/', follow_redirects=False)
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 1162, in get
pgadmin-x86_64-linux>     return self.open(*args, **kw)
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/regression/python_test_utils/csrf_test_client.py", line 74, in open
pgadmin-x86_64-linux>     return super().open(*args, **kwargs)
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/testing.py", line 235, in open
pgadmin-x86_64-linux>     response = super().open(
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 1116, in open
pgadmin-x86_64-linux>     response_parts = self.run_wsgi_app(request.environ, buffered=buffered)
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 988, in run_wsgi_app
pgadmin-x86_64-linux>     rv = run_wsgi_app(self.application, environ, buffered=buffered)
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/test.py", line 1264, in run_wsgi_app
pgadmin-x86_64-linux>     app_rv = app(environ, start_response)
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/app.py", line 1536, in __call__
pgadmin-x86_64-linux>     return self.wsgi_app(environ, start_response)
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgAdmin4.py", line 76, in __call__
pgadmin-x86_64-linux>     return self.app(environ, start_response)
pgadmin-x86_64-linux>   File "/nix/store/ibp1nxpnhqz202i0m4wz05daz5fbvb52-python3.13-werkzeug-3.1.5/lib/python3.13/site-packages/werkzeug/middleware/proxy_fix.py", line 183, in __call__
pgadmin-x86_64-linux>     return self.app(environ, start_response)
pgadmin-x86_64-linux>   File "/nix/store/6j74rgh92k1ib77q5c7vd0rk3d4qnx7c-python3.13-flask-socketio-5.6.0/lib/python3.13/site-packages/flask_socketio/__init__.py", line 42, in __call__
pgadmin-x86_64-linux>     return super().__call__(environ, start_response)
pgadmin-x86_64-linux>   File "/nix/store/409xjmxrqnxrzx32bxnp5042mganbrwf-python3.13-python-engineio-4.13.1/lib/python3.13/site-packages/engineio/middleware.py", line 74, in __call__
pgadmin-x86_64-linux>     return self.wsgi_app(environ, start_response)
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/app.py", line 1514, in wsgi_app
pgadmin-x86_64-linux>     response = self.handle_exception(e)
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/app.py", line 1510, in wsgi_app
pgadmin-x86_64-linux>     ctx.push()
pgadmin-x86_64-linux>   File "/nix/store/zb4958rw6hq47my3kg8iyry4cb4fpc9n-python3.13-flask-3.1.2/lib/python3.13/site-packages/flask/ctx.py", line 386, in push
pgadmin-x86_64-linux>     self.session = session_interface.open_session(self.app, self.request)
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgadmin/utils/session.py", line 314, in open_session
pgadmin-x86_64-linux>     return self.manager.get(sid, digest)
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgadmin/utils/session.py", line 160, in get
pgadmin-x86_64-linux>     if self.is_session_ready(session) and\
pgadmin-x86_64-linux>   File "/build/source/pip-build/pgadmin4/pgadmin/utils/session.py", line 125, in is_session_ready
pgadmin-x86_64-linux>     return _session['_id'] is not None
pgadmin-x86_64-linux> TypeError: 'NoneType' object is not subscriptable
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session readiness validation to handle additional error conditions, enhancing stability during session state checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->