### PR TITLE
Fix issue with Username being required for Shared server import config

### DIFF
--- a/web/pgadmin/utils/__init__.py
+++ b/web/pgadmin/utils/__init__.py
@@ -735,8 +735,9 @@ def load_database_servers(input_file, selected_servers,
 
             is_shared = obj.get("Shared", None)
             username = obj.get("Username", None)
+            shared_username = obj.get("SharedUsername", None)
             if is_shared and not username:
-                username = obj.get("SharedUsername", None)
+                username = shared_username
 
             # Create the server
             new_server = Server()
@@ -805,7 +806,7 @@ def load_database_servers(input_file, selected_servers,
 
             new_server.shared = is_shared
 
-            new_server.shared_username = obj.get("SharedUsername", None)
+            new_server.shared_username = shared_username
 
             new_server.kerberos_conn = obj.get("KerberosAuthentication", None)
 

--- a/web/pgadmin/utils/__init__.py
+++ b/web/pgadmin/utils/__init__.py
@@ -733,6 +733,11 @@ def load_database_servers(input_file, selected_servers,
                 groups_added = groups_added + 1
                 groups = ServerGroup.query.filter_by(user_id=user_id)
 
+            is_shared = obj.get("Shared", None)
+            username = obj.get("Username", None)
+            if is_shared and not username:
+                username = obj.get("SharedUsername", None)
+
             # Create the server
             new_server = Server()
             new_server.name = obj["Name"]
@@ -744,7 +749,7 @@ def load_database_servers(input_file, selected_servers,
 
             new_server.port = obj.get("Port", None)
 
-            new_server.username = obj.get("Username", None)
+            new_server.username = username
 
             new_server.role = obj.get("Role", None)
 
@@ -798,7 +803,7 @@ def load_database_servers(input_file, selected_servers,
             new_server.tunnel_keep_alive = \
                 obj.get("TunnelKeepAlive", None)
 
-            new_server.shared = obj.get("Shared", None)
+            new_server.shared = is_shared
 
             new_server.shared_username = obj.get("SharedUsername", None)
 

--- a/web/pgadmin/utils/__init__.py
+++ b/web/pgadmin/utils/__init__.py
@@ -736,7 +736,7 @@ def load_database_servers(input_file, selected_servers,
             is_shared = obj.get("Shared", None)
             username = obj.get("Username", None)
             shared_username = obj.get("SharedUsername", None)
-            if is_shared and not username:
+            if is_shared and username is None:
                 username = shared_username
 
             # Create the server

--- a/web/pgadmin/utils/__init__.py
+++ b/web/pgadmin/utils/__init__.py
@@ -601,8 +601,10 @@ def validate_json_data(data, is_admin):
     for server in data["Servers"]:
         obj = data["Servers"][server]
 
+        is_shared = obj.get("Shared", None)
+
         # Check if server is shared.Won't import if user is non-admin
-        if obj.get('Shared', None) and not is_admin:
+        if is_shared and not is_admin:
             print("Won't import the server '%s' as it is shared " %
                   obj["Name"])
             skip_servers.append(server)
@@ -627,14 +629,25 @@ def validate_json_data(data, is_admin):
         is_service_attrib_available = obj.get("Service", None) is not None
 
         if not is_service_attrib_available:
-            for attrib in ("Port", "Username"):
-                errmsg = check_attrib(attrib)
+            errmsg = check_attrib("Port")
+            if errmsg:
+                return errmsg
+            errmsg = check_is_integer(obj["Port"])
+            if errmsg:
+                return errmsg
+
+            if is_shared:
+                # Shared servers may carry either the owner's username
+                # or a per-user override, so accept either attribute.
+                if "Username" not in obj and "SharedUsername" not in obj:
+                    return gettext(
+                        "'Username' or 'SharedUsername' attribute not "
+                        "found for server '%s'" % server
+                    )
+            else:
+                errmsg = check_attrib("Username")
                 if errmsg:
                     return errmsg
-                if attrib == 'Port':
-                    errmsg = check_is_integer(obj[attrib])
-                    if errmsg:
-                        return errmsg
 
         errmsg = check_attrib("MaintenanceDB")
         if errmsg:


### PR DESCRIPTION
Resolves https://github.com/pgadmin-org/pgadmin4/issues/9226

# What does this PR do?
This PR resolves `Username attribute not found for server 'shared_server'` errors where server json import validation logic had a hard constraint on `Username` being required even when `Shared` was set to true. This PR introduces more coherent constraint validation logic for shared servers so that you are required to either provide `SharedUsername` or `Username` (for backwards compatibility). Furthermore, the underlying data model 'Username' property is set to 'SharedUsername' (for shared servers only) to align with UI behaviour for setting this fallback.

The UX also feels better as when after registering shared servers with only the `SharedUsername` set, when trying to connect to the server for the first time it prompts for the password (instead of showing an infinite loading spinner because the underlying `Username` is not set)

# Summary of changes
add separate `Username` constraint validation logic for shared servers when importing `servers.json`
add fallback to set `Username` to `SharedUsername` for shared servers so that the UX flow matches the manual UI creation flow for registering new shared servers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import and validation of shared database servers: shared servers are now skipped for non-admin users, username requirements are enforced conditionally (allowing a shared-specific username when appropriate), and the effective credential used for imported servers is computed reliably. This yields more accurate configuration, fewer import errors, and improved security when handling shared server entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->