### PR TITLE
Fixed infinite loading after idle connection loss on Linux Desktop. #6308

### DIFF
--- a/web/pgadmin/browser/utils.py
+++ b/web/pgadmin/browser/utils.py
@@ -433,7 +433,12 @@ class PGChildNodeView(NodeView):
 
         try:
             conn = manager.connection(did=did)
-            if not conn.connected():
+            # Use connection_ping() instead of connected() to detect
+            # stale / half-open TCP connections that were silently
+            # dropped while pgAdmin was idle.  connected() only checks
+            # local state and would miss these, causing the subsequent
+            # SQL queries to hang indefinitely.
+            if not conn.connection_ping():
                 status, msg = conn.connect()
                 if not status:
                     return internal_server_error(errormsg=msg)

--- a/web/pgadmin/browser/utils.py
+++ b/web/pgadmin/browser/utils.py
@@ -18,7 +18,7 @@ from flask_babel import gettext
 
 from config import PG_DEFAULT_DRIVER
 from pgadmin.utils.ajax import make_json_response, precondition_required,\
-    internal_server_error
+    internal_server_error, service_unavailable
 from pgadmin.utils.exception import ConnectionLost, SSHTunnelConnectionLost,\
     CryptKeyMissing
 from pgadmin.utils.constants import DATABASE_LAST_SYSTEM_OID
@@ -441,7 +441,9 @@ class PGChildNodeView(NodeView):
             if not conn.connection_ping():
                 status, msg = conn.connect()
                 if not status:
-                    return internal_server_error(errormsg=msg)
+                    return service_unavailable(
+                        msg, info="CONNECTION_LOST"
+                    )
         except (ConnectionLost, SSHTunnelConnectionLost, CryptKeyMissing):
             raise
         except Exception:

--- a/web/pgadmin/browser/utils.py
+++ b/web/pgadmin/browser/utils.py
@@ -433,12 +433,12 @@ class PGChildNodeView(NodeView):
 
         try:
             conn = manager.connection(did=did)
