### PR TITLE
Logging: include config-DB path/URI in migration failure messages (refs #9976)

### DIFF
--- a/web/pgadmin/__init__.py
+++ b/web/pgadmin/__init__.py
@@ -362,6 +362,24 @@ def create_app(app_name=None):
     from config import SQLITE_PATH
     from pgadmin.setup import db_upgrade
 
+    def _describe_config_db():
+        """
+        Return a human-readable identifier of the configuration database
+        currently in use, for inclusion in error logs. Passwords in an
+        external CONFIG_DATABASE_URI are redacted.
+        """
+        if config.CONFIG_DATABASE_URI is not None and \
+                len(config.CONFIG_DATABASE_URI) > 0:
+            # Redact any password in the URI before logging.
+            import re
+            safe_uri = re.sub(
+                r'(://[^:/@]+:)([^@]+)(@)',
+                r'\1***\3',
+                config.CONFIG_DATABASE_URI
+            )
+            return 'external config DB: {0}'.format(safe_uri)
+        return 'SQLite config DB at: {0}'.format(SQLITE_PATH)
+
     def backup_db_file():
         """
         Create a backup of the current database file
@@ -378,7 +396,8 @@ def create_app(app_name=None):
                 'CORRUPTED_DB_BACKUP_FILE'] = backup_file_name
             app.logger.info('Database migration completed.')
         except Exception:
-            app.logger.error('Database migration failed')
+            app.logger.error(
+                'Database migration failed (%s)', _describe_config_db())
             app.logger.error(traceback.format_exc())
             raise RuntimeError('Migration failed')
 
@@ -390,7 +409,8 @@ def create_app(app_name=None):
             db_upgrade(app)
             os.environ['CORRUPTED_DB_BACKUP_FILE'] = ''
         except Exception:
-            app.logger.error('Database migration failed')
+            app.logger.error(
+                'Database migration failed (%s)', _describe_config_db())
             app.logger.error(traceback.format_exc())
             backup_db_file()
 
@@ -398,8 +418,8 @@ def create_app(app_name=None):
         is_db_error, invalid_tb_names = check_db_tables()
         if is_db_error:
             app.logger.error(
-                'Table(s) {0} are missing in the'
-                ' database'.format(invalid_tb_names))
+                'Table(s) {0} are missing in the database ({1})'.format(
+                    invalid_tb_names, _describe_config_db()))
             backup_db_file()
 
     def run_migration_for_sqlite():


### PR DESCRIPTION
Refs #9976 (the "report the DB path in the logs" improvement).

## Problem

When the configuration-DB migration fails, the log currently reads:

```
ERROR pgadmin: Database migration failed
ERROR pgadmin: Traceback (most recent call last): ...
```

It doesn't say **which** database file pgAdmin was trying to migrate. The reporter on #9976 spent time hunting through `%appdata%` looking for a stale `pgadmin4.db` left over from a 2019 install. Knowing the path up front would have shortened that investigation considerably.

## Fix

Pure additive logging. Add a small helper `_describe_config_db()` that returns one of:

- **Default (SQLite) mode**:
  `SQLite config DB at: /path/to/pgadmin4.db`
- **External (`CONFIG_DATABASE_URI`) mode**:
  `external config DB: postgresql+psycopg://user:***@host/db`
  (password between `:` and `@` is redacted before logging — the reporter on a separate issue uses Docker secrets for this URI, so we should never leak the credential in logs)

Include that string in the three migration-failure log sites:
1. `backup_db_file()` retry catch
2. `upgrade_db()` catch
3. Missing-tables check

After the change, the same scenario logs as:

```
ERROR pgadmin: Database migration failed (SQLite config DB at: C:\Users\<name>\AppData\Roaming\pgAdmin\pgadmin4.db)
ERROR pgadmin: Traceback (most recent call last): ...
```

— which is exactly what the reporter spent time hunting for.

## Redaction behaviour

| Input URI | Output |
|---|---|
| `postgresql+psycopg://user:edb@127.0.0.1:5432/pgadmin` | `postgresql+psycopg://user:***@127.0.0.1:5432/pgadmin` |
| `postgresql://user:p%40ss@host/db` (URL-encoded `@`) | `postgresql://user:***@host/db` |
| `postgresql://user:secret@host:5432/db?sslmode=require` | `postgresql://user:***@host:5432/db?sslmode=require` |
| `postgresql+psycopg://host/db` (no creds) | `postgresql+psycopg://host/db` (unchanged) |
| `postgresql://user@host/db` (no password) | `postgresql://user@host/db` (unchanged) |

The redaction is **deliberately conservative** — only the password between `:` and `@` after the scheme. Query-string secrets (some operators put e.g. `password=xxx` in URI parameters) are not redacted; that's a wider concern out of scope for this small logging improvement.

## Scope notes

- **Companion to #10011**, which fixes the actual migration crash on #9976. This PR addresses the *"easier troubleshooting"* item of the reporter's wishlist; #10011 addresses the *"successful database migration"* item. The two remaining items (clearer GUI error, GitHub-issue button) are bigger UX changes that warrant separate, more deliberate work.
- **No behavior change.** Pure additive logging.

## Test plan

- [x] `pycodestyle` clean.
- [x] Redactor unit-tested against the 5 URI shapes in the table above; all pass.
- [ ] **Recommended for maintainers**: force a migration failure (e.g. seed an orphan FK target into `pgadmin4.db` and start pgAdmin) → check the log lines now include the SQLite path.
- [ ] Same with `CONFIG_DATABASE_URI` set → check the log includes the redacted URI form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during database migration failures with clearer context about which configuration database is in use.
  * Enhanced logging to redact sensitive credentials and provide more detailed troubleshooting information when database operations encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->