### PR TITLE
Fixed an issue where ALT+F5 for execute query in Query Tool shows cro…

### DIFF
--- a/web/pgadmin/static/js/components/ReactCodeMirror/components/Editor.jsx
+++ b/web/pgadmin/static/js/components/ReactCodeMirror/components/Editor.jsx
@@ -119,9 +119,9 @@ function insertTabWithUnit({ state, dispatch }) {
 /* React wrapper for CodeMirror */
 const defaultExtensions = [
   highlightSpecialChars(),
-  rectangularSelection(),
   dropCursor(),
-  crosshairCursor(),
+  rectangularSelection({ eventFilter: (e) => e.altKey && e.ctrlKey }),
+  crosshairCursor({ key: 'Control' }),
   EditorState.allowMultipleSelections.of(true),
   indentOnInput(),
   syntaxHighlighting,


### PR DESCRIPTION
…sshairCursor icon for rectangularSelection. #9570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rectangular selection in the code editor now requires both Alt and Ctrl keys.
  * Crosshair cursor in the code editor now activates only when the Control key is pressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->