### PR TITLE
Pin Axios to 1.14.0 to avoid https://thehackernews.com/2026/03/axios-supply-chain-attack-pushes-cross.html

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-unused-imports": "^4.4.1"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "1.14.0",
     "electron-context-menu": "^4.1.0",
     "electron-store": "^11.0.2"
   }

--- a/web/package.json
+++ b/web/package.json
@@ -99,7 +99,7 @@
     "ajv": "^8.8.2",
     "anti-trojan-source": "^1.4.0",
     "aspen-decorations": "^1.0.2",
-    "axios": "^1.13.5",
+    "axios": "1.14.0",
     "babelify": "~10.0.0",
     "bignumber.js": "^10.0.2",
     "brace": "^0.11.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios dependency to version 1.14.0 across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->