### PR TITLE
Fixed an issue where the Query tool kept prompting for a password when using a shared server. #9789

### DIFF
--- a/web/pgadmin/tools/sqleditor/__init__.py
+++ b/web/pgadmin/tools/sqleditor/__init__.py
@@ -517,8 +517,9 @@ def _init_sqleditor(trans_id, connect, sgid, sid, did, dbname=None, **kwargs):
         # Import here to avoid circular dependency
         from pgadmin.browser.server_groups.servers import ServerModule
         shared_server = ServerModule.get_shared_server(server, sgid)
-        server = ServerModule.get_shared_server_properties(server,
-                                                        shared_server)
+        if shared_server is not None:
+            server = ServerModule.get_shared_server_properties(server,
+                                                               shared_server)
     manager = get_driver(PG_DEFAULT_DRIVER).connection_manager(sid)
 
     if kwargs.get('password', None) is None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-server handling in the SQL Editor: when a server is shared by another user, the editor now resolves and uses the shared server’s properties for authentication and connection initialization. This prevents connection and access errors and ensures seamless use of shared database resources within the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->