### PR TITLE
docker: read PGADMIN_CONFIG_CONFIG_DATABASE_URI safely via os.environ (fixes #9984)

### DIFF
--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -195,9 +195,28 @@ EOF
 fi
 
 # Check whether the external configuration database exists if it is being used.
+#
+# The URI is read inside Python via os.environ — the shell no longer
+# participates in Python-literal quoting. `ast.literal_eval` unwraps the
+# legacy `'url'` form that the config_distro.py generation convention
+# requires; raw values pass through unchanged. On any Python failure the
+# "False" default below is preserved so first-launch user setup still
+# runs (see #9984).
 external_config_db_exists="False"
 if [ -n "${PGADMIN_CONFIG_CONFIG_DATABASE_URI}" ]; then
-     external_config_db_exists=$(cd /pgadmin4/pgadmin/utils && $SU_EXEC /venv/bin/python3 -c "from check_external_config_db import check_external_config_db; val = check_external_config_db(\"${PGADMIN_CONFIG_CONFIG_DATABASE_URI}\"); print(val)")
+    result=$(cd /pgadmin4/pgadmin/utils && $SU_EXEC /venv/bin/python3 -c "
+import os, ast
+from check_external_config_db import check_external_config_db
+raw = os.environ['PGADMIN_CONFIG_CONFIG_DATABASE_URI']
+try:
+    uri = ast.literal_eval(raw)
+except (ValueError, SyntaxError):
+    uri = raw
+print(check_external_config_db(uri))
+" 2>/dev/null)
+    if [ -n "$result" ]; then
+        external_config_db_exists="$result"
+    fi
 fi
 
 # DRY of the code to load the PGADMIN_SERVER_JSON_FILE


### PR DESCRIPTION
Closes #9984.

## Problem

The container entrypoint constructed a Python `-c` argument by shell-substituting `${PGADMIN_CONFIG_CONFIG_DATABASE_URI}` inside a double-quoted Python string:

```bash
val = check_external_config_db("${PGADMIN_CONFIG_CONFIG_DATABASE_URI}")
```

That collided with the long-standing **`config_distro.py` convention**, which requires the env var's value to **be** a Python literal (so the entrypoint's `CONFIG_DATABASE_URI = $val` write produces valid Python). Users therefore set the env var to `'postgresql+psycopg://...'`. The entrypoint then re-wrapped that literal in another set of quotes, producing:

```python
check_external_config_db("'postgresql+psycopg://...'")
```

— a string with literal single quotes inside. SQLAlchemy can't parse it:

```
sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from given URL string
```

The Python crash made `$(...)` capture an empty string, so the downstream check `[ "${external_config_db_exists}" = "False" ]` also failed — silently skipping the entire first-launch user-setup block. That is the **second symptom** on the issue: `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD` getting ignored.

## Regression history

Bisected to commit `1fe840fca` ("Allow to pass PGADMIN_CONFIG_CONFIG_DATABASE_URI from docker secrets", #5869, **Oct 2024**), which incidentally added `"…"` shell quoting around the expansion in a PR whose actual scope was docker-secrets support (`file_env` helper). The pre-regression form (`ed211a2bb`, #7811, Sep 2024) used a bare expansion and worked correctly with the convention.

Both env-var forms have been broken in shipped images since Oct 2024:

| Env var form | Symptom |
|---|---|
| `PGADMIN_CONFIG_CONFIG_DATABASE_URI="'postgresql+psycopg://…'"` (with quotes, documented) | SQLAlchemy `ArgumentError` + silent `PGADMIN_DEFAULT_EMAIL` skip |
| `PGADMIN_CONFIG_CONFIG_DATABASE_URI=postgresql+psycopg://…` (without quotes, naive) | `config_distro.py` `SyntaxError` on startup → container exits |

## Fix

Rather than restore the bare-expansion form (a 7-year Chesterton's fence that the next shellcheck-style cleanup would reintroduce), **remove the shell from the quoting question altogether**:

- Read the env var **inside Python** via `os.environ` — the shell no longer participates in Python-literal handling.
- Use `ast.literal_eval` to unwrap the legacy `'url'` / `"url"` form when present; on `ValueError`/`SyntaxError`, fall through to the raw value (so users who set the env var without quotes also work).
- Default `external_config_db_exists` stays `"False"` on any Python failure (only overwritten when the Python call produces non-empty stdout) — fixes the secondary `PGADMIN_DEFAULT_EMAIL`-ignored regression.

## Verification (manual)

| Form | Result |
|---|---|
| `'postgresql+psycopg://…'` (legacy single-quoted) | `ast.literal_eval` unwraps → clean URI ✓ |
| `"postgresql+psycopg://…"` (double-quoted) | `ast.literal_eval` unwraps → clean URI ✓ |
| `postgresql+psycopg://…` (raw, no quotes) | `ast.literal_eval` raises → fall through to raw ✓ |
| End-to-end against live Postgres 17, no `server` table | returns `False` (first-launch path runs) ✓ |
| End-to-end against live Postgres 17, with `server` table seeded | returns `True` (skip first-launch as designed for #7811) ✓ |
| Malformed env var | Python fails → `external_config_db_exists` stays `"False"` → first-launch path runs (no silent skip) ✓ |

## Notes

- **`ast.literal_eval` safety**: parses Python literals only; cannot execute arbitrary code. Available since Python 2.6 (2008); pgAdmin's Docker image uses `python:3-alpine` (currently 3.12+), so no version-availability concern.
- **No new dependencies**, no docs changes, no behavior change for users with already-working configs (no working configs exist on master — both forms fail).
- **1 file changed**, +20/-1.

## Test plan

- [x] Bash syntax check (`bash -n pkg/docker/entrypoint.sh`) clean.
- [x] All three env-var forms validated against a live Postgres 17 (Tests 1-5 above).
- [ ] Container test (recommended for maintainers): rebuild the docker image off this branch, set `PGADMIN_CONFIG_CONFIG_DATABASE_URI="'postgresql+psycopg://…'"` + `PGADMIN_DEFAULT_EMAIL` + `PGADMIN_DEFAULT_PASSWORD`, run a fresh container → verify (1) no `ArgumentError` in container logs, (2) default admin user is created against the external DB, (3) restart with `server` table populated → first-launch is skipped as in #7811.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Docker configuration database initialization by fixing potential issues with special characters in database connection strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->