### PR TITLE
Fix apparmor_parser not found error in desktop postinst script

### DIFF
--- a/pkg/debian/build.sh
+++ b/pkg/debian/build.sh
@@ -84,7 +84,11 @@ EOF
 #!/bin/sh
 
 echo "Load apparmor pgAdmin profile..."
-apparmor_parser -r /etc/apparmor.d/pgadmin4
+if command -v apparmor_parser >/dev/null 2>&1; then
+  apparmor_parser -r /etc/apparmor.d/pgadmin4
+else
+  echo "Warning: apparmor_parser not found, skipping profile load. pgAdmin desktop may not work on Ubuntu 24+ with userns restrictions."
+fi
 EOF
   chmod 755 "${DESKTOPROOT}/DEBIAN/postinst"
 fi


### PR DESCRIPTION
  Add a runtime guard in the postinst so apparmor_parser is only called
  when available. Previously, packages built on Ubuntu 24+ would fail to
  install on headless servers or systems without AppArmor tools. A warning
  is printed when the profile load is skipped to aid debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Debian package installation now handles missing AppArmor tools gracefully, displaying a warning and continuing installation instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->