### PR TITLE
Migrations: use resolve_fks=False so reflect() survives stale FKs (fixes #9976)

### DIFF
--- a/web/migrations/versions/09d53fca90c7_.py
+++ b/web/migrations/versions/09d53fca90c7_.py
@@ -125,7 +125,7 @@ def upgrade():
         # get metadata from current connection
         meta = sa.MetaData()
         # define table representation
-        meta.reflect(op.get_bind(), only=('role',))
+        meta.reflect(op.get_bind(), only=('role',), resolve_fks=False)
         role_table = sa.Table('role', meta)
 
         op.execute(
@@ -168,7 +168,7 @@ def upgrade():
     # get metadata from current connection
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('version',))
+    meta.reflect(op.get_bind(), only=('version',), resolve_fks=False)
     version_table = sa.Table('version', meta)
 
     op.execute(

--- a/web/migrations/versions/1f0eddc8fc79_.py
+++ b/web/migrations/versions/1f0eddc8fc79_.py
@@ -36,7 +36,7 @@ def upgrade():
     # get metadata from current connection
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('role',))
+    meta.reflect(op.get_bind(), only=('role',), resolve_fks=False)
     role_table = sa.Table('role', meta)
 
     from pgadmin.tools.user_management.PgAdminPermissions import (

--- a/web/migrations/versions/44b9ce549393_.py
+++ b/web/migrations/versions/44b9ce549393_.py
@@ -39,7 +39,9 @@ def upgrade():
     # get metadata from current connection
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('server', 'sharedserver'))
+    meta.reflect(op.get_bind(),
+                 only=('server', 'sharedserver'),
+                 resolve_fks=False)
     table = sa.Table('server', meta)
     op.execute(
         table.update().values(prepare_threshold=5)

--- a/web/migrations/versions/7fedf8531802_.py
+++ b/web/migrations/versions/7fedf8531802_.py
@@ -37,7 +37,7 @@ def upgrade():
     # For internal email is a user name, so update the existing records.
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('user',))
+    meta.reflect(op.get_bind(), only=('user',), resolve_fks=False)
     user_table = sa.Table('user', meta)
 
     op.execute(

--- a/web/migrations/versions/ac2c2e27dc2d_.py
+++ b/web/migrations/versions/ac2c2e27dc2d_.py
@@ -33,7 +33,7 @@ def upgrade():
     session.commit()
 
     meta = sa.MetaData()
-    meta.reflect(op.get_bind(), only=('user_macros',))
+    meta.reflect(op.get_bind(), only=('user_macros',), resolve_fks=False)
     user_macros_table = sa.Table('user_macros', meta)
 
     # Create a select statement
@@ -61,7 +61,7 @@ def upgrade():
         sa.PrimaryKeyConstraint('id',))
 
     # Reflect the new table structure
-    meta.reflect(op.get_bind(), only=('user_macros',))
+    meta.reflect(op.get_bind(), only=('user_macros',), resolve_fks=False)
     new_user_macros_table = sa.Table('user_macros', meta)
 
     # Bulk insert the fetched data into the new user_macros table

--- a/web/migrations/versions/add_tools_ai_perm_.py
+++ b/web/migrations/versions/add_tools_ai_perm_.py
@@ -27,7 +27,7 @@ depends_on = None
 def upgrade():
     # Get metadata from current connection
     meta = sa.MetaData()
-    meta.reflect(op.get_bind(), only=('role',))
+    meta.reflect(op.get_bind(), only=('role',), resolve_fks=False)
     role_table = sa.Table('role', meta)
 
     # Get all roles with permissions

--- a/web/migrations/versions/aff1436e3c8c_.py
+++ b/web/migrations/versions/aff1436e3c8c_.py
@@ -29,7 +29,7 @@ def upgrade():
     # get metadata from current connection
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('server',))
+    meta.reflect(op.get_bind(), only=('server',), resolve_fks=False)
     server_table = sa.Table('server', meta)
     op.execute(
         server_table.update().where(server_table.c.connect_timeout == 0 or

--- a/web/migrations/versions/c465fee44968_.py
+++ b/web/migrations/versions/c465fee44968_.py
@@ -31,7 +31,7 @@ def upgrade():
 
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('user',))
+    meta.reflect(op.get_bind(), only=('user',), resolve_fks=False)
     user_table = sa.Table('user', meta)
 
     op.execute(

--- a/web/migrations/versions/c62bcc14c3d6_.py
+++ b/web/migrations/versions/c62bcc14c3d6_.py
@@ -27,7 +27,7 @@ depends_on = None
 def upgrade():
     # Add 'change_password' permission to all roles except 'Administrator'.
     meta = sa.MetaData()
-    meta.reflect(op.get_bind(), only=('role', 'setting'))
+    meta.reflect(op.get_bind(), only=('role', 'setting'), resolve_fks=False)
     role_table = sa.Table('role', meta)
 
     perm = role_table.c.permissions

--- a/web/migrations/versions/d39482714a2e_.py
+++ b/web/migrations/versions/d39482714a2e_.py
@@ -32,7 +32,7 @@ def upgrade():
     # get metadata from current connection
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('server',))
+    meta.reflect(op.get_bind(), only=('server',), resolve_fks=False)
     server_table = sa.Table('server', meta)
 
     op.execute(

--- a/web/migrations/versions/e6ed5dac37c2_.py
+++ b/web/migrations/versions/e6ed5dac37c2_.py
@@ -66,8 +66,10 @@ def upgrade():
     # get metadata from current connection
     meta = sa.MetaData()
     # define table representation
-    meta.reflect(op.get_bind(), only=('user_preferences', 'module_preference',
-                                      'preference_category', 'preferences'))
+    meta.reflect(op.get_bind(),
+                 only=('user_preferences', 'module_preference',
+                       'preference_category', 'preferences'),
+                 resolve_fks=False)
     module_pref_table = sa.Table('module_preference', meta)
 
     module_id = session.query(ModulePreference).filter_by(

--- a/web/migrations/versions/f656e56dfdc8_.py
+++ b/web/migrations/versions/f656e56dfdc8_.py
@@ -53,7 +53,7 @@ def migrate_connection_params(table_name):
 
     # define table representation
     meta = sa.MetaData()
-    meta.reflect(op.get_bind(), only=(table_name,))
+    meta.reflect(op.get_bind(), only=(table_name,), resolve_fks=False)
     server_table = sa.Table(table_name, meta)
 
     # Create a select statement


### PR DESCRIPTION
Refs #9976 (the database-migration crash).

## Problem

A user installing pgAdmin 9.15 fresh on a machine where an old `pgadmin4.db` lingers (e.g. from a 2019-era install in `%appdata%\pgAdmin`) hits a startup failure:

```
sqlalchemy.exc.NoSuchTableError: user_old
```

The traceback (in #9976) points at migration `aff1436e3c8c_.py:32`:

```python
meta = sa.MetaData()
meta.reflect(op.get_bind(), only=('server',))
```

SQLAlchemy's `MetaData.reflect()` defaults to `resolve_fks=True`, which **auto-follows** the reflected table's FOREIGN KEY references and reflects the targets too. On the reporter's old DB, `server.user_id` carries a stale FK to a long-removed `user_old` table. The auto-cascade trips on the orphan FK target and raises `NoSuchTableError`, aborting the migration. The GUI then shows the generic "Server could not be contacted" — confusing because the migration crash is the real failure.

## Fix

None of the existing pgAdmin migrations actually need the FK target tables — they each do an UPDATE/INSERT/SELECT against the explicitly-requested table only. Sweep all 14 `meta.reflect()` call sites across 12 migration files and pass `resolve_fks=False`. Same behavior for healthy DBs (the FK targets just don't get auto-reflected, which the migrations don't care about); broken-FK DBs now survive the reflect step.

| Migration | Sites |
|---|---|
| `09d53fca90c7_.py` | role, version |
| `1f0eddc8fc79_.py` | role |
| `44b9ce549393_.py` | server, sharedserver |
| `7fedf8531802_.py` | user |
| `ac2c2e27dc2d_.py` | user_macros (×2) |
| `add_tools_ai_perm_.py` | role |
| `aff1436e3c8c_.py` | **server (the reporter's hit site)** |
| `c465fee44968_.py` | user |
| `c62bcc14c3d6_.py` | role, setting |
| `d39482714a2e_.py` | server |
| `e6ed5dac37c2_.py` | user_preferences, module_preference, … |
| `f656e56dfdc8_.py` | server/sharedserver (via parameter) |

**Total**: 12 files, +19/-15, all 14 reflect call sites guarded.

## Verification (manual, empirical)

| Backend | Result |
|---|---|
| SQLite in-memory, broken-FK setup matching the reporter's DB | **Before**: reproduces `NoSuchTableError(user_old)` exactly. **After**: reflect succeeds, `connect_timeout 0→10` UPDATE works on 2 seeded rows. |
| Live PostgreSQL 17 (the external `CONFIG_DATABASE_URI` config-DB case) | **With** `resolve_fks=False`: reflect returns only the requested table (`['..._server']`). **Without**: reflect returns the requested table AND its FK target (`['..._server', '..._user_old']`) — confirming the parameter actually controls cascading reflection in both engines. UPDATE works either way. |

## SQLAlchemy compatibility

The `resolve_fks` keyword has been in `MetaData.reflect()` since SQLAlchemy **1.3** (2019). pgAdmin requires SQLAlchemy 2.* (`requirements.txt`), so this is well within compatibility.

## Scope notes

This PR closes only the **database-migration crash** symptom of #9976. The reporter's three UX asks — clearer GUI error (`Server could not be contacted` → `Database migration failed`), log the DB path, GitHub-issue button with a prefilled traceback — are addressed in a follow-up PR I'm preparing separately. Their separation makes review and revert easier.

## Test plan

- [x] `pycodestyle` clean for all lines this PR touches (one pre-existing E231 in `e6ed5dac37c2_.py:107` on origin/master is not in the PR's scope).
- [x] Empirical SQLite + PostgreSQL verification (above).
- [ ] **Recommended for maintainers**: copy a pre-9.0 `pgadmin4.db` with `server.user_id` referencing a long-removed table → start pgAdmin against it → migration completes; default-user setup proceeds; existing servers are visible after restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration implementation to optimize schema reflection behavior across multiple migration versions, improving migration consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->