### PR TITLE
Fix issue with importing CheckBoxTree component

### DIFF
--- a/web/webpack.shim.js
+++ b/web/webpack.shim.js
@@ -44,6 +44,11 @@ let webpackShimConfig = {
     'graphlib': path.join(__dirname, 'node_modules/graphlib'),
     'react': path.join(__dirname, 'node_modules/react'),
     'react-dom': path.join(__dirname, 'node_modules/react-dom'),
+
+    // v2 added "type":"module" to package.json, causing webpack to treat lib/index.js
+    // as ESM (even though it's a UMD bundle) and ignore its module.exports assignment. Force the true
+    // ESM entry instead so webpack reads the proper export statements.
+    'react-checkbox-tree': path.join(__dirname, 'node_modules/react-checkbox-tree/lib/index.esm.js'),
     'stylis': path.join(__dirname, 'node_modules/stylis'),
     'popper.js': path.join(__dirname, 'node_modules/popper.js'),
 


### PR DESCRIPTION
Resolves https://github.com/pgadmin-org/pgadmin4/issues/9972

# What does this PR do?
The react-checkbox-tree v2 release added "type": "module" to its package.json, which made webpack treat its UMD bundle (lib/index.js) as ESM and ignore the module.exports assignment. This means that importing the component yielded undefined and crashed the tree views. Aliasing the package to its true ESM entry (lib/index.esm.js) makes webpack read the proper export statements and restores the component.

# Summary of changes
add forced routing to underlying esm module declaration when importing from `react-checkbox-tree`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webpack module resolution configuration for the checkbox tree component to ensure correct import handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->