### PR TITLE
fix(test): stabilize bgprocess polling in backup/restore/IE/maintenance tests

### DIFF
--- a/web/pgadmin/tools/backup/tests/test_backup_utils.py
+++ b/web/pgadmin/tools/backup/tests/test_backup_utils.py
@@ -25,11 +25,12 @@ def create_backup_job(tester, url, params, assert_equal):
 
 def run_backup_job(tester, job_id, expected_params, assert_in, assert_not_in,
                    assert_equal):
-    cnt = 0
     the_process = None
-    while True:
-        if cnt >= 5:
-            break
+    # Wait up to 30s for the background pg_dump to actually finish.
+    # The completion signal is `exit_code` becoming non-None — NOT the
+    # mere presence of `execution_time`, which is set while the process
+    # is still running.
+    for _ in range(60):
         # Check the process list
         response1 = tester.get('/misc/bgprocess/?_={0}'.format(
             secrets.choice(range(1, 9999999))))
@@ -39,13 +40,12 @@ def run_backup_job(tester, job_id, expected_params, assert_in, assert_not_in,
         try:
             the_process = next(
                 p for p in process_list if p['id'] == job_id)
-        except Exception:
+        except StopIteration:
             the_process = None
 
-        if the_process and 'execution_time' in the_process:
+        if the_process and the_process.get('exit_code') is not None:
             break
         time.sleep(0.5)
-        cnt += 1
 
     assert_equal('execution_time' in the_process, True)
     assert_equal('stime' in the_process, True)

--- a/web/pgadmin/tools/import_export/tests/test_import_export_utils.py
+++ b/web/pgadmin/tools/import_export/tests/test_import_export_utils.py
@@ -38,11 +38,12 @@ def create_import_export_job(tester, url, params, assert_equal):
 
 def run_import_export_job(tester, job_id, expected_params, assert_in,
                           assert_not_in, assert_equal):
-    cnt = 0
     the_process = None
-    while True:
-        if cnt >= 5:
-            break
+    # Wait up to 30s for the background psql/COPY job to actually finish.
+    # The completion signal is `exit_code` becoming non-None — NOT the
+    # mere presence of `execution_time`, which is set while the process
+    # is still running.
+    for _ in range(60):
         # Check the process list
         response1 = tester.get('/misc/bgprocess/?_={0}'.format(
             secrets.choice(range(1, 9999999))))
@@ -52,13 +53,12 @@ def run_import_export_job(tester, job_id, expected_params, assert_in,
         try:
             the_process = next(
                 p for p in process_list if p['id'] == job_id)
-        except Exception:
+        except StopIteration:
             the_process = None
 
-        if the_process and 'execution_time' in the_process:
+        if the_process and the_process.get('exit_code') is not None:
             break
         time.sleep(0.5)
-        cnt += 1
 
     assert_equal('execution_time' in the_process, True)
     assert_equal('stime' in the_process, True)

--- a/web/pgadmin/tools/maintenance/tests/test_create_maintenance_job.py
+++ b/web/pgadmin/tools/maintenance/tests/test_create_maintenance_job.py
@@ -73,11 +73,12 @@ class MaintenanceJobTest(BaseTestGenerator):
         response_data = json.loads(response.data.decode('utf-8'))
         job_id = response_data['data']['job_id']
 
-        cnt = 0
         the_process = None
-        while True:
-            if cnt >= 10:
-                break
+        # Wait up to 30s for the background maintenance command to
+        # actually finish. The completion signal is `exit_code` becoming
+        # non-None — NOT the mere presence of `execution_time`, which is
+        # set while the process is still running.
+        for _ in range(60):
             # Check the process list
             response1 = self.tester.get('/misc/bgprocess/?_={0}'.format(
                 secrets.choice(range(1, 9999999))))
@@ -87,13 +88,12 @@ class MaintenanceJobTest(BaseTestGenerator):
             try:
                 the_process = next(
                     p for p in process_list if p['id'] == job_id)
-            except Exception:
+            except StopIteration:
                 the_process = None
 
-            if the_process and 'execution_time' in the_process:
+            if the_process and the_process.get('exit_code') is not None:
                 break
             time.sleep(0.5)
-            cnt += 1
 
         self.assertTrue('execution_time' in the_process)
         self.assertTrue('stime' in the_process)

--- a/web/pgadmin/tools/restore/tests/test_create_restore_job.py
+++ b/web/pgadmin/tools/restore/tests/test_create_restore_job.py
@@ -165,11 +165,12 @@ class RestoreJobTest(BaseTestGenerator):
         response_data = json.loads(response.data.decode('utf-8'))
         job_id = response_data['data']['job_id']
 
-        cnt = 0
         the_process = None
-        while True:
-            if cnt >= 5:
-                break
+        # Wait up to 30s for the background pg_restore to actually
+        # finish. The completion signal is `exit_code` becoming non-None
+        # — NOT the mere presence of `execution_time`, which is set
+        # while the process is still running.
+        for _ in range(60):
             # Check the process list
             response1 = self.tester.get('/misc/bgprocess/?_={0}'.format(
                 secrets.choice(range(1, 9999999))))
@@ -179,13 +180,12 @@ class RestoreJobTest(BaseTestGenerator):
             try:
                 the_process = next(
                     p for p in process_list if p['id'] == job_id)
-            except Exception:
+            except StopIteration:
                 the_process = None
 
-            if the_process and 'execution_time' in the_process:
+            if the_process and the_process.get('exit_code') is not None:
                 break
             time.sleep(0.5)
-            cnt += 1
 
         self.assertTrue('execution_time' in the_process)
         self.assertTrue('stime' in the_process)


### PR DESCRIPTION
## Summary

The shared bgprocess polling helpers in four test modules share the same race that just surfaced on the macos-latest / pg16 leg of #9955's CI run ([run 26148720940, job 76930277702](https://github.com/pgadmin-org/pgadmin4/actions/runs/26154521710/job/76930277702?pr=9955)):

- **Wait budget was 2.5 s** (5 iterations × 0.5 s; maintenance used 5 s).
- **Wrong break condition.** Polling broke on `'execution_time' in the_process` — but `execution_time` is the *elapsed time of a running* bgprocess. It's set before the wrapped `pg_dump` / `pg_restore` / `psql` / `COPY` actually finishes. The completion signal is `exit_code` becoming non-`None`.
- Result: the helper could return control while the wrapped command was still running, and the next assertion — e.g. `assert_equal(the_process['exit_code'] in [0, 1], True)` — fired on `None in [0, 1]`, i.e. `False != True`.

Some scenarios masked the bug by listing `None` in their `expected_exit_code` set (a tell that someone noticed the polling was unreliable and widened the accepted set instead of fixing the polling). Scenarios that didn't include `None` were the ones that flaked.

## Files changed

All four helpers fixed identically:

- `web/pgadmin/tools/backup/tests/test_backup_utils.py`
- `web/pgadmin/tools/import_export/tests/test_import_export_utils.py`
- `web/pgadmin/tools/maintenance/tests/test_create_maintenance_job.py`
- `web/pgadmin/tools/restore/tests/test_create_restore_job.py`

## Fix

- Poll for **up to 60 × 0.5 s = 30 s** (generous enough for the slowest CI runner).
- Break only when `the_process.get('exit_code') is not None` — the actual completion signal.
- Narrow `except Exception:` to `except StopIteration:` — the only thing `next(...)` here can raise.

No call-site changes needed. The helper contract (returns once the job is done; raises if the bgprocess never finished) is unchanged in spirit and strictly more reliable in practice.

## Test plan

- [x] `pycodestyle` on all four files → 0 violations
- [ ] CI run-python-tests-pg matrix passes consistently (this is the real verification — the bug only shows on slow runners)
- [ ] The macos-latest / pg16 leg that flaked in #9955 no longer fails

## Related

- Fixes the unrelated flake observed in #9955's CI ([run 26154521710](https://github.com/pgadmin-org/pgadmin4/actions/runs/26154521710)). #9955 is JS-lockfile-only and should not have triggered any Python test — confirming this fix should make #9955 (and similar future PRs) stop hitting that flake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved polling logic for background job completion in backup, import/export, maintenance, and restore test utilities for more reliable test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->