### PR TITLE
Generate ALTER TABLE SET UNLOGGED/LOGGED when persistence is changed (#9677)

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/templates/tables/sql/11_plus/update.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/templates/tables/sql/11_plus/update.sql
@@ -51,6 +51,14 @@ ALTER TABLE IF EXISTS {{conn|qtIdent(data.schema, data.name)}}
 
 {% endif %}
 {#####################################################}
+{## Change table persistence (UNLOGGED / LOGGED) ##}
+{#####################################################}
+{% if data.relpersistence is defined and data.relpersistence != o_data.relpersistence %}
+ALTER TABLE IF EXISTS {{conn|qtIdent(data.schema, data.name)}}
+    SET {% if data.relpersistence %}UNLOGGED{% else %}LOGGED{% endif %};
+
+{% endif %}
+{#####################################################}
 {## Change tablespace ##}
 {#####################################################}
 {% if data.spcname and data.spcname != o_data.spcname %}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/templates/tables/sql/default/update.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/templates/tables/sql/default/update.sql
@@ -51,6 +51,14 @@ ALTER TABLE IF EXISTS {{conn|qtIdent(data.schema, data.name)}}
 
 {% endif %}
 {#####################################################}
+{## Change table persistence (UNLOGGED / LOGGED) ##}
+{#####################################################}
+{% if data.relpersistence is defined and data.relpersistence != o_data.relpersistence %}
+ALTER TABLE IF EXISTS {{conn|qtIdent(data.schema, data.name)}}
+    SET {% if data.relpersistence %}UNLOGGED{% else %}LOGGED{% endif %};
+
+{% endif %}
+{#####################################################}
 {## Change tablespace ##}
 {#####################################################}
 {% if data.spcname and data.spcname != o_data.spcname %}

--- a/web/pgadmin/static/js/helpers/Layout/index.jsx
+++ b/web/pgadmin/static/js/helpers/Layout/index.jsx
@@ -67,6 +67,8 @@ export function TabTitle({id, closable, defaultInternal}) {
       <span style={{textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap'}} data-visible={layoutDocker.isTabVisible(id)}>{attrs.title}</span>
       {closable && <PgIconButton title={gettext('Close')} icon={<CloseIcon style={{height: '0.7em'}} />} size="xs" noBorder onClick={()=>{
         layoutDocker.close(id);
+      }} onMouseDown={(e)=>{
+        if(e.button === 1) { e.preventDefault(); layoutDocker.close(id); }
       }} style={{margin: '-1px -10px -1px 0'}} />}
     </Box>
   );

--- a/web/pgadmin/static/js/helpers/Layout/index.jsx
+++ b/web/pgadmin/static/js/helpers/Layout/index.jsx
@@ -67,8 +67,6 @@ export function TabTitle({id, closable, defaultInternal}) {
       <span style={{textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap'}} data-visible={layoutDocker.isTabVisible(id)}>{attrs.title}</span>
       {closable && <PgIconButton title={gettext('Close')} icon={<CloseIcon style={{height: '0.7em'}} />} size="xs" noBorder onClick={()=>{
         layoutDocker.close(id);
-      }} onMouseDown={(e)=>{
-        if(e.button === 1) { e.preventDefault(); layoutDocker.close(id); }
       }} style={{margin: '-1px -10px -1px 0'}} />}
     </Box>
   );


### PR DESCRIPTION
Closes #9677

## Problem

The Unlogged toggle in Table Properties → Advanced has no effect. Toggling it and saving produces no DDL — the `relpersistence` change was tracked in the form but never written to the update SQL templates.

## Fix

Add the missing block to both `default/update.sql` and `11_plus/update.sql`:

```sql
{% if data.relpersistence is defined and data.relpersistence != o_data.relpersistence %}
ALTER TABLE IF EXISTS ... SET {% if data.relpersistence %}UNLOGGED{% else %}LOGGED{% endif %};
{% endif %}
```

The `relpersistence` field is already fetched by `properties.sql` (`relpersistence = 'u'` → true) and tracked in the form; this change wires it through to DDL generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table persistence can now be modified to LOGGED or UNLOGGED states when updating table configurations. This functionality is now available across all PostgreSQL versions supported by the application, including PostgreSQL 11 and later versions as well as earlier supported versions, providing users complete flexibility in managing their table durability settings and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->