### PR TITLE
fix: resolve E501 pycodestyle line-too-long in llm tools database module

### DIFF
--- a/web/pgadmin/llm/tools/database.py
+++ b/web/pgadmin/llm/tools/database.py
@@ -84,7 +84,9 @@ def _get_connection(sid: int, did: int, conn_id: str):
         )
 
 
-def _connect_readonly(_manager, conn, conn_id: str) -> tuple[bool, Optional[str]]:
+def _connect_readonly(
+    _manager, conn, conn_id: str
+) -> tuple[bool, Optional[str]]:
     """
     Establish a read-only connection.
 


### PR DESCRIPTION
## Summary

Fixes a `pycodestyle` E501 violation in `web/pgadmin/llm/tools/database.py`.

The `_connect_readonly` function signature exceeded the 79-character line limit. The signature has been wrapped across multiple lines to comply with the project's pycodestyle configuration.

## Changes

- `web/pgadmin/llm/tools/database.py`: Wrapped `_connect_readonly` function signature to fix E501 line-too-long error.

## Verification

```
$ pycodestyle --config=.pycodestyle web/pgadmin/llm/tools/database.py
# No output — all checks pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting updates to improve code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->