### PR TITLE
fix: filtering pg_attribute only by attname can return the wrong attnum if the column name exists in multiple table

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/foreign_tables/foreign_table_columns/tests/utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/foreign_tables/foreign_table_columns/tests/utils.py
@@ -112,8 +112,11 @@ def create_column(server, db_name, schema_name, table_name, col_name,
         connection.commit()
         # Get column position of newly added column
         pg_cursor.execute(
-            "select attnum from pg_catalog.pg_attribute where attname=%s",
-            (col_name,)
+            "SELECT a.attnum FROM pg_catalog.pg_attribute a "
+            "JOIN pg_catalog.pg_class c ON c.oid = a.attrelid "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname=%s AND c.relname=%s AND a.attname=%s",
+            (schema_name, table_name, col_name,)
         )
         col = pg_cursor.fetchone()
         col_pos = ''
@@ -163,8 +166,11 @@ def create_identity_column(server, db_name, schema_name, table_name,
         connection.commit()
         # Get column position of newly added column
         pg_cursor.execute(
-            "select attnum from pg_catalog.pg_attribute where attname=%s",
-            (col_name,)
+            "SELECT a.attnum FROM pg_catalog.pg_attribute a "
+            "JOIN pg_catalog.pg_class c ON c.oid = a.attrelid "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname=%s AND c.relname=%s AND a.attname=%s",
+            (schema_name, table_name, col_name,)
         )
         col = pg_cursor.fetchone()
         col_pos = ''

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/columns/tests/utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/columns/tests/utils.py
@@ -112,8 +112,11 @@ def create_column(server, db_name, schema_name, table_name, col_name,
         connection.commit()
         # Get column position of newly added column
         pg_cursor.execute(
-            "select attnum from pg_catalog.pg_attribute where attname=%s",
-            (col_name,)
+            "SELECT a.attnum FROM pg_catalog.pg_attribute a "
+            "JOIN pg_catalog.pg_class c ON c.oid = a.attrelid "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname=%s AND c.relname=%s AND a.attname=%s",
+            (schema_name, table_name, col_name,)
         )
         col = pg_cursor.fetchone()
         col_pos = ''
@@ -163,8 +166,11 @@ def create_identity_column(server, db_name, schema_name, table_name,
         connection.commit()
         # Get column position of newly added column
         pg_cursor.execute(
-            "select attnum from pg_catalog.pg_attribute where attname=%s",
-            (col_name,)
+            "SELECT a.attnum FROM pg_catalog.pg_attribute a "
+            "JOIN pg_catalog.pg_class c ON c.oid = a.attrelid "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname=%s AND c.relname=%s AND a.attname=%s",
+            (schema_name, table_name, col_name,)
         )
         col = pg_cursor.fetchone()
         col_pos = ''

--- a/web/pgadmin/dashboard/__init__.py
+++ b/web/pgadmin/dashboard/__init__.py
@@ -699,7 +699,7 @@ def terminate_session(sid=None, did=None, pid=None):
 @check_precondition
 def check_system_statistics(sid=None, did=None):
     sql = (
-        "SELECT * FROM pg_catalog.pg_extension "
+        "SELECT 1 FROM pg_catalog.pg_extension "
         "WHERE extname = 'system_stats';"
     )
     status, res = g.conn.execute_scalar(sql)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test utilities to perform schema- and table-aware column lookups, increasing accuracy of column creation and identity-column tests across schemas.

* **Bug Fixes**
  * Made extension-presence checks leaner and more consistent, improving reliability of the dashboard's system-statistics indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->