### PR TITLE
build(mac): drop webpack heap from 6 GB to 4 GB on the macOS build

### DIFF
--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -307,12 +307,15 @@ _complete_bundle() {
         # Jenkins console instead of an empty gap before the trap fires.
         # NODE_ENV mirrors the top-level "bundle" npm script (see
         # web/package.json). NODE_OPTIONS bumps V8's old-space ceiling
-        # past the 3 GB default the npm script uses: the macOS x64 builder
-        # OS-OOM-kills webpack inside TerserPlugin at the 3 GB setting
-        # (build #1294, sealing asset processing at 92%). Other build
+        # past the 3 GB default the npm script uses: at 3 GB the macOS
+        # x64 builder OS-OOM-killed webpack inside TerserPlugin (build
+        # #1294, sealing asset processing at 92%). 6 GB was too much for
+        # the x64 VM's total RAM and pushed earlier steps into low-memory
+        # failures (build #1295), so we land at 4 GB — enough headroom
+        # for Terser without starving the rest of the build. Other build
         # paths still get 3 GB via the npm script.
         export NODE_ENV=production
-        export NODE_OPTIONS=--max-old-space-size=6144
+        export NODE_OPTIONS=--max-old-space-size=4096
         echo "==> Running ESLint..."
         yarn run linter 2>&1
         echo "==> Running webpack bundle..."


### PR DESCRIPTION
## Summary

- The 6 GB ceiling set by #9967 was too aggressive for the macOS x64 VM's total RAM. Build [#1295 on `pgabf-macos-x64`](http://jenkins.buildfarm.pgadmin.org:8080/job/pgadmin4-macos-qa/label=macos-x64/1295/consoleText) failed in `_build_runtime` at `unzip electron-vX.X.X-darwin-x64.zip` with exit code 2 — never even reached webpack — which points at OS-level memory pressure spilling out of the Node process and starving the rest of the build.
- Drop the ceiling back to 4 GB, which still gives Terser a full extra gigabyte beyond the original 3 GB setting that OOM-killed webpack in #1294, but leaves enough headroom for the other steps in the appbundle build to coexist.
- Only the macOS appbundle path changes (see `pkg/mac/build-functions.sh`); linux/pip/Makefile and dev-machine builds keep the 3 GB the `bundle` npm script ships with.

## Caveat

`--max-old-space-size` is a ceiling, not a reservation, so 6 GB shouldn't strictly have *caused* the unzip failure unless something else (worker leftover, disk pressure, or a transient flake) was contributing. 4 GB is the safe step back; if the next build still fails at unzip we should look at the worker's free RAM/disk rather than tune the heap further.

## Test plan

- [ ] Re-trigger `pgadmin4-macos-qa` on both `macos-x64` and `macos-arm64` and confirm the appbundle builds successfully end-to-end.
- [ ] On x64, verify the build clears `_build_runtime` (electron unzip) without exit code 2.
- [ ] On x64, verify webpack progresses past `92% [0] sealing asset processing TerserPlugin` to `emitting`/`done`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted memory configuration for the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->