### PR TITLE
Fix a couple of related issues in the Query Tool layout.

### DIFF
--- a/web/pgadmin/browser/__init__.py
+++ b/web/pgadmin/browser/__init__.py
@@ -494,6 +494,9 @@ def utils():
     except Exception:
         pg_libpq_version = 0
 
+    # Check if LLM features are enabled (system-level AND provider configured)
+    from pgadmin.llm.utils import is_llm_enabled
+
     for submodule in current_blueprint.submodules:
         snippets.extend(submodule.jssnippets)
 
@@ -538,7 +541,7 @@ def utils():
                 "Administrator") else restricted_shared_storage_list,
             enable_server_passexec_cmd=config.ENABLE_SERVER_PASS_EXEC_CMD,
             max_server_tags_allowed=config.MAX_SERVER_TAGS_ALLOWED,
-            llm_enabled=config.LLM_ENABLED,
+            llm_enabled=is_llm_enabled(),
         ), 200)
     response.headers['Content-Type'] = MIMETYPE_APP_JS
     response.headers['Cache-Control'] = NO_CACHE_CONTROL

--- a/web/pgadmin/static/js/helpers/Layout/index.jsx
+++ b/web/pgadmin/static/js/helpers/Layout/index.jsx
@@ -220,6 +220,10 @@ export class LayoutDocker {
   }
 
   loadLayout(savedLayout) {
+    if (!savedLayout) {
+      // No saved layout - DockLayout already initialized with defaultLayout
+      return;
+    }
     try {
       this.layoutObj.loadLayout(JSON.parse(savedLayout));
       this.addMissingDefaultPanels();
@@ -252,6 +256,22 @@ export class LayoutDocker {
     // Only add non-closable tabs (closable tabs may have been intentionally removed)
     const missingNonClosableTabs = missingTabs.filter(tab => !tab.internal?.closable);
 
+    if (missingNonClosableTabs.length === 0) return;
+
+    // Save the active tab IDs for each panel group before adding missing tabs,
+    // so that newly added tabs don't steal focus from the user's current tab.
+    const savedActiveIds = [];
+    const collectActiveIds = (box) => {
+      box.children.forEach((child) => {
+        if (child.children) {
+          collectActiveIds(child);
+        } else if (child.activeId) {
+          savedActiveIds.push(child.activeId);
+        }
+      });
+    };
+    collectActiveIds(this.layoutObj.getLayout().dockbox);
+
     // Add each missing tab next to a sibling from its original panel group
     missingNonClosableTabs.forEach((tab) => {
       const siblingId = this.findSiblingTab(tab.id, flatDefault, flatCurrent);
@@ -269,6 +289,11 @@ export class LayoutDocker {
           ...tab.internal
         }, this.resetToTabPanel, 'middle');
       }
+    });
+
+    // Restore the original active tabs so newly added tabs don't steal focus
+    savedActiveIds.forEach((activeId) => {
+      this.focus(activeId);
     });
   }
 

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -232,8 +232,8 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
               maximizable: true,
               tabs: [
                 LayoutDocker.getPanel({id: PANELS.QUERY, title: gettext('Query'), content: <Query  onTextSelect={(text) => setSelectedText(text)} setQtStatePartial={setQtStatePartial}/>}),
-                LayoutDocker.getPanel({id: PANELS.HISTORY, title: gettext('Query History'), content: <QueryHistory />}),
                 ...(pgAdmin.llm_enabled ? [LayoutDocker.getPanel({id: PANELS.AI_ASSISTANT, title: gettext('AI Assistant'), content: <NLQChatPanel />})] : []),
+                LayoutDocker.getPanel({id: PANELS.HISTORY, title: gettext('Query History'), content: <QueryHistory />}),
               ],
             },
             {


### PR DESCRIPTION
- Hide the AI Assistant tab if AI is disabled or uncofnigured.
- Ensure the AI Assistant tab is not the first one shown (that should be the Query tab - saved layouts may need a reset).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when no saved layout exists and preserved the default layout.
  * Restored prior tab focus after adding missing panels to avoid unexpected focus shifts.
  * Adjusted Query Tool tab ordering to improve navigation flow and consistency.

* **Improvements**
  * LLM availability is now checked dynamically at request time for more accurate feature exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->