-            # Use connection_ping() instead of connected() to detect
-            # stale / half-open TCP connections that were silently
-            # dropped while pgAdmin was idle.  connected() only checks
-            # local state and would miss these, causing the subsequent
-            # SQL queries to hang indefinitely.
-            if not conn.connection_ping():
+            # Use ping() instead of connected() to detect stale /
+            # half-open TCP connections that were silently dropped while
+            # pgAdmin was idle.  connected() only checks local state and
+            # would miss these, causing the subsequent SQL queries to
+            # hang indefinitely.
+            if not conn.ping():
                 status, msg = conn.connect()
                 if not status:
                     return service_unavailable(

--- a/web/pgadmin/static/js/tree/tree_nodes.ts
+++ b/web/pgadmin/static/js/tree/tree_nodes.ts
@@ -121,12 +121,45 @@ export class ManageTreeNodes {
     let treeData = [];
     if (url) {
       try {
-        const res = await api.get(url);
+        const res = await api.get(url, {timeout: 30000});
         treeData = res.data.data;
       } catch (error) {
         /* react-aspen does not handle reject case */
         console.error(error);
-        pgAdmin.Browser.notifier.error(parseApiError(error)||'Node Load Error...');
+        if (error.response?.status === 503 &&
+            error.response?.data?.info === 'CONNECTION_LOST') {
+          // Connection dropped while idle.  Walk up to the server node
+          // and mark it disconnected, then show a reconnect prompt so
+          // the user can re-establish instead of seeing a silent
+          // spinner.
+          let serverNode = node;
+          while (serverNode) {
+            const d = serverNode.metadata?.data ?? serverNode.data;
+            if (d?._type === 'server') break;
+            serverNode = serverNode.parentNode ?? null;
+          }
+          if (serverNode) {
+            const sData = serverNode.metadata?.data ?? serverNode.data;
+            if (sData) sData.connected = false;
+            pgAdmin.Browser.tree?.addIcon(serverNode, {icon: 'icon-server-not-connected'});
+            pgAdmin.Browser.tree?.close(serverNode);
+          }
+          pgAdmin.Browser.notifier.confirm(
+            gettext('Connection lost'),
+            gettext('The connection to the server has been lost. Would you like to reconnect?'),
+            function() {
+              // Re-open (connect) the server node in the tree which
+              // will trigger the standard connect-to-server flow
+              // including any password prompts.
+              if (serverNode && pgAdmin.Browser.tree) {
+                pgAdmin.Browser.tree.toggle(serverNode);
+              }
+            },
+            function() { /* cancelled */ }
+          );
+        } else {
+          pgAdmin.Browser.notifier.error(parseApiError(error)||'Node Load Error...');
+        }
         return [];
       }
     }

--- a/web/pgadmin/static/js/tree/tree_nodes.ts
+++ b/web/pgadmin/static/js/tree/tree_nodes.ts
@@ -126,8 +126,15 @@ export class ManageTreeNodes {
       } catch (error) {
         /* react-aspen does not handle reject case */
         console.error(error);
-        if (error.response?.status === 503 &&
-            error.response?.data?.info === 'CONNECTION_LOST') {
+        const isConnectionLost =
+          (error.response?.status === 503 &&
+            error.response?.data?.info === 'CONNECTION_LOST') ||
+          // Axios client-side timeout has no error.response — treat it
+          // as a likely connection loss so the reconnect dialog still
+          // triggers when the server hangs on a recently-dead socket
+          // (before TCP keepalives detect it).
+          error.code === 'ECONNABORTED';
+        if (isConnectionLost) {
           // Connection dropped while idle.  Walk up to the server node
           // and mark it disconnected, then show a reconnect prompt so
           // the user can re-establish instead of seeing a silent
@@ -138,16 +145,30 @@ export class ManageTreeNodes {
             if (d?._type === 'server') break;
             serverNode = serverNode.parentNode ?? null;
           }
+          const sData = serverNode
+            ? (serverNode.metadata?.data ?? serverNode.data)
+            : null;
+          // When a server has multiple expanded children, every in-flight
+          // child-load request will fail independently.  Guard with a
+          // per-server flag so we only show one reconnect dialog at a
+          // time instead of stacking them.
+          if (sData?._reconnectPending) return [];
           if (serverNode) {
-            const sData = serverNode.metadata?.data ?? serverNode.data;
-            if (sData) sData.connected = false;
+            if (sData) {
+              sData.connected = false;
+              sData._reconnectPending = true;
+            }
             pgAdmin.Browser.tree?.addIcon(serverNode, {icon: 'icon-server-not-connected'});
             pgAdmin.Browser.tree?.close(serverNode);
           }
+          const clearPending = () => {
+            if (sData) sData._reconnectPending = false;
+          };
           pgAdmin.Browser.notifier.confirm(
             gettext('Connection lost'),
             gettext('The connection to the server has been lost. Would you like to reconnect?'),
             function() {
+              clearPending();
               // Re-open (connect) the server node in the tree which
               // will trigger the standard connect-to-server flow
               // including any password prompts.
@@ -155,7 +176,7 @@ export class ManageTreeNodes {
                 pgAdmin.Browser.tree.toggle(serverNode);
               }
             },
-            function() { /* cancelled */ }
+            clearPending,
           );
         } else {
           pgAdmin.Browser.notifier.error(parseApiError(error)||'Node Load Error...');

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -193,23 +193,23 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
     eventBus.current.fireEvent(QUERY_TOOL_EVENTS.CHANGE_EOL, lineSep);
   }, []);
 
-  useInterval(async ()=>{
+  const refreshConnectionStatus = useCallback(async (transId) => {
     try {
-      let {data: respData} = await fetchConnectionStatus(api, qtState.params.trans_id);
+      let {data: respData} = await fetchConnectionStatus(api, transId);
       if(respData.data) {
         setQtStatePartial({
           connected: true,
           connection_status: respData.data.status,
         });
+        if(respData.data.notifies) {
+          eventBus.current.fireEvent(QUERY_TOOL_EVENTS.PUSH_NOTICE, respData.data.notifies);
+        }
       } else {
         setQtStatePartial({
           connected: false,
           connection_status: null,
           connection_status_msg: gettext('An unexpected error occurred - ensure you are logged into the application.')
         });
-      }
-      if(respData.data.notifies) {
-        eventBus.current.fireEvent(QUERY_TOOL_EVENTS.PUSH_NOTICE, respData.data.notifies);
       }
     } catch (error) {
       console.error(error);
@@ -219,6 +219,10 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
         connection_status_msg: parseApiError(error),
       });
     }
+  }, [api]);
+
+  useInterval(()=>{
+    refreshConnectionStatus(qtState.params.trans_id);
   }, pollTime);
 
 
@@ -454,13 +458,14 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
       forceClose();
     });
 
-    qtPanelDocker.eventBus.registerListener(LAYOUT_EVENTS.CLOSING, (id)=>{
+    const onLayoutClosing = (id)=>{
       if(qtPanelId == id) {
         eventBus.current.fireEvent(QUERY_TOOL_EVENTS.WARN_SAVE_DATA_CLOSE);
       }
-    });
+    };
+    qtPanelDocker.eventBus.registerListener(LAYOUT_EVENTS.CLOSING, onLayoutClosing);
 
-    qtPanelDocker.eventBus.registerListener(LAYOUT_EVENTS.ACTIVE, _.debounce((currentTabId)=>{
+    const onLayoutActive = _.debounce((currentTabId)=>{
       /* Focus the appropriate panel on visible */
       if(qtPanelId == currentTabId) {
         setQtStatePartial({is_visible: true});
@@ -475,7 +480,8 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
       } else {
         setQtStatePartial({is_visible: false});
       }
-    }, 100));
+    }, 100);
+    qtPanelDocker.eventBus.registerListener(LAYOUT_EVENTS.ACTIVE, onLayoutActive);
 
     /* If the tab or window is not visible, applicable for open in new tab */
     const onVisibilityChange = function() {
@@ -490,37 +496,18 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
         // while the tab was hidden.
         const {params, connected_once} = qtStateRef.current;
         if(params?.trans_id && connected_once) {
-          fetchConnectionStatus(api, params.trans_id)
-            .then(({data: respData}) => {
-              if(respData.data) {
-                setQtStatePartial({
-                  connected: true,
-                  connection_status: respData.data.status,
-                });
-                if(respData.data.notifies) {
-                  eventBus.current.fireEvent(QUERY_TOOL_EVENTS.PUSH_NOTICE, respData.data.notifies);
-                }
-              } else {
-                setQtStatePartial({
-                  connected: false,
-                  connection_status: null,
-                  connection_status_msg: gettext('An unexpected error occurred - ensure you are logged into the application.')
-                });
-              }
-            })
-            .catch((error) => {
-              console.error(error);
-              setQtStatePartial({
-                connected: false,
-                connection_status: null,
-                connection_status_msg: parseApiError(error),
-              });
-            });
+          refreshConnectionStatus(params.trans_id);
         }
       }
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
-    return ()=>document.removeEventListener('visibilitychange', onVisibilityChange);
+    return ()=>{
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      if(qtPanelDocker?.eventBus) {
+        qtPanelDocker.eventBus.deregisterListener(LAYOUT_EVENTS.CLOSING, onLayoutClosing);
+        qtPanelDocker.eventBus.deregisterListener(LAYOUT_EVENTS.ACTIVE, onLayoutActive);
+      }
+    };
   }, []);
 
   useEffect(() => { qtStateRef.current = qtState; }, [qtState]);

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -484,10 +484,15 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
     qtPanelDocker.eventBus.registerListener(LAYOUT_EVENTS.ACTIVE, onLayoutActive);
 
     /* If the tab or window is not visible, applicable for open in new tab */
