### PR TITLE
Fixed python & feature test failures caused by Werkzeug 3.1.7 rejecting empty Host header in CSRF token generation.

### DIFF
--- a/web/regression/python_test_utils/csrf_test_client.py
+++ b/web/regression/python_test_utils/csrf_test_client.py
@@ -93,9 +93,10 @@ class TestClient(testing.FlaskClient):
         # this test client, such as the secure cookie that
         # powers `flask.session`,
         # and make a test request context that has those cookies in it.
+        server_name = self.app.config.get("SERVER_NAME") or "localhost"
         environ_overrides = {
             'wsgi.url_scheme': 'http',
-            'HTTP_HOST': current_app.config["SERVER_NAME"] or "localhost"
+            'HTTP_HOST': server_name
         }
         self._add_cookies_to_wsgi(environ_overrides)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CSRF handling in test utilities: test requests now include a sensible default host and explicit HTTP scheme, and session cookies are saved more reliably. This makes cookie/session behavior in tests more closely match production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->