### PR TITLE
Add toast_tuple_target to Materialized View properties dialog (#9626)

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/static/js/mview.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/static/js/mview.ui.js
@@ -106,6 +106,11 @@ export default class MViewSchema extends BaseUISchema {
         id: 'fillfactor', label: gettext('Fill factor'),
         group: gettext('Definition'), mode: ['edit', 'create'],
         noEmpty: false, type: 'int', controlProps: {min: 10, max: 100}
+      },{
+        id: 'toast_tuple_target', label: gettext('Toast tuple target'),
+        group: gettext('Definition'), mode: ['edit', 'create'],
+        noEmpty: false, type: 'int', controlProps: {min: 128, max: 8160},
+        min_version: 110000,
       },
       {
         id: 'dependsonextensions',

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/create.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/create.sql
@@ -7,11 +7,13 @@
 {% endif %}
 {% if data.name and data.schema and data.definition %}
 CREATE MATERIALIZED VIEW{% if add_not_exists_clause %} IF NOT EXISTS{% endif %} {{ conn|qtIdent(data.schema, data.name) }}
-{% if(data.fillfactor or data.autovacuum_enabled in ('t', 'f') or data.toast_autovacuum_enabled in ('t', 'f') or data['vacuum_data']|length > 0) %}
+{% if(data.fillfactor or data.toast_tuple_target or data.autovacuum_enabled in ('t', 'f') or data.toast_autovacuum_enabled in ('t', 'f') or data['vacuum_data']|length > 0) %}
 {% set ns = namespace(add_comma=false) %}
 WITH (
 {% if data.fillfactor %}
-    FILLFACTOR = {{ data.fillfactor }}{% set ns.add_comma = true%}{% endif %}{% if data.autovacuum_enabled in ('t', 'f') %}
+    FILLFACTOR = {{ data.fillfactor }}{% set ns.add_comma = true%}{% endif %}{% if data.toast_tuple_target %}
+{% if ns.add_comma %},
+{% endif %}    TOAST_TUPLE_TARGET = {{ data.toast_tuple_target }}{% set ns.add_comma = true%}{% endif %}{% if data.autovacuum_enabled in ('t', 'f') %}
 {% if ns.add_comma %},
 {% endif %}
     autovacuum_enabled = {% if data.autovacuum_enabled == 't' %}TRUE{% else %}FALSE{% endif %}{% set ns.add_comma = true%}{% endif %}{% if data.toast_autovacuum_enabled in ('t', 'f')  %}

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/properties.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/properties.sql
@@ -24,6 +24,8 @@ SELECT
     (SELECT pg_catalog.array_agg(provider || '=' || label) FROM pg_catalog.pg_seclabels sl1 WHERE sl1.objoid=c.oid AND sl1.objsubid=0) AS seclabels,
     substring(pg_catalog.array_to_string(c.reloptions, ',')
       FROM 'fillfactor=([0-9]*)') AS fillfactor,
+    substring(pg_catalog.array_to_string(c.reloptions, ',')
+      FROM 'toast_tuple_target=([0-9]*)') AS toast_tuple_target,
     (substring(pg_catalog.array_to_string(c.reloptions, ',') FROM 'autovacuum_enabled=([a-z|0-9]*)'))::BOOL AS autovacuum_enabled,
     substring(pg_catalog.array_to_string(c.reloptions, ',')
       FROM 'autovacuum_vacuum_threshold=([0-9]*)') AS autovacuum_vacuum_threshold,

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/update.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/update.sql
@@ -96,7 +96,7 @@ SET(
   TOAST_TUPLE_TARGET = {{ data.toast_tuple_target }}
 );
 
-{% elif data.toast_tuple_target == '' and o_data.toast_tuple_target|default('', 'true') != data.toast_tuple_target %}
+{% elif (data.toast_tuple_target == '' or data.toast_tuple_target == None) and data.toast_tuple_target != o_data.toast_tuple_target %}
 ALTER MATERIALIZED VIEW IF EXISTS {{ conn|qtIdent(view_schema, view_name) }}
 RESET(
   TOAST_TUPLE_TARGET

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/update.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/update.sql
@@ -80,6 +80,20 @@ RESET(
 );
 
 {% endif %}
+{# ======= SET/RESET Toast Tuple Target ========= #}
+{% if data.toast_tuple_target and o_data.toast_tuple_target != data.toast_tuple_target %}
+ALTER MATERIALIZED VIEW IF EXISTS {{ conn|qtIdent(view_schema, view_name) }}
+SET(
+  TOAST_TUPLE_TARGET = {{ data.toast_tuple_target }}
+);
+
+{% elif data.toast_tuple_target == '' and o_data.toast_tuple_target|default('', 'true') != data.toast_tuple_target %}
+ALTER MATERIALIZED VIEW IF EXISTS {{ conn|qtIdent(view_schema, view_name) }}
+RESET(
+  TOAST_TUPLE_TARGET
+);
+
+{% endif %}
 {# ===== Check for with_data property ===== #}
 {% if data.with_data is defined and o_data.with_data|lower != data.with_data|lower  %}
 REFRESH MATERIALIZED VIEW {{ conn|qtIdent(view_schema, view_name) }} WITH{{ ' NO' if data.with_data|lower == 'false' else '' }} DATA;

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/update.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/views/templates/mviews/pg/default/sql/update.sql
@@ -27,16 +27,25 @@ ALTER TABLE IF EXISTS {{ conn|qtIdent(view_schema, view_name) }}
 {% if def and def != o_data.definition.rstrip(';') %}
 DROP MATERIALIZED VIEW IF EXISTS {{ conn|qtIdent(view_schema, view_name) }};
 CREATE MATERIALIZED VIEW IF NOT EXISTS {{ conn|qtIdent(view_schema, view_name) }}
-{% if data.fillfactor or o_data.fillfactor %}
+{% if data.fillfactor or o_data.fillfactor or data.toast_tuple_target or o_data.toast_tuple_target %}
+{% set ns = namespace(add_comma=false) %}
 WITH(
 {% if data.fillfactor %}
-    FILLFACTOR = {{ data.fillfactor }}{% if (data['vacuum_data'] is defined and data['vacuum_data']['changed']|length > 0) %},{% endif %}
+    FILLFACTOR = {{ data.fillfactor }}{% set ns.add_comma = true %}
 {% elif o_data.fillfactor %}
-    FILLFACTOR = {{ o_data.fillfactor }}{% if (data['vacuum_data'] is defined and data['vacuum_data']['changed']|length > 0) %},{% endif %}
+    FILLFACTOR = {{ o_data.fillfactor }}{% set ns.add_comma = true %}
+{% endif %}
+{% if data.toast_tuple_target %}
+{% if ns.add_comma %},
+{% endif %}    TOAST_TUPLE_TARGET = {{ data.toast_tuple_target }}{% set ns.add_comma = true %}
+{% elif o_data.toast_tuple_target %}
+{% if ns.add_comma %},
+{% endif %}    TOAST_TUPLE_TARGET = {{ o_data.toast_tuple_target }}{% set ns.add_comma = true %}
 {% endif %}
 
 {% if data['vacuum_data']['changed']|length > 0 %}
-{% for field in data['vacuum_data']['changed'] %} {{ field.name }} = {{ field.value|lower }}{% if not loop.last  %},
+{% if ns.add_comma %},
+{% endif %}{% for field in data['vacuum_data']['changed'] %} {{ field.name }} = {{ field.value|lower }}{% if not loop.last  %},
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Closes #9626

## Problem

The `toast_tuple_target` storage parameter (PostgreSQL 11+) is supported by materialized views via `ALTER MATERIALIZED VIEW ... SET(TOAST_TUPLE_TARGET = N)`, but the pgAdmin Materialized View properties dialog has no way to view or change it.

## Changes

- **properties.sql** — extract `toast_tuple_target` from `c.reloptions` (same regex pattern as `fillfactor`)
- **create.sql** — include `TOAST_TUPLE_TARGET` in the `WITH` clause when set; extend the condition that decides whether a `WITH` block is needed
- **update.sql** — `SET` / `RESET` `TOAST_TUPLE_TARGET` when the value changes (mirrors the `FILLFACTOR` block exactly)
- **mview.ui.js** — integer input field (min 128, max 8160) in the Definition group, `min_version: 110000`