### PR TITLE
chore(deps): bump cryptography 47.0.* -> 48.0.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ bcrypt==5.0.*
 boto3==1.42.*; python_version <= '3.9'
 boto3==1.43.*; python_version > '3.9'
 certifi==2026.4.22
-cryptography==47.0.*
+cryptography==48.0.*
 Flask-Babel==4.0.*
 Flask-Compress==1.*
 Flask-Login==0.*


### PR DESCRIPTION
## Summary

Supersedes dependabot #9926 (and its `/web/regression` duplicate #9932 — that file inherits via `-r ../../requirements.txt`, so the single edit covers both).

## Why this is safe — short version

cryptography 48 is a smaller bump than the major-version label suggests, and **none** of its breaking changes touch pgAdmin's usage.

### Documented breaking changes in 48.0.0

1. **Removed Python 3.8 support.** pgAdmin already requires Python ≥ 3.9 across all supported platforms.
   - Side note: `requires_python` now excludes 3.9.0 and 3.9.1 specifically. Nothing in pgAdmin's CI or packaging targets those exact patch versions (3.9.0 = Sep 2020, 3.9.1 = Dec 2020).
2. **Stricter X.509 CRL parsing.** A CRL whose inner `TBSCertList.signature` doesn't match the outer `signatureAlgorithm` now raises `ValueError` instead of being parsed and rejected later during signature verification.
3. Added ML-KEM / ML-DSA post-quantum primitives (additive).

### pgAdmin's `cryptography` surface area

```
web/pgadmin/settings/__init__.py        Fernet
web/pgadmin/utils/session.py            Fernet, hashes, HKDF
web/pgadmin/utils/crypto.py             Cipher, AES, CFB8
```

**No** imports of `cryptography.x509`, `CertificateRevocationList`, or `load_pem_x509_crl` anywhere in the tree. The stricter CRL parsing in 48 cannot affect pgAdmin.

### About the OpenSSL 1.1.x removal

I initially flagged "drops OpenSSL 1.1.x" as a concern, but on closer reading of the changelog that happened in **cryptography 47**, which master is already on. No new platform-support regression from this bump.

## Test plan

- [x] No pgAdmin Python code touched — only `requirements.txt:25`
- [x] `grep` confirms no `x509` / CRL usage anywhere in the tree
- [ ] CI matrix on this PR (Linux/Mac/Windows × PG 14-18) passes — that's the real verification

## Supersedes

- Dependabot #9926 (canonical), #9932 (regression-folder duplicate). Will close both once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cryptography dependency to version 48.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->