### PR TITLE
Fix flakey SchemaDialogView 'change text' JS test

### DIFF
--- a/web/regression/javascript/SchemaView/SchemaDialogView.spec.js
+++ b/web/regression/javascript/SchemaView/SchemaDialogView.spec.js
@@ -101,6 +101,10 @@ describe('SchemaView', ()=>{
       });
 
       it('change text', async ()=>{
+        // Wait for autofocus timer (200ms in FormView) to complete
+        await act(async ()=>{
+          await new Promise(resolve => setTimeout(resolve, 500));
+        });
         await user.type(ctrl.container.querySelector('[name="field2"]'), '2');
         /* Error should come for field1 as it is empty and noEmpty true */
         expect(ctrl.container.querySelector('[data-test="notifier-message"]')).toHaveTextContent('\'Field1\' cannot be empty.');


### PR DESCRIPTION
Add a wait for the FormView autofocus timer (200ms) to complete before typing, preventing a race condition where the autofocus moves focus away from the target field on slow CI machines. This matches the pattern already used by simulateValidData in the same test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timing reliability in schema dialog view test by adjusting focus-related test execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->