### PR TITLE
OAuth2: actionable error when openid scope lacks OAUTH2_SERVER_METADATA_URL

### DIFF
--- a/web/config.py
+++ b/web/config.py
@@ -822,7 +822,10 @@ OAUTH2_CONFIG = [
         # URL is used for authentication,
         # Ex: https://github.com/login/oauth/authorize
         'OAUTH2_AUTHORIZATION_URL': None,
-        # server metadata url might optional for your provider
+        # OpenID Connect discovery URL for the provider. Required when
+        # OAUTH2_SCOPE contains 'openid' (so pgAdmin can fetch the JWKS
+        # to verify the id_token); optional otherwise.
+        # Example: https://<issuer>/.well-known/openid-configuration
         'OAUTH2_SERVER_METADATA_URL': None,
         # Oauth base url, ex: https://api.github.com/
         'OAUTH2_API_BASE_URL': None,

--- a/web/pgadmin/authenticate/oauth2.py
+++ b/web/pgadmin/authenticate/oauth2.py
@@ -284,6 +284,31 @@ class OAuth2Authentication(BaseAuthentication):
         return token
 
     def _authorize_access_token(self, provider_name, provider, client):
+        # Pre-flight: if the provider's scope includes 'openid', the
+        # OAuth server will return an id_token that pgAdmin must
+        # verify. Verification requires JWKS, which Authlib fetches
+        # via the discovery document. Without OAUTH2_SERVER_METADATA_URL,
+        # verification fails deep inside Authlib with a cryptic
+        # `Missing "jwks_uri" in metadata` error. Catch the misconfig
+        # here with actionable guidance, before any network round-trip.
+        scope = provider.get('OAUTH2_SCOPE') or ''
+        scope_parts = scope.split() if isinstance(scope, str) else []
+        if 'openid' in scope_parts and \
+                not provider.get('OAUTH2_SERVER_METADATA_URL'):
+            guidance = gettext(
+                "OAuth2 provider '%(name)s' is configured with 'openid' "
+                "in OAUTH2_SCOPE but OAUTH2_SERVER_METADATA_URL is not "
+                "set. pgAdmin needs the provider's OpenID Connect "
+                "discovery URL to verify the id_token. Either set "
+                "OAUTH2_SERVER_METADATA_URL to the discovery URL "
+                "(e.g. https://<issuer>/.well-known/openid-"
+                "configuration), or remove 'openid' from OAUTH2_SCOPE."
+            ) % {'name': provider_name}
+            current_app.logger.error(
+                "OAuth2 (%s): %s", provider_name, guidance
+            )
+            raise RuntimeError(guidance)
+
         client_auth_method = provider.get(
             'OAUTH2_CLIENT_AUTH_METHOD', 'client_secret'
         )


### PR DESCRIPTION
Closes #9988.

## Problem

When `OAUTH2_SCOPE` contains `openid`, the OAuth server returns an `id_token` that pgAdmin must verify. Verification requires the JWKS, which Authlib fetches via the OpenID Connect discovery document (`OAUTH2_SERVER_METADATA_URL`). If the discovery URL is missing, verification fails deep inside Authlib with:

```
Missing "jwks_uri" in metadata
```

That message surfaces verbatim to the user (as JSON `errormsg`) and to the log. Neither names the actual config knob the admin needs to fix. The inline comment in `web/config.py` made things worse by asserting unconditionally that the URL "might optional for your provider".

## Fix

Pre-flight check at the entry of `_authorize_access_token`:

1. If `OAUTH2_SCOPE` contains `openid` **and** `OAUTH2_SERVER_METADATA_URL` is not set → raise `RuntimeError` with actionable guidance before any network round-trip.
2. Updates the `config.py` comment to clarify the conditional requirement.

## End-user effect

Reporter's misconfig now produces:

> *OAuth2 provider '&lt;name&gt;' is configured with 'openid' in OAUTH2_SCOPE but OAUTH2_SERVER_METADATA_URL is not set. pgAdmin needs the provider's OpenID Connect discovery URL to verify the id_token. Either set OAUTH2_SERVER_METADATA_URL to the discovery URL (e.g. https://&lt;issuer&gt;/.well-known/openid-configuration), or remove 'openid' from OAUTH2_SCOPE.*

Same text in both the browser response and `error_log`.

## Notes

- **Other failure modes unchanged**: network errors, invalid client secrets, etc. still raise Authlib's original exceptions.
- **No regression risk for non-OIDC providers**: the check only fires when `openid` is in the scope.
- **No new dependencies, no migration**, 2 files / +29/-1.

## Test plan

- [x] `pycodestyle` clean on both files.
- [ ] Manual: configure an OAuth2 provider with `OAUTH2_SCOPE: 'openid email profile'`, omit `OAUTH2_SERVER_METADATA_URL`, attempt login → expect the actionable message (not the cryptic `Missing "jwks_uri" in metadata`).
- [ ] Manual: configure same provider with `OAUTH2_SCOPE: 'email profile'` (no openid), omit metadata URL → login succeeds (proves the check doesn't fire when not needed).
- [ ] Manual: configure with both `openid` scope **and** `OAUTH2_SERVER_METADATA_URL` set → login succeeds (proves the check doesn't false-positive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 configuration validation to detect missing OpenID Connect server metadata and provide detailed error guidance before network requests occur, preventing cryptic downstream failures.

* **Documentation**
  * Updated OAuth2 provider configuration documentation clarifying when OpenID Connect discovery URL is required versus optional, with example URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->