### PR TITLE
fix(pkg/linux): pin psycopg-c build to x86-64 v1 baseline

### DIFF
--- a/pkg/linux/build-functions.sh
+++ b/pkg/linux/build-functions.sh
@@ -77,8 +77,28 @@ _create_python_virtualenv() {
     pip3 install --upgrade pip
     pip3 install wheel
 
-    # Install the requirements
-    pip3 install --force-reinstall --no-cache-dir --no-binary psycopg -r "${SOURCEDIR}/requirements.txt"
+    # Install the requirements.
+    #
+    # psycopg is built from source against the system libpq (see
+    # --no-binary psycopg). Pin the C extension to the x86-64 v1
+    # baseline so the resulting .so runs on every x86_64 CPU we
+    # claim to support. Without this, gcc on a modern build host
+    # may emit AVX2/BMI2/FMA instructions that SIGILL on older
+    # CPUs (Ivy Bridge and earlier) and on default Proxmox kvm64
+    # VMs at psycopg_c.pq module-load time. Issue #9935.
+    #
+    # The flags are scoped to this pip invocation so they don't
+    # leak into any other build steps in the same shell. Other
+    # arches build with their distro defaults.
+    if [ "$(uname -m)" = "x86_64" ]; then
+        CFLAGS="${CFLAGS:-} -O2 -march=x86-64 -mtune=generic" \
+        CXXFLAGS="${CXXFLAGS:-} -O2 -march=x86-64 -mtune=generic" \
+            pip3 install --force-reinstall --no-cache-dir \
+                --no-binary psycopg -r "${SOURCEDIR}/requirements.txt"
+    else
+        pip3 install --force-reinstall --no-cache-dir \
+            --no-binary psycopg -r "${SOURCEDIR}/requirements.txt"
+    fi
 
     # Fixup the paths in the venv activation scripts
     sed -i 's/VIRTUAL_ENV=.*/VIRTUAL_ENV="\/usr\/pgadmin4\/venv"/g' venv/bin/activate


### PR DESCRIPTION
## Summary

Fixes #9935.

The DEB build compiles `psycopg-c` from source on the build host (`pip3 install --no-binary psycopg ...`). With no explicit `-march`, gcc on a modern build host can auto-vectorize parts of the extension using AVX2/BMI2/FMA. The resulting `.so` then SIGILLs at `psycopg_c.pq` module-load time on any CPU lacking those instructions — pre-Haswell hardware (e.g. Intel i5-3450 / Ivy Bridge) and default Proxmox `kvm64` VMs both hit this. Two independent reports on the issue.

Set `CFLAGS=-O2 -march=x86-64 -mtune=generic` (and `CXXFLAGS` likewise) for just the `pip install` invocation on `x86_64` build hosts. This pins the resulting extension to the x86-64 v1 baseline regardless of what the build host's CPU supports, so the DEB runs on every x86_64 CPU we claim to support.

## Scope notes

- Flags are scoped to the pip invocation; they don't leak into any other build step in the same shell.
- Non-x86_64 builds (ARM, etc.) keep their distro defaults — `-march=x86-64` only makes sense on x86_64.
- The pip wheel build path (`pkg/pip/setup_pip.py`) already uses `psycopg[binary]` from PyPI and is unaffected.
- The Docker / container build path doesn't compile psycopg from source either, so it's unaffected.

## Test plan

I don't have the DEB build infrastructure locally, so this needs a build-side verification:

- [ ] Build the DEB on the usual build host and confirm `objdump -d /usr/pgadmin4/venv/lib/python3.14/site-packages/psycopg_c/pq.*.so | awk '/^[[:xdigit:]]/ {print $NF}' | sort -u | grep -E '^(vp|vmov|vex|tzcnt|bzhi|pext|pdep|fma|kor|kand)'` returns **no** AVX2/BMI2/FMA mnemonics.
- [ ] Smoke-test the resulting DEB on an Ivy Bridge box or a Proxmox `kvm64` VM — pgAdmin should start without SIGILL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build process by implementing architecture-specific compiler flags for Python dependencies, improving compatibility and performance during installation across different CPU architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->