### PR TITLE
Fix CheckBoxTree rendering by aliasing react-checkbox-tree to its ESM bundle

### DIFF
--- a/web/webpack.shim.js
+++ b/web/webpack.shim.js
@@ -44,6 +44,13 @@ let webpackShimConfig = {
     'graphlib': path.join(__dirname, 'node_modules/graphlib'),
     'react': path.join(__dirname, 'node_modules/react'),
     'react-dom': path.join(__dirname, 'node_modules/react-dom'),
+    // react-checkbox-tree v2 marks the package as "type": "module" but ships
+    // a UMD bundle as its CommonJS entry point. Babel transforms our ESM
+    // imports to require(), so webpack picks the UMD file and then treats it
+    // as ESM (because of "type": "module") — and module.exports never runs,
+    // leaving the default export undefined. Point directly at the ESM bundle
+    // to bypass the broken main entry.
+    'react-checkbox-tree$': path.join(__dirname, 'node_modules/react-checkbox-tree/lib/index.esm.js'),
     'stylis': path.join(__dirname, 'node_modules/stylis'),
     'popper.js': path.join(__dirname, 'node_modules/popper.js'),
 


### PR DESCRIPTION
## Summary

- `react-checkbox-tree` v2 (bumped to `^2.0.1` in #9870) marks the package as `"type": "module"` while still pointing its `require` exports condition at a UMD bundle. Babel transforms our `import` statements to `require()`, so webpack picks the UMD file and then treats it as ESM (because of `"type": "module"`). The UMD wrapper's `module.exports = factory(...)` never runs in that context and the default export is `undefined` — which is why dialogs that mount `CheckBoxTree` (Tools → Import/Export Servers and similar) fail with *"Element type is invalid"*.
- Add a webpack `resolve.alias` for `react-checkbox-tree` pointing at the package's ESM bundle (`lib/index.esm.js`). That file is explicitly exposed by the package's own `"./*": "./*"` exports passthrough, has a real default export, and is what webpack would have picked if our build didn't down-transform imports to requires.
- The `$` suffix makes it an exact-match alias, so any future subpath imports (e.g. CSS) continue to resolve normally.

## Test plan

- [x] `yarn run linter` — clean
- [x] `yarn run jest` — all 140 suites / 824 tests pass
- [x] `yarn run bundle:dev` and `yarn run bundle` both compile cleanly (only the pre-existing asset-size advisory warnings)
- [x] Bundle inspection: before the fix, `app.bundle.js` contained `node_modules/react-checkbox-tree/lib/index.js` (the UMD wrapper); after the fix, only `lib/index.esm.js` is bundled and the `webpackUniversalModuleDefinition` wrapper is gone
- [ ] Manual smoke test: Tools → Import Servers and Tools → Export Servers render their dialogs without the *"Element type is invalid"* error

Closes #9972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated webpack configuration to resolve compatibility issues with the react-checkbox-tree dependency by ensuring the correct module bundle is loaded during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgadmin-org/pgadmin4/pull/9989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->