### PR TITLE
Fix translation for 'Refresh' in Czech

### DIFF
--- a/web/pgadmin/translations/cs/LC_MESSAGES/messages.po
+++ b/web/pgadmin/translations/cs/LC_MESSAGES/messages.po
@@ -10973,7 +10973,7 @@ msgstr "Vytvořit - %s"
 
 #: pgadmin/browser/static/js/node.js:131
 msgid "Refresh..."
-msgstr "Občerstvit..."
+msgstr "Obnovit..."
 
 #: pgadmin/browser/static/js/node.js:144
 msgid "Properties..."


### PR DESCRIPTION
"Obnovit" is more IT relevant than "Občerstvit" ("Občerstvit" is more food relevant).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Czech language translations to improve accuracy and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->