### PR TITLE
issue 9656: for debian platform use absolute paths for a2enmod, a2enc…

### DIFF
--- a/pkg/linux/setup-web.sh
+++ b/pkg/linux/setup-web.sh
@@ -112,8 +112,8 @@ if [ ${IS_DEBIAN} == 1 ]; then
 
     case ${RESPONSE} in
         y|Y )
-            a2enmod wsgi 1> /dev/null
-            a2enconf pgadmin4 1> /dev/null
+            /usr/sbin/a2enmod wsgi 1> /dev/null
+            /usr/sbin/a2enconf pgadmin4 1> /dev/null
             ;;
         * )
             exit 1;;


### PR DESCRIPTION
fix for issue 9656: for debian platform use absolute paths for a2enmod, a2enconf in pkg/linux/setup-web.sh (installed: usr/pgadmin4/bin/setup-web.sh)

Reason: debian does not have /usr/sbin which contains a2enmod and a2enconf in the path environment variable anymore. This is the case for debian13 (trixie, released 2025-08-09) and before, I am not sure since which release

Applies to [Updated version for release v9.14](https://github.com/pgadmin-org/pgadmin4/commit/d8a078af5323d84f0970adf957673bde19026804)

Thank you [anilsahoo20](https://github.com/anilsahoo20) and [akshay-joshi](https://github.com/akshay-joshi) for answering to the issue 9656 I raised. I am glad to finally submit this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the Debian/Ubuntu setup script to more reliably locate Apache configuration commands during the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->