### PR TITLE
fix(docker): ship libpq-oauth-18.so and libcurl for PostgreSQL 18 OAuth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,7 @@ RUN apk update && apk upgrade && \
         bash \
         postfix \
         krb5-libs \
+        libcurl \
         libjpeg-turbo \
         shadow \
         sudo \
@@ -174,7 +175,7 @@ COPY --from=env-builder /venv /venv
 
 # Copy in the tools
 COPY --from=tool-builder /usr/local/pgsql /usr/local/
-COPY --from=pg18-builder /usr/local/lib/libpq.so.5.18 /usr/lib/liblz4.so.1.10.0 /usr/lib/
+COPY --from=pg18-builder /usr/local/lib/libpq.so.5.18 /usr/local/lib/libpq-oauth-18.so /usr/lib/liblz4.so.1.10.0 /usr/lib/
 
 RUN ln -s libpq.so.5.18 /usr/lib/libpq.so.5 && \
     ln -s libpq.so.5.18 /usr/lib/libpq.so && \


### PR DESCRIPTION
## Summary

- The `dpage/pgadmin4` container image ships `libpq.so.5.18` but not `libpq-oauth-18.so`, the SASL `OAUTHBEARER` flow plugin that libpq 18 dlopens when a server uses an `oauth` `pg_hba.conf` rule. The plugin's runtime dependency `libcurl.so.4` is also missing.
- As a result any attempt to connect to a PostgreSQL 18 server requiring OAuth fails with `no OAuth flows are available (try installing the libpq-oauth package)` before the flow can begin.
- This change adds `libpq-oauth-18.so` to the existing `COPY --from=pg18-builder` line (it sits next to `libpq.so.5.18` in `/usr/local/lib` in `postgres:18-alpine`, built for the same Alpine/musl ABI) and installs the `libcurl` apk package so `libcurl.so.4` is present for the plugin to dlopen at runtime.

Scope is intentionally limited to the *packaging* gap that makes the plugin unloadable. libpq-oauth's only implemented flow is device-authorization (RFC 8628), and surfacing its `Visit https://… and enter the code: XXX-YYY` prompt to the pgAdmin web UI is a separate, larger piece of work (`PQauthDataHook` plus front-end changes) outside the scope of this fix.

## Test plan

- [ ] `check-container-build` CI workflow builds the image successfully.
- [ ] Manual smoke (post-merge or in a local build): inside the resulting image, `ctypes.CDLL("/usr/lib/libpq-oauth-18.so")` succeeds, and connecting to a PostgreSQL 18 server with an `oauth` `pg_hba.conf` rule reaches the OAuth flow instead of failing with "no OAuth flows are available".

Closes #9951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies to include curl support
  * Added PostgreSQL OAuth library to runtime image

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->