### PR TITLE
[#9646] securityContext initContainers

### DIFF
--- a/pkg/helm/templates/deployment.yaml
+++ b/pkg/helm/templates/deployment.yaml
@@ -192,24 +192,9 @@ spec:
             limits:
               cpu: 50m
               memory: 64Mi
-          securityContext:
-            seLinuxOptions: {}
-            runAsUser: 1001
-            runAsGroup: 1001
-            runAsNonRoot: true
-            privileged: false
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            seccompProfile:
-              type: RuntimeDefault
-            {{- if .Values.global.compatibility.appArmor.enabled }}
-            appArmorProfile:
-              type: RuntimeDefault
-            {{- end }}
-            windowsOptions:
-              hostProcess: false
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- include "renderSecurityContext" (dict "securityContext" .Values.containerSecurityContext "context" .) | nindent 12 }}
+          {{- end }}
         - name: unset-python3-cli-net-cap
           image: {{ template "pgadmin4.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -226,21 +211,6 @@ spec:
             limits:
               cpu: 50m
               memory: 64Mi
-          securityContext:
-            seLinuxOptions: {}
-            runAsUser: 1001
-            runAsGroup: 1001
-            runAsNonRoot: true
-            privileged: false
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            seccompProfile:
-              type: RuntimeDefault
-            {{- if .Values.global.compatibility.appArmor.enabled }}
-            appArmorProfile:
-              type: RuntimeDefault
-            {{- end }}
-            windowsOptions:
-              hostProcess: false
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- include "renderSecurityContext" (dict "securityContext" .Values.containerSecurityContext "context" .) | nindent 12 }}
+          {{- end }}


### PR DESCRIPTION
- fixes #9646
- use renderSecurityContext for initContainers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security context settings for container initialization are now configurable via deployment values, allowing customization of SELinux, AppArmor, user/group IDs, and privilege settings instead of using hardcoded defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->