### PR TITLE
CLI: skip delete_adhoc_servers() in CLI mode (fixes setup.py user-management regression)

### DIFF
--- a/web/pgadmin/__init__.py
+++ b/web/pgadmin/__init__.py
@@ -495,7 +495,15 @@ def create_app(app_name=None):
             run_migration_for_sqlite()
 
         # Delete all the adhoc(temporary) servers from the pgAdmin database.
-        delete_adhoc_servers()
+        # Adhoc servers are created by interactive tools (Schema Diff,
+        # Query Tool ad-hoc connections, etc.) — they have no meaning
+        # in CLI sessions (`setup.py update-user`, etc.) and accessing
+        # `current_user` inside the user-scoped cleanup branch would
+        # fail with `AttributeError: 'PgAdmin' object has no attribute
+        # 'login_manager'` because Flask-Security has not yet been
+        # initialised at this point in create_app.
+        if not cli_mode:
+            delete_adhoc_servers()
 
     Mail(app)
 


### PR DESCRIPTION
Closes #9987.

## Problem

`setup.py update-user` (and other CLI user-management commands) crash with:

```
AttributeError: 'PgAdmin' object has no attribute 'login_manager'
```

…blocking all CLI automation: config scripts, Kubernetes operators, password rotations.

## Root cause

PR #9830 ("enforce data isolation and harden shared servers in server mode") added a per-user scoping check to `delete_adhoc_servers()` that touches `current_user.is_authenticated`.

Call sequence on the CLI path:

1. `setup.py:432` calls `ManageRoles.get_role(...)` inside `app.test_request_context()` (so SQLAlchemy session works)
2. → `setup.py:154` invokes `create_app('-cli')`
3. → `pgadmin/__init__.py:498` calls `delete_adhoc_servers()`
4. → `delete_adhoc_servers()` reads `current_user.is_authenticated`
5. → Flask-Login's LocalProxy calls `current_app.login_manager._load_user()`
6. → **boom**: `login_manager` is installed at `create_app:546` (Flask-Security `init_app`), AFTER line 498

In normal web startup the call at line 498 also runs with no `login_manager` yet — but `has_request_context()` returns `False` there, so the `has_user` guard short-circuits before the `current_user` access. CLI is different because `setup.py` deliberately opens a `test_request_context` for SQLAlchemy.

## Fix

Wrap the cleanup call in `if not cli_mode:` — the same pattern already used elsewhere in `create_app` for paths init, etc. **Adhoc servers are a UI/tool concept** (Schema Diff workspaces, Query Tool ad-hoc connections, PSQL connections) — they have no meaning in a CLI session that only wants to read/write one user row.

Skipping the cleanup in CLI mode is semantically correct, not just a workaround.

## End-user effect

Reporter's command now succeeds:

```bash
$ python3 setup.py update-user rhino@example.com --password abc123 --role Administrator
           User Details
+---------------------------------+
| Field       | Value             |
|-------------+-------------------|
| Username    | rhino@example.com |
| Email       | rhino@example.com |
| auth_source | internal          |
| role        | Administrator     |
| active      | True              |
+---------------------------------+
```

(matching the v9.13 baseline they cited).

## Behaviour matrix

| Mode | `delete_adhoc_servers()` runs? | Why |
|---|---|---|
| Desktop/Server (web) | Yes — at startup as before | `cli_mode == False` |
| CLI (`setup.py *`) | No | `cli_mode == True`; no UI ever creates adhoc servers in CLI sessions, nothing to clean up |
| Per-tool exit cleanup (`delete_adhoc_servers(sid=...)`) | Unchanged | Called from a real request context in the running web app |

## Notes

- **No new dependencies, no migration**, 1 file / +9/-1.
- **No `login_manager` defensive coupling added** — the root cause is "this function shouldn't run in CLI mode in the first place", so the fix is at the call site, not inside the function. Future callers from a real request context get the full per-user scoping as PR #9830 intended.

## Test plan

- [x] `pycodestyle` clean.
- [ ] Manual: `python3 setup.py update-user <email> --password <pw> --role Administrator` against a freshly-installed pgAdmin → succeeds without traceback.
- [ ] Manual: `python3 setup.py add-user <email> ...` → succeeds.
- [ ] Manual: start pgAdmin in desktop/server mode → adhoc servers from a previous run are still cleaned up at startup (regression guard for the web-mode path).
- [ ] Manual: open a Schema Diff workspace against ad-hoc connection params; close it; restart pgAdmin → adhoc server is gone (per-tool cleanup still works).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where temporary server cleanup was incorrectly executed during CLI operations, preventing initialization failures in command-line mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->