### PR TITLE
Fixed an issue where Query Tool's Messages tab content right-click "Select All"…

### DIFF
--- a/web/pgadmin/tools/sqleditor/static/js/components/sections/Messages.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/sections/Messages.jsx
@@ -10,27 +10,26 @@ import { styled } from '@mui/material/styles';
 import React from 'react';
 import { QueryToolEventsContext } from '../QueryToolComponent';
 import { QUERY_TOOL_EVENTS } from '../QueryToolConstants';
-import gettext from 'sources/gettext';
-import { PgMenu, PgMenuItem } from '../../../../../../static/js/components/Menu';
 
-const StyledDiv = styled('div')(({theme}) => ({
+const StyledTextarea = styled('textarea')(({theme}) => ({
   whiteSpace: 'pre-wrap',
   fontFamily: '"Source Code Pro", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
   padding: '5px 10px',
   overflow: 'auto',
   height: '100%',
+  width: '100%',
   fontSize: '12px',
-  userSelect: 'text',
   backgroundColor: theme.palette.background.default,
   color: theme.palette.text.primary,
+  border: 'none',
+  outline: 'none',
+  resize: 'none',
   ...theme.mixins.fontSourceCode,
 }));
 
 export function Messages() {
 
   const [messageText, setMessageText] = React.useState('');
-  const [contextPos, setContextPos] = React.useState(null);
-  const containerRef = React.useRef(null);
   const eventBus = React.useContext(QueryToolEventsContext);
   React.useEffect(()=>{
     eventBus.registerListener(QUERY_TOOL_EVENTS.SET_MESSAGE, (text, append=false)=>{
@@ -42,45 +41,5 @@ export function Messages() {
       });
     });
   }, []);
-
-  const handleContextMenu = React.useCallback((e)=>{
-    e.preventDefault();
-    setContextPos({x: e.clientX, y: e.clientY});
-  }, []);
-
-  const selectAll = React.useCallback(()=>{
-    if(containerRef.current) {
-      const selection = window.getSelection();
-      const range = document.createRange();
-      range.selectNodeContents(containerRef.current);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
-    setContextPos(null);
-  }, []);
-
-  const copyToClipboard = React.useCallback(()=>{
-    const selection = window.getSelection();
-    const text = selection.toString();
-    if(text) {
-      navigator.clipboard.writeText(text);
-    }
-    setContextPos(null);
-  }, []);
-
-  return <>
-    <StyledDiv tabIndex="0" ref={containerRef} onContextMenu={handleContextMenu}>
-      {messageText}
-    </StyledDiv>
-    <PgMenu
-      anchorPoint={contextPos ? {x: contextPos.x, y: contextPos.y} : undefined}
-      open={Boolean(contextPos)}
-      onClose={()=>setContextPos(null)}
-      label="messages-context"
-      portal
-    >
-      <PgMenuItem onClick={copyToClipboard}>{gettext('Copy')}</PgMenuItem>
-      <PgMenuItem onClick={selectAll}>{gettext('Select All')}</PgMenuItem>
-    </PgMenu>
-  </>;
+  return <StyledTextarea value={messageText} readOnly/>;
 }


### PR DESCRIPTION
… selects the entire page's content and copying the selection by right-click "Copy" reset the selection. #8992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages view now uses a read-only, full-width text area for displaying messages.
  * Improved text selection, copy and select-all behavior while preserving existing live message updates.
  * Visual tweaks: borderless/outline-less appearance and disabled resizing for a cleaner, consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->