### PR TITLE
fix(docker): make CAP_NET_BIND_SERVICE optional for restricted runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,7 +204,10 @@ RUN /venv/bin/python3 -m pip install --no-cache-dir gunicorn==23.0.0 && \
     chown pgadmin:root /pgadmin4/config_distro.py && \
     chmod g=u /pgadmin4/config_distro.py && \
     chmod g=u /etc/passwd && \
-    setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/python3.[0-9][0-9] && \
+    PYBIN="$(ls /usr/local/bin/python3.[0-9][0-9] 2>/dev/null | head -n1)" && \
+    cp "$PYBIN" /usr/local/bin/python3-cap && \
+    setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/python3-cap && \
+    ln -s /usr/local/bin/python3-cap /venv/bin/python3-cap && \
     echo "pgadmin ALL = NOPASSWD: /usr/sbin/postfix start" > /etc/sudoers.d/postfix && \
     echo "pgadminr ALL = NOPASSWD: /usr/sbin/postfix start" >> /etc/sudoers.d/postfix
 

--- a/docs/en_US/container_deployment.rst
+++ b/docs/en_US/container_deployment.rst
@@ -320,6 +320,44 @@ Run a TLS secured container using a shared config/storage directory in
         -e 'PGADMIN_ENABLE_TLS=True' \
         -d dpage/pgadmin4
 
