### PR TITLE
Use ServerManager's passfile in connect() credential gate.

### DIFF
--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -17,7 +17,6 @@ import os
 import secrets
 import datetime
 import asyncio
-import copy
 from collections import deque
 import psycopg
 from flask import g, current_app
@@ -281,7 +280,6 @@ class Connection(BaseConnection):
         password, encpass, is_update_password = \
             self._check_user_password(kwargs)
 
-        passfile = kwargs['passfile'] if 'passfile' in kwargs else None
         tunnel_password = kwargs['tunnel_password'] if 'tunnel_password' in \
                                                        kwargs else ''
 
@@ -313,14 +311,21 @@ class Connection(BaseConnection):
         if is_error:
             return False, errmsg
 
-        # If no password credential is found then connect request might
-        # come from Query tool, ViewData grid, debugger etc tools.
-        # we will check for pgpass file availability from connection manager
-        # if it's present then we will use it
-        if not password and not encpass and not passfile:
-            passfile = manager.get_connection_param_value('passfile')
-            if manager.passexec:
-                password = manager.passexec.get()
+        # If no password credential is found then connect request might come
+        # from Query tool, ViewData grid, debugger, etc. In that case, fall
+        # back to using the password returned from manager.passexec.
+        passfile = manager.get_connection_param_value('passfile')
+        if not password and not encpass and not passfile and manager.passexec:
+            password = manager.passexec.get()
+
+        # create_connection_string() automatically picks up the passfile from
+        # connection parameters. Warn if that differs from the passfile kwarg.
+        passfile_kwarg = kwargs.get('passfile', None)
+        if passfile_kwarg and passfile_kwarg != passfile:
+            current_app.logger.warning(
+                'Using the first of two specified passfiles: '
+                f'{passfile!r}, {passfile_kwarg!r}'
+            )
 
         try:
             database = self.db

--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -315,16 +315,23 @@ class Connection(BaseConnection):
         # from Query tool, ViewData grid, debugger, etc. In that case, fall
         # back to using the password returned from manager.passexec.
         passfile = manager.get_connection_param_value('passfile')
-        if not password and not encpass and not passfile and manager.passexec:
-            password = manager.passexec.get()
+        if not password and not encpass and manager.passexec:
+            if not passfile:
+                password = manager.passexec.get()
+            else:
+                current_app.logger.warning(
+                    'Ignoring passexec in favor of the specified passfile '
+                    f'({passfile!r}).'
+                )
 
         # create_connection_string() automatically picks up the passfile from
         # connection parameters. Warn if that differs from the passfile kwarg.
         passfile_kwarg = kwargs.get('passfile', None)
         if passfile_kwarg and passfile_kwarg != passfile:
             current_app.logger.warning(
-                'Using the first of two specified passfiles: '
-                f'{passfile!r}, {passfile_kwarg!r}'
+                'Conflicting passfiles specified through keyword arguments '
+                f'({passfile_kwarg!r}) and connection parameters '
+                f'({passfile!r}); using the latter.'
             )
 
         try:


### PR DESCRIPTION
Checking for a passfile is done by using the value returned by the ServerManager, which will also be used when constructing the connection string.

The ServerManager supplied passfile is preferred over (a) any specified passexec, (b) any passfile kwarg passed to Connection::connect(). This is probably the desired behaviour, but it is still different from the previous version. For this, warnings are emitted when:
- passexec has been specified but is ignored in favor of the ServerManager passfile,
- a passfile kwarg is supplied to Connection::connect() but is ignored in favor of the ServerManager passfile.

~~Use PassFile to retrieve a password when one is not retrieved by other means. The PassFile setting was already passed to connect() but was never read.~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential resolution flow updated: passfile from the manager is always considered and local passfile input no longer forces early fallback; external password executor is used only when no credentials or passfile are present.
  * Added a warning when a provided passfile differs from the manager's passfile.
  * PassFile reading now reports explicit I/O or encoding failures with a localized error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->