### PR TITLE
feat: include authenticated user identity in HTTP access log

### DIFF
--- a/pkg/docker/gunicorn_config.py
+++ b/pkg/docker/gunicorn_config.py
@@ -8,7 +8,10 @@ gunicorn.SERVER_SOFTWARE = "Python"
 # Include the authenticated user identity in the access log.
 # %({x-remote-user}o)s reads the X-Remote-User response header set by pgAdmin
 # for authenticated requests; unauthenticated requests log '-'.
-access_log_format = '%(h)s %(l)s %({x-remote-user}o)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+access_log_format = (
+    '%(h)s %(l)s %({x-remote-user}o)s %(t)s "%(r)s" %(s)s %(b)s '
+    '"%(f)s" "%(a)s"'
+)
 
 if JSON_LOGGER:
     logconfig_dict = {

--- a/pkg/docker/gunicorn_config.py
+++ b/pkg/docker/gunicorn_config.py
@@ -5,6 +5,11 @@ from config import JSON_LOGGER, CONSOLE_LOG_LEVEL, CONSOLE_LOG_FORMAT_JSON
 
 gunicorn.SERVER_SOFTWARE = "Python"
 
+# Include the authenticated user identity in the access log.
+# %({x-remote-user}o)s reads the X-Remote-User response header set by pgAdmin
+# for authenticated requests; unauthenticated requests log '-'.
+access_log_format = '%(h)s %(l)s %({x-remote-user}o)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+
 if JSON_LOGGER:
     logconfig_dict = {
         "version": 1,

--- a/web/config.py
+++ b/web/config.py
@@ -301,6 +301,9 @@ else:
 LOG_ROTATION_SIZE = 10  # In MBs
 LOG_ROTATION_AGE = 1440  # In minutes
 LOG_ROTATION_MAX_LOG_FILES = 90  # Maximum number of backups to retain
+# Include the authenticated username in the X-Remote-User response header so
+# it can be captured in the HTTP access log. Disabled by default.
+LOG_AUTHENTICATED_USER = False
 ##########################################################################
 # Server Connection Driver Settings
 ##########################################################################

--- a/web/pgadmin/__init__.py
+++ b/web/pgadmin/__init__.py
@@ -863,8 +863,14 @@ def create_app(app_name=None):
 
     @app.after_request
     def after_request(response):
-        if current_user.is_authenticated:
-            response.headers['X-Remote-User'] = current_user.username
+        if config.LOG_AUTHENTICATED_USER:
+            if current_user.is_authenticated and current_user.username:
+                # Encode as latin-1 to avoid gunicorn 500s for unicode names
+                safe = current_user.username.encode(
+                    'latin-1', 'replace').decode('latin-1')
+                response.headers['X-Remote-User'] = safe
+            else:
+                response.headers.pop('X-Remote-User', None)
 
         if 'key' in request.args:
             domain = dict()

--- a/web/pgadmin/__init__.py
+++ b/web/pgadmin/__init__.py
@@ -863,6 +863,9 @@ def create_app(app_name=None):
 
     @app.after_request
     def after_request(response):
+        if current_user.is_authenticated:
+            response.headers['X-Remote-User'] = current_user.username
+
         if 'key' in request.args:
             domain = dict()
             if config.COOKIE_DEFAULT_DOMAIN and \


### PR DESCRIPTION
Set an X-Remote-User response header containing the authenticated username on every request. This allows the access log to be configured to include user identity via standard log format directives (%({x-remote-user}o)s in gunicorn, %{X-Remote-User}o in Apache) without requiring any changes to pgAdmin's session or auth behaviour.

Closes #9990

Default gunicorn access log format is at https://gunicorn.org/reference/settings/?h=access_log#access_log_format and https://github.com/benoitc/gunicorn/blob/9bc5891b4b06f25a8ce0e707053dcb2fb9bf638c/gunicorn/config.py#L1413 ; I confirmed that all other fields are default; this PR only changes the user name field.

Performed an end-to-end test on kubernetes with KIND

With this PR:

<img width="1871" height="938" alt="pgadmin-loguserid-branch" src="https://github.com/user-attachments/assets/e10a9a0b-7abb-4c08-9888-7daff4ee19b9" />

Master Branch:

<img width="1875" height="936" alt="pgadmin-master-branch" src="https://github.com/user-attachments/assets/d1910bbb-3946-4646-816c-dfa890ed6512" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to include the authenticated username in responses so HTTP access logs can record user identity, improving audit trails and monitoring.
  * New configuration toggle (disabled by default) to enable or disable this behavior.
  * When enabled and a user is authenticated, a response header carries a latin-1-safe username; when disabled or unauthenticated, no username is added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->