+    // Track whether this panel was active before the window was hidden,
+    // so only the active instance refreshes on return.
+    let wasActiveBeforeHide = false;
     const onVisibilityChange = function() {
       if(document.hidden) {
+        wasActiveBeforeHide = qtStateRef.current.is_visible;
         setQtStatePartial({is_visible: false});
       } else {
+        if(!wasActiveBeforeHide) return;
         setQtStatePartial({is_visible: true});
         // When the tab becomes visible again after being hidden (e.g. user
         // switched away on Linux Desktop), immediately check the connection
@@ -503,6 +508,7 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
     document.addEventListener('visibilitychange', onVisibilityChange);
     return ()=>{
       document.removeEventListener('visibilitychange', onVisibilityChange);
+      onLayoutActive.cancel();
       if(qtPanelDocker?.eventBus) {
         qtPanelDocker.eventBus.deregisterListener(LAYOUT_EVENTS.CLOSING, onLayoutClosing);
         qtPanelDocker.eventBus.deregisterListener(LAYOUT_EVENTS.ACTIVE, onLayoutActive);

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -168,6 +168,7 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
     setQtState((prev)=>({...prev,...evalFunc(null, state, prev)}));
   };
   const isDirtyRef = useRef(false); // usefull when conn change.
+  const qtStateRef = useRef(qtState);
   const eventBus = useRef(eventBusObj || (new EventBus()));
   const docker = useRef(null);
   const api = useMemo(()=>getApiInstance(), []);
@@ -477,7 +478,7 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
     }, 100));
 
     /* If the tab or window is not visible, applicable for open in new tab */
