### PR TITLE
Server UI: clarify SSH tunnel identity-file password prompt label (fixes #9981)

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/static/js/server.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/static/js/server.ui.js
@@ -489,7 +489,8 @@ export default class ServerSchema extends BaseUISchema {
         readonly: obj.isConnected,
       },
       {
-        id: 'tunnel_prompt_password', label: gettext('Prompt for password?'),
+        id: 'tunnel_prompt_password',
+        label: gettext('Prompt for identity file password?'),
         type: 'switch', group: gettext('SSH Tunnel'), mode: ['properties', 'edit', 'create'],
         deps: ['tunnel_authentication', 'use_ssh_tunnel'],
         depChange: (state)=>{
@@ -500,7 +501,7 @@ export default class ServerSchema extends BaseUISchema {
         disabled: function(state) {
           return !state.tunnel_authentication || !state.use_ssh_tunnel;
         },
-        helpMessage: gettext('This setting applies only when using an identity file. An identity file may or may not have a password. If set to true the system will prompt for the password.')
+        helpMessage: gettext('Enable if the identity file is passphrase-protected, to be prompted for the passphrase at connection time. This setting applies only to identity-file authentication. When using password authentication for the SSH tunnel, leave the SSH password field empty to be prompted on connection.')
       },
       {
         id: 'save_tunnel_password', label: gettext('Save password?'),


### PR DESCRIPTION
Closes #9981.

## What the issue is

A user reported in #9981 that after upgrading to v9.15 they "can't change Prompt for password under SSH Tunnel". The toggle appears greyed out and won't respond to clicks. They eventually found the working "Prompt for password" under the **Connection** section (the v9.14 behaviour) and posted a screenshot of it in their follow-up comment.

## Not a regression — new field with confusing UX

The `tunnel_prompt_password` switch was added in **commit `f3567518d`** (Oct 2025, PR #6996, *"Added option to skip the password dialog when using an identity file"*). It's a new feature in v9.15, not a change to an existing one. By design, it's only meaningful for **identity-file** authentication — it controls whether pgAdmin prompts for the identity file's passphrase at connection time. The `disabled` callback correctly greys it out when `!tunnel_authentication` (i.e., when using SSH password auth instead of an identity file).

The reporter was using **password authentication**, so the toggle was disabled as designed. But:

1. The label `Prompt for password?` reads as generic SSH-password prompting, not identity-file-passphrase prompting.
2. The help text mentions identity files but is buried after the user has already concluded the toggle is broken.

Hence the false-positive "regression" report. The Connection-level "Prompt for password" they found in their second screenshot is the v9.14 mechanism, which still works exactly as before.

## Fix

Two small UX changes, **no behaviour change**:

- **Rename the label** from `Prompt for password?` to `Prompt for identity file password?` — scope is explicit on first glance.
- **Expand the help text** to:
  - State what enabling does in identity-file mode.
  - Note that the field applies only to identity-file auth.
  - Point users to the password-auth equivalent (leave the SSH password field empty → pgAdmin prompts on connection).

The `disabled` callback is **preserved** per pgAdmin's existing UI convention: conditionally-relevant fields stay visible but greyed out, rather than disappearing entirely. That keeps the option discoverable to users who might switch authentication modes.

## Diff

1 file changed, +3/-2:

```diff
-      id: 'tunnel_prompt_password', label: gettext('Prompt for password?'),
+      id: 'tunnel_prompt_password',
+      label: gettext('Prompt for identity file password?'),
       ...
-      helpMessage: gettext('This setting applies only when using an identity file. An identity file may or may not have a password. If set to true the system will prompt for the password.')
+      helpMessage: gettext('Enable if the identity file is passphrase-protected, to be prompted for the passphrase at connection time. This setting applies only to identity-file authentication. When using password authentication for the SSH tunnel, leave the SSH password field empty to be prompted on connection.')
```

## Test plan

- [x] `yarn linter` clean.
- [ ] Manual: open server-edit dialog, SSH Tunnel section, Authentication = Identity file → toggle is enabled, label reads "Prompt for identity file password?".
- [ ] Manual: switch Authentication to Password → toggle becomes greyed out (and resets to false via existing `depChange`).
- [ ] Manual: hover help icon → reads the new expanded help text covering both auth modes.
- [ ] Manual: a user following the help-text guidance ("leave the SSH password field empty") for password auth → connection prompts for the SSH password as expected (regression guard for the v9.14 behaviour).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated SSH tunnel passphrase prompt label and help text** to clarify it applies only to identity-file authentication, with guidance on proper field usage for password-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->