### PR TITLE
build(mac): split bundle step and capture stderr for diagnostics

### DIFF
--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -291,8 +291,29 @@ _complete_bundle() {
     pushd "${SOURCE_DIR}/web" > /dev/null || exit
         yarn set version berry
         yarn set version 4
-        yarn install
-        yarn run bundle
+        yarn install 2>&1
+
+        # Record the source commit hash before the heavy lint/webpack
+        # steps. `yarn run` needs node_modules so this runs after install,
+        # but it's a pure `git log` redirect (see web/package.json
+        # "git:hash") that costs ~nothing, so doing it up front means the
+        # commit_hash file is captured even if webpack later bails out.
+        echo "==> Recording git hash..."
+        yarn run git:hash
+
+        # Split the "bundle" script into its underlying steps and merge
+        # stderr into stdout, so a crash inside lint/webpack (e.g. an OOM
+        # kill or native-module load failure) leaves a trace in the
+        # Jenkins console instead of an empty gap before the trap fires.
+        # Env vars match the top-level "bundle" npm script (see web/package.json)
+        # so behavior is identical to `yarn run bundle`.
+        export NODE_ENV=production
+        export NODE_OPTIONS=--max-old-space-size=3072
+        echo "==> Running ESLint..."
+        yarn run linter 2>&1
+        echo "==> Running webpack bundle..."
+        yarn run webpacker 2>&1
+        unset NODE_ENV NODE_OPTIONS
 
         curl https://curl.se/ca/cacert.pem -o cacert.pem -s
     popd > /dev/null || exit


### PR DESCRIPTION
## Summary

- macOS x64 appbundle builds can fail inside `yarn run bundle` with **zero console output** — the Jenkins log jumps from `yarn install ... Done with warnings` straight to the EXIT trap's failure message, leaving no signal as to whether linter, webpack, or a native module load was the culprit. Prompted by build [#1293 on `pgabf-macos-x64`](http://jenkins.buildfarm.pgadmin.org:8080/job/pgadmin4-macos-qa/label=macos-x64/1293/consoleText) (arm64 of the same commit passed cleanly).
- Replace the monolithic `yarn run bundle` call in `pkg/mac/build-functions.sh::_complete_bundle` with its individual steps, with stderr merged to stdout and a stage marker echoed before each, so the next failure is diagnosable:
  ```
  yarn install
  yarn run git:hash    # cheap source-hash capture, moved up front
  yarn run linter
  yarn run webpacker
  ```
- `NODE_ENV=production` and `NODE_OPTIONS=--max-old-space-size=3072` are exported explicitly to mirror the `cross-env` wrapper inside the top-level `bundle` npm script, so build output stays byte-identical to before.

No-op for successful builds; pure diagnostics win on failure.

## Test plan

- [ ] Trigger `pgadmin4-macos-qa` on both `macos-x64` and `macos-arm64` and confirm the appbundle still builds successfully.
- [ ] Inspect the Jenkins console of a passing build and verify the new `==> Running ...` markers appear in order, followed by the usual `<s> [webpack.Progress] …` lines.
- [ ] (Optional) Force a webpack failure locally (e.g. introduce a syntax error in a `.jsx`) and confirm the error text now reaches the console between the `==> Running webpack bundle...` marker and the EXIT trap message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the web frontend build process for improved reliability and error visibility, with separated build steps and enhanced logging during compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->