### PR TITLE
build(mac): bump webpack heap to 6 GB on the macOS appbundle build

### DIFF
--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -305,10 +305,14 @@ _complete_bundle() {
         # stderr into stdout, so a crash inside lint/webpack (e.g. an OOM
         # kill or native-module load failure) leaves a trace in the
         # Jenkins console instead of an empty gap before the trap fires.
-        # Env vars match the top-level "bundle" npm script (see web/package.json)
-        # so behavior is identical to `yarn run bundle`.
+        # NODE_ENV mirrors the top-level "bundle" npm script (see
+        # web/package.json). NODE_OPTIONS bumps V8's old-space ceiling
+        # past the 3 GB default the npm script uses: the macOS x64 builder
+        # OS-OOM-kills webpack inside TerserPlugin at the 3 GB setting
+        # (build #1294, sealing asset processing at 92%). Other build
+        # paths still get 3 GB via the npm script.
         export NODE_ENV=production
-        export NODE_OPTIONS=--max-old-space-size=3072
+        export NODE_OPTIONS=--max-old-space-size=6144
         echo "==> Running ESLint..."
         yarn run linter 2>&1
         echo "==> Running webpack bundle..."


### PR DESCRIPTION
## Summary

- macOS x64 appbundle builds keep dying inside webpack's `TerserPlugin` at 92% (asset processing). Build [#1294 on `pgabf-macos-x64`](http://jenkins.buildfarm.pgadmin.org:8080/job/pgadmin4-macos-qa/label=macos-x64/1294/consoleText) reached `<s> [webpack.Progress] 92% [0] sealing asset processing TerserPlugin` and was killed with no V8 fatal-error preamble — pointing at the OS reaping the Node process under memory pressure rather than V8 hitting its own ceiling. (Diagnostics are visible thanks to #9965.)
- `TerserPlugin` is already running single-threaded (`parallel: false` in `web/webpack.config.js`), so we can't claw memory back by reducing worker count. Bump V8's old-space ceiling from 3072 MB to 6144 MB inside the macOS appbundle build only.
- The change lives entirely in `pkg/mac/build-functions.sh::_complete_bundle`, which already bypasses `yarn run bundle` and calls `yarn run webpacker` directly (see d96e8634). So this knob is **independent of the npm script** and does **not** affect linux/pip/Makefile or dev-machine builds — they keep the 3 GB that the `bundle` npm script has been shipping with for years.

## Test plan

- [ ] Re-trigger `pgadmin4-macos-qa` on both `macos-x64` and `macos-arm64` and confirm the appbundle now builds successfully end-to-end.
- [ ] In the x64 Jenkins console, verify webpack progresses past `92% [0] sealing asset processing TerserPlugin` and reaches `emitting`/`done` without truncation.
- [ ] Spot-check the produced `.dmg` size on x64 vs arm64 to confirm both bundles are intact.

## If this doesn't work

The next step would be switching the minimiser from Terser to esbuild via `terser-webpack-plugin`'s `minify` option (much lower memory). That's a larger, more invasive change, so this cheap fix goes first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for macOS builds to enhance build performance and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->