+Restricted Security Contexts (OpenShift, ``--cap-drop=ALL``)
+************************************************************
+
+Some platforms refuse to honor Linux file capabilities. The two situations
+the pgAdmin container handles automatically are:
+
+- ``--cap-drop=ALL`` (or an equivalent restricted Kubernetes SecurityContext
+  such as OpenShift's ``restricted-v2`` SCC), which zeros the bounding set
+  and removes ``CAP_NET_BIND_SERVICE``. Exec of a capability-tagged binary
+  then fails with ``Operation not permitted``.
+
+- ``--security-opt=no-new-privileges`` (or
+  ``allowPrivilegeEscalation: false``), which causes the kernel to silently
+  strip file capabilities on exec. The binary runs, but a subsequent
+  ``bind()`` to a port below 1024 fails with ``EPERM``.
+
+The container's entrypoint reads ``/proc/self/status`` at startup, detects
+either condition, switches gunicorn to the non-capability python
+interpreter, and (when *PGADMIN_LISTEN_PORT* is not set) defaults the
+listen port to **8080** for plain HTTP and **8443** for TLS instead of
+80/443. A message is logged so the choice is visible.
+
+In practice this means a typical OpenShift deployment requires no special
+build, no setcap, and no custom configuration — only a Service / Route
+that targets the chosen non-privileged port:
+
+.. code-block:: bash
+
+    docker run --rm -p 8080:8080 \
+        --security-opt=no-new-privileges \
+        --cap-drop=ALL \
+        -e 'PGADMIN_DEFAULT_EMAIL=user@domain.com' \
+        -e 'PGADMIN_DEFAULT_PASSWORD=SuperSecret' \
+        dpage/pgadmin4
+
+If you explicitly set *PGADMIN_LISTEN_PORT*, that value is honored in both
+the restricted and unrestricted paths.
+
 Reverse Proxying
 ****************
 

--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -75,6 +75,53 @@ else
     fi
 fi
 
+# Decide which python interpreter to use for gunicorn.
+#
+# /venv/bin/python3-cap is a symlink to /usr/local/bin/python3-cap, a copy
+# of the system python carrying CAP_NET_BIND_SERVICE. It is needed to bind
+# to privileged ports (the default 80/443) as the non-root pgadmin user.
+#
+# Some platforms refuse to honor file capabilities, in which case execing
+# the capped binary either fails outright or silently strips the caps so
+# bind() to a port <1024 still returns EPERM:
+#
+#   - NoNewPrivs=1 (--security-opt=no-new-privileges, OpenShift's
+#     allowPrivilegeEscalation: false): the kernel silently strips file
+#     capabilities on exec.
+#   - CAP_NET_BIND_SERVICE missing from the bounding set (--cap-drop=ALL,
+#     OpenShift restricted-v2 SCC): exec of the capped binary returns
+#     EPERM.
+#
+# Detect either condition via /proc/self/status. When restricted, fall
+# back to the un-capped venv python and (if the user has not picked a
+# port) default PGADMIN_LISTEN_PORT to 8080/8443 so the server can
+# actually bind.
+PYTHON_BIN=/venv/bin/python3-cap
+restricted=0
+
+if grep -q '^NoNewPrivs:[[:space:]]*1' /proc/self/status 2>/dev/null; then
+    restricted=1
+fi
+
+if [ "$restricted" = "0" ]; then
+    cap_bnd=$(awk '/^CapBnd:/ { print $2 }' /proc/self/status 2>/dev/null)
+    if [ -n "$cap_bnd" ] && [ "$(( 0x${cap_bnd} & 0x400 ))" -eq 0 ]; then
+        restricted=1
+    fi
+fi
+
+if [ "$restricted" = "1" ] || [ ! -x /venv/bin/python3-cap ]; then
+    PYTHON_BIN=/venv/bin/python3
+    if [ -z "${PGADMIN_LISTEN_PORT}" ]; then
+        if [ -n "${PGADMIN_ENABLE_TLS}" ]; then
+            export PGADMIN_LISTEN_PORT=8443
+        else
+            export PGADMIN_LISTEN_PORT=8080
+        fi
+        echo "Restricted security context detected; defaulting PGADMIN_LISTEN_PORT to ${PGADMIN_LISTEN_PORT}."
+    fi
+fi
+
 # usage: file_env VAR [DEFAULT] ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
 #  "$XYZ_DB_PASSWORD" from a file, for Docker's secrets feature)
@@ -275,7 +322,7 @@ else
 fi
 
 if [ -n "${PGADMIN_ENABLE_TLS}" ]; then
-    exec $SU_EXEC /venv/bin/gunicorn --limit-request-line "${GUNICORN_LIMIT_REQUEST_LINE:-8190}" --timeout "${TIMEOUT}" --bind "${BIND_ADDRESS}" -w 1 --threads "${GUNICORN_THREADS:-25}" --access-logfile "${GUNICORN_ACCESS_LOGFILE:--}" --keyfile /certs/server.key --certfile /certs/server.cert -c gunicorn_config.py run_pgadmin:app
+    exec $SU_EXEC "${PYTHON_BIN}" /venv/bin/gunicorn --limit-request-line "${GUNICORN_LIMIT_REQUEST_LINE:-8190}" --timeout "${TIMEOUT}" --bind "${BIND_ADDRESS}" -w 1 --threads "${GUNICORN_THREADS:-25}" --access-logfile "${GUNICORN_ACCESS_LOGFILE:--}" --keyfile /certs/server.key --certfile /certs/server.cert -c gunicorn_config.py run_pgadmin:app
 else
-    exec $SU_EXEC /venv/bin/gunicorn --limit-request-line "${GUNICORN_LIMIT_REQUEST_LINE:-8190}" --limit-request-fields "${GUNICORN_LIMIT_REQUEST_FIELDS:-100}" --limit-request-field_size "${GUNICORN_LIMIT_REQUEST_FIELD_SIZE:-8190}" --timeout "${TIMEOUT}" --bind "${BIND_ADDRESS}" -w 1 --threads "${GUNICORN_THREADS:-25}" --access-logfile "${GUNICORN_ACCESS_LOGFILE:--}" -c gunicorn_config.py run_pgadmin:app
+    exec $SU_EXEC "${PYTHON_BIN}" /venv/bin/gunicorn --limit-request-line "${GUNICORN_LIMIT_REQUEST_LINE:-8190}" --limit-request-fields "${GUNICORN_LIMIT_REQUEST_FIELDS:-100}" --limit-request-field_size "${GUNICORN_LIMIT_REQUEST_FIELD_SIZE:-8190}" --timeout "${TIMEOUT}" --bind "${BIND_ADDRESS}" -w 1 --threads "${GUNICORN_THREADS:-25}" --access-logfile "${GUNICORN_ACCESS_LOGFILE:--}" -c gunicorn_config.py run_pgadmin:app
 fi


### PR DESCRIPTION
Fixes #9657. Supersedes #9950 (opened by @neel5481, who is currently on vacation — picking this up because the issue is urgent for OpenShift users).

## Problem

The pgAdmin Docker image fails to start on OpenShift `restricted-v2` SCC (and any runtime that drops capabilities or sets `no_new_privs`):

```
/entrypoint.sh: /venv/bin/gunicorn: /venv/bin/python3: bad interpreter: Operation not permitted
```

Root cause: the Dockerfile sets `CAP_NET_BIND_SERVICE` on the python interpreter so the non-root pgadmin user can bind to ports 80/443. The kernel refuses to exec a capability-tagged binary when:

- `CAP_NET_BIND_SERVICE` is missing from the bounding set (`--cap-drop=ALL`, restricted SCC) — exec returns EPERM, OR
- `NoNewPrivs=1` (`--security-opt=no-new-privileges`, `allowPrivilegeEscalation: false`) — exec succeeds but the kernel silently strips file caps, so a later `bind()` to a port <1024 still fails.

## Approach

Split the interpreter so we don't have to choose between "default works" and "OpenShift works":

- **Dockerfile** — copy `python3.X` to `/usr/local/bin/python3-cap` and apply `setcap` to the **copy**. The original `/usr/local/bin/python3.X` stays un-capped, so `/venv/bin/python3` (which symlinks to it) execs cleanly under restricted SCCs. Add a parallel `/venv/bin/python3-cap` symlink so the venv's `pyvenv.cfg` lookup still works when the capped interpreter is used.
- **entrypoint.sh** — read `/proc/self/status` at startup:
  - `NoNewPrivs:` field → caps-on-exec stripped
  - `CapBnd:` field → check bit 10 (`0x400`, `CAP_NET_BIND_SERVICE`)

  If either condition indicates a restricted runtime, invoke gunicorn through the **un-capped** `/venv/bin/python3` and (only when `PGADMIN_LISTEN_PORT` is unset) default to **8080**/**8443** instead of 80/443. A startup log line records the choice.
- **Docs** — new "Restricted Security Contexts" subsection covering the auto-detected fallback and the OpenShift / `--cap-drop=ALL` invocation.

## Why this is non-breaking (vs. #9950)

#9950 changed the image defaults to 8080/8443 unconditionally, which breaks every existing \`docker run -p 80:80 dpage/pgadmin4\` (and the TLS equivalent). That's a user-visible behavior change.

This PR keeps the 80/443 defaults in every environment where the *current* image already works. The fallback only triggers in environments where the current image is **already broken** (can't start at all), so there is no regression surface for existing deployments.

Decision matrix:

| Runtime | Bounding set has `NET_BIND_SERVICE` | `NoNewPrivs` | Behavior |
|---|---|---|---|
| Normal docker run | yes | 0 | python3-cap, port 80/443 (unchanged) |
| `--cap-drop=ALL` | no | 0 | python3, port 8080/8443 (new: was broken) |
| `--security-opt=no-new-privileges` | yes | 1 | python3, port 8080/8443 (new: was broken) |
| OpenShift restricted-v2 SCC | no | 1 | python3, port 8080/8443 (new: was broken) |
| Any of the above with `PGADMIN_LISTEN_PORT=NNNN` | * | * | python3 or python3-cap by detection, port NNNN |

Detection uses two `grep`/`awk` reads of `/proc/self/status` — no fork/exec of the capped binary, no audit-log noise.

## Test plan

- [x] Build: \`docker build -t pgadmin4:test .\`
- [ ] Unrestricted, default port 80 still works: \`docker run --rm -p 80:80 -e PGADMIN_DEFAULT_EMAIL=… -e PGADMIN_DEFAULT_PASSWORD=… pgadmin4:test\` — verify accessible at http://localhost
- [ ] TLS default 443 still works (with cert + key mounted): \`docker run --rm -p 443:443 -e PGADMIN_ENABLE_TLS=True …\`
- [ ] Restricted, no overrides → auto-falls-back to 8080: \`docker run --rm -p 8080:8080 --security-opt=no-new-privileges --cap-drop=ALL -e PGADMIN_DEFAULT_EMAIL=… -e PGADMIN_DEFAULT_PASSWORD=… pgadmin4:test\` — verify log line "Restricted security context detected; defaulting PGADMIN_LISTEN_PORT to 8080." and accessibility at http://localhost:8080
- [ ] Restricted TLS auto-falls-back to 8443: same as above with \`-e PGADMIN_ENABLE_TLS=True\` and 8443 mapping
- [ ] Explicit override honored in restricted env: \`-e PGADMIN_LISTEN_PORT=9090 -p 9090:9090\` under \`--cap-drop=ALL\`
- [ ] OpenShift \`restricted-v2\` SCC: \`oc run pgadmin --image=…\` succeeds and listens on 8080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * pgAdmin container now adapts to restricted security contexts (e.g., OpenShift with `--cap-drop=ALL`), automatically defaulting to port 8080 for HTTP and port 8443 for TLS when running under these constraints.

* **Documentation**
  * Added section documenting pgAdmin's behavior in restricted security contexts and default port configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->