-    document.addEventListener('visibilitychange', function() {
+    const onVisibilityChange = function() {
       if(document.hidden) {
         setQtStatePartial({is_visible: false});
       } else {
@@ -487,14 +488,18 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
         // status.  This ensures a dead connection is detected right away
         // instead of waiting for the next poll interval, which was disabled
         // while the tab was hidden.
-        if(qtState.params?.trans_id && qtState.connected_once) {
-          fetchConnectionStatus(api, qtState.params.trans_id)
+        const {params, connected_once} = qtStateRef.current;
+        if(params?.trans_id && connected_once) {
+          fetchConnectionStatus(api, params.trans_id)
             .then(({data: respData}) => {
               if(respData.data) {
                 setQtStatePartial({
                   connected: true,
                   connection_status: respData.data.status,
                 });
+                if(respData.data.notifies) {
+                  eventBus.current.fireEvent(QUERY_TOOL_EVENTS.PUSH_NOTICE, respData.data.notifies);
+                }
               } else {
                 setQtStatePartial({
                   connected: false,
@@ -513,8 +518,12 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
             });
         }
       }
-    });
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return ()=>document.removeEventListener('visibilitychange', onVisibilityChange);
   }, []);
+
+  useEffect(() => { qtStateRef.current = qtState; }, [qtState]);
 
   useEffect(() => usePreferences.subscribe(
     state => {

--- a/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/QueryToolComponent.jsx
@@ -482,6 +482,36 @@ export default function QueryToolComponent({params, pgWindow, pgAdmin, selectedN
         setQtStatePartial({is_visible: false});
       } else {
         setQtStatePartial({is_visible: true});
+        // When the tab becomes visible again after being hidden (e.g. user
+        // switched away on Linux Desktop), immediately check the connection
+        // status.  This ensures a dead connection is detected right away
+        // instead of waiting for the next poll interval, which was disabled
+        // while the tab was hidden.
+        if(qtState.params?.trans_id && qtState.connected_once) {
+          fetchConnectionStatus(api, qtState.params.trans_id)
+            .then(({data: respData}) => {
+              if(respData.data) {
+                setQtStatePartial({
+                  connected: true,
+                  connection_status: respData.data.status,
+                });
+              } else {
+                setQtStatePartial({
+                  connected: false,
+                  connection_status: null,
+                  connection_status_msg: gettext('An unexpected error occurred - ensure you are logged into the application.')
+                });
+              }
+            })
+            .catch((error) => {
+              console.error(error);
+              setQtStatePartial({
+                connected: false,
+                connection_status: null,
+                connection_status_msg: parseApiError(error),
+              });
+            });
+        }
       }
     });
   }, []);

--- a/web/pgadmin/utils/driver/abstract.py
+++ b/web/pgadmin/utils/driver/abstract.py
@@ -114,7 +114,16 @@ class BaseConnection(metaclass=ABCMeta):
 
     * connected()
       - Implement this method to get the status of the connection. It should
-        return True for connected, otherwise False
+        return True for connected, otherwise False.  This is a local check
+        only (e.g. inspecting driver-level state) and may not detect
+        server-side disconnects.  Use connection_ping() when a network-level
+        check is required.
+
+    * connection_ping()
+      - Implement this method to verify the connection is alive by sending a
+        lightweight query (e.g. SELECT 1) to the server.  Returns True if the
+        server responds, False otherwise.  Unlike connected(), this detects
+        stale or half-open TCP connections that were silently dropped.
 
     * reset()
       - Implement this method to reconnect the database server (if possible)

--- a/web/pgadmin/utils/driver/abstract.py
+++ b/web/pgadmin/utils/driver/abstract.py
@@ -208,6 +208,14 @@ class BaseConnection(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def connection_ping(self):
+        """
+        Check if the connection is actually alive by sending a lightweight
+        query to the server.  Returns True if alive, False otherwise.
+        """
+        pass
+
+    @abstractmethod
     def reset(self):
         pass
 

--- a/web/pgadmin/utils/driver/abstract.py
+++ b/web/pgadmin/utils/driver/abstract.py
@@ -116,14 +116,8 @@ class BaseConnection(metaclass=ABCMeta):
       - Implement this method to get the status of the connection. It should
         return True for connected, otherwise False.  This is a local check
         only (e.g. inspecting driver-level state) and may not detect
-        server-side disconnects.  Use connection_ping() when a network-level
-        check is required.
-
-    * connection_ping()
-      - Implement this method to verify the connection is alive by sending a
-        lightweight query (e.g. SELECT 1) to the server.  Returns True if the
-        server responds, False otherwise.  Unlike connected(), this detects
-        stale or half-open TCP connections that were silently dropped.
+        server-side disconnects.  Use ping() when a network-level check is
+        required.
 
     * reset()
       - Implement this method to reconnect the database server (if possible)
@@ -133,9 +127,13 @@ class BaseConnection(metaclass=ABCMeta):
         connection. Range of return values different for each driver type.
 
     * ping()
-      - Implement this method to ping the server. There are times, a connection
-        has been lost, but - the connection driver does not know about it. This
-        can be helpful to figure out the actual reason for query failure.
+      - Implement this method to verify the connection is alive by sending a
+        lightweight query (e.g. SELECT 1) to the server.  Returns True if the
+        server responds, False otherwise.  Unlike connected(), this detects
+        stale or half-open TCP connections that were silently dropped.  When
+        a query is already in progress or the connection is inside a
+        transaction block, the probe is skipped and True is returned (the
+        connection is evidently alive).
 
     * _release()
       - Implement this method to release the connection object. This should not
@@ -217,14 +215,6 @@ class BaseConnection(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def connection_ping(self):
-        """
-        Check if the connection is actually alive by sending a lightweight
-        query to the server.  Returns True if alive, False otherwise.
-        """
-        pass
-
-    @abstractmethod
     def reset(self):
         pass
 
@@ -234,6 +224,10 @@ class BaseConnection(metaclass=ABCMeta):
 
     @abstractmethod
     def ping(self):
+        """
+        Check if the connection is actually alive by sending a lightweight
+        query to the server.  Returns True if alive, False otherwise.
+        """
         pass
 
     @abstractmethod

--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -1413,6 +1413,31 @@ WHERE db.datname = current_database()""")
             self.conn = None
         return False
 
+    def connection_ping(self):
+        """
+        Check if the connection is actually alive by executing a lightweight
+        query.  Unlike connected(), which only inspects local state, this
+        sends traffic to the server and will detect stale / half-open TCP
+        connections that were silently dropped by firewalls or the OS while
+        pgAdmin was idle.
+
+        Returns True if alive, False otherwise.
+        """
+        if not self.connected():
+            return False
+        try:
+            cur = self.conn.cursor()
+            cur.execute("SELECT 1")
+            cur.close()
+            return True
+        except Exception:
+            try:
+                self.conn.close()
+            except Exception:
+                pass
+            self.conn = None
+            return False
+
     def _decrypt_password(self, manager):
         """
         Decrypt password

--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -1413,46 +1413,6 @@ WHERE db.datname = current_database()""")
             self.conn = None
         return False
 
-    def connection_ping(self):
-        """
-        Check if the connection is actually alive by executing a lightweight
-        query.  Unlike connected(), which only inspects local state, this
-        sends traffic to the server and will detect stale / half-open TCP
-        connections that were silently dropped by firewalls or the OS while
-        pgAdmin was idle.
-
-        Returns True if alive, False otherwise.
-        """
-        if not self.connected():
-            return False
-
-        try:
-            # Check the transaction status before executing the ping
-            # query.  If a query is already in progress (ACTIVE) or we
-            # are inside a transaction block (INTRANS / INERROR), running
-            # SELECT 1 would fail or disrupt the ongoing operation.  In
-            # those states the connection is evidently alive, so just
-            # return True.
-            txn_status = self.conn.info.transaction_status
-            if txn_status != 0:
-                # 0 = IDLE — safe to send a query
-                # 1 = ACTIVE — command in progress, connection is alive
-                # 2 = INTRANS — in transaction block, connection is alive
-                # 3 = INERROR — in failed transaction, connection is alive
-                return True
-
-            cur = self.conn.cursor()
-            cur.execute("SELECT 1")
-            cur.close()
-            return True
-        except Exception:
-            try:
-                self.conn.close()
-            except Exception:
-                pass
-            self.conn = None
-            return False
-
     def _decrypt_password(self, manager):
         """
         Decrypt password
@@ -1526,7 +1486,43 @@ Failed to reset the connection to the server due to following error:
         return self.__async_query_error
 
     def ping(self):
-        return self.execute_scalar('SELECT 1')
+        """
+        Check if the connection is actually alive by executing a lightweight
+        query.  Unlike connected(), which only inspects local state, this
+        sends traffic to the server and will detect stale / half-open TCP
+        connections that were silently dropped by firewalls or the OS while
+        pgAdmin was idle.
+
+        Returns True if alive, False otherwise.
+        """
+        if not self.connected():
+            return False
+
+        try:
+            # Check the transaction status before executing the ping
+            # query.  If a query is already in progress (ACTIVE) or we
+            # are inside a transaction block (INTRANS / INERROR), running
+            # SELECT 1 would fail or disrupt the ongoing operation.  In
+            # those states the connection is evidently alive, so just
+            # return True.
+            #   0 = IDLE     — safe to send a query
+            #   1 = ACTIVE   — command in progress, connection is alive
+            #   2 = INTRANS  — in transaction block, connection is alive
+            #   3 = INERROR  — in failed transaction, connection is alive
+            if self.conn.info.transaction_status != 0:
+                return True
+
+            cur = self.conn.cursor()
+            cur.execute("SELECT 1")
+            cur.close()
+            return True
+        except Exception:
+            try:
+                self.conn.close()
+            except Exception:
+                pass
+            self.conn = None
+            return False
 
     def _release(self):
         if self.wasConnected:

--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -1425,7 +1425,22 @@ WHERE db.datname = current_database()""")
         """
         if not self.connected():
             return False
+
         try:
+            # Check the transaction status before executing the ping
+            # query.  If a query is already in progress (ACTIVE) or we
+            # are inside a transaction block (INTRANS / INERROR), running
+            # SELECT 1 would fail or disrupt the ongoing operation.  In
+            # those states the connection is evidently alive, so just
+            # return True.
+            txn_status = self.conn.info.transaction_status
+            if txn_status != 0:
+                # 0 = IDLE — safe to send a query
+                # 1 = ACTIVE — command in progress, connection is alive
+                # 2 = INTRANS — in transaction block, connection is alive
+                # 3 = INERROR — in failed transaction, connection is alive
+                return True
+
             cur = self.conn.cursor()
             cur.execute("SELECT 1")
             cur.close()

--- a/web/pgadmin/utils/driver/psycopg3/server_manager.py
+++ b/web/pgadmin/utils/driver/psycopg3/server_manager.py
@@ -699,6 +699,22 @@ WHERE db.oid = {0}""".format(did))
                 display_dsn_args[key] = orig_value if with_complete_path else \
                     value
 
+        # Enable TCP keepalive so that stale/half-open connections are
+        # detected by the OS within a reasonable time instead of hanging
+        # for the full TCP retransmission timeout (which can be many
+        # minutes).  These are libpq parameters passed through to
+        # setsockopt and only take effect if not already set by the user
+        # in connection_params.
+        keepalive_defaults = {
+            'keepalives': 1,
+            'keepalives_idle': 30,
+            'keepalives_interval': 10,
+            'keepalives_count': 3,
+        }
+        for k, v in keepalive_defaults.items():
+            if k not in dsn_args:
+                dsn_args[k] = v
+
         self.display_connection_string = make_conninfo(**display_dsn_args)
 
         return make_conninfo(**dsn_args)


### PR DESCRIPTION
When pgAdmin is left idle for an extended period on Linux Desktop, the database connection gets silently dropped. Instead of showing the reconnect dialog, the application hangs with an infinite spinner.

Fixes:
- Added `connection_ping()` to detect stale/half-open TCP connections that `connected()` misses (it only checks local state).
- Used `connection_ping()` in the Object Explorer `children()` endpoint to detect dead connections before they cause a hang.
- Added TCP keepalive defaults to all database connections so the OS detects dead sockets faster.
- Added CONNECTION_LOST handling in the Object Explorer tree with a reconnect dialog.
- Query Tool now checks connection status immediately when the tab becomes visible again.

Refs #6308, #9700, #8279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconnection dialog when a server connection is detected as lost; server node shows "not connected" state and can be closed automatically.
  * Query tool refreshes connection status on tab visibility and uses refactored, more reliable polling.

* **Bug Fixes**
  * Improved connection health checks to detect stale TCP sessions and avoid relying on stale local state.
  * Default TCP keepalive parameters added for more stable long-lived connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->