### PR TITLE
fix(openai): Tool name or arguments might be empty/null

### DIFF
--- a/web/pgadmin/llm/providers/openai.py
+++ b/web/pgadmin/llm/providers/openai.py
@@ -783,9 +783,9 @@ class OpenAIClient(LLMClient):
                 if 'id' in tc_delta:
                     tc['id'] = tc_delta['id']
                 func = tc_delta.get('function', {})
-                if 'name' in func:
+                if 'name' in func and func['name']:
                     tc['name'] = func['name']
-                if 'arguments' in func:
+                if 'arguments' in func and func['arguments']:
                     tc['arguments'] += func['arguments']
 
         # Build final response


### PR DESCRIPTION
Some providers might return empty/null values in streaming delta (I guess it's to keep schema consistent?). For example, streaming data for a request might be:

data: { ... "choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0, ... "function":{"name":"get_database_schema","arguments":""}}]}}] ... }
data: { ... "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":null,"arguments":"{}"}}]}}] ... }
data: { ... "choices":[{"index":0,"finish_reason":"tool_calls","delta":{}}] ... }
data: [DONE]

Then pgAdmin will combine the delta to a tool call with name "null" and arguments "{}", which leads to a error that can't find the tool.

Though I don't find the official doc that mentions we should skip null value in delta, the official openai python sdk skips null values [1].

This commit is to skip null values in streaming delta to avoid empty/null tool name or arguments.

[1] https://github.com/openai/openai-python/blob/58184ad545ee2abd98e171ee09766f259d7f38cd/src/openai/lib/streaming/_deltas.py#L6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where empty values were incorrectly overwriting valid tool call information when streaming responses from OpenAI, improving the reliability of tool call handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->