### PR TITLE
ci: run data-isolation tests in server mode

### DIFF
--- a/.github/workflows/run-python-tests-server-mode.yml
+++ b/.github/workflows/run-python-tests-server-mode.yml
@@ -33,6 +33,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We don't run any authenticated git operations after checkout
+          # (no push, no submodule fetch, no comment back to the PR), so
+          # persisting the token in the local git config only widens the
+          # blast radius of an unrelated step compromise.
+          persist-credentials: false
 
       - name: Update python version
         uses: actions/setup-python@v5
@@ -71,9 +77,20 @@ jobs:
           sudo sed -i "s/port = 543[0-9]/port = 59${PG_VER}/g" /etc/postgresql/${PG_VER}/main/postgresql.conf
           sudo su - postgres -c "/usr/lib/postgresql/${PG_VER}/bin/postgres -D /var/lib/postgresql/${PG_VER}/main -c config_file=/etc/postgresql/${PG_VER}/main/postgresql.conf &"
 
-          until sudo runuser -l postgres -c "pg_isready -p 59${PG_VER}" 2>/dev/null; do
-            >&2 echo "Postgres is unavailable - sleeping for 2 seconds"
+          # Bounded readiness wait: 60 attempts × 2s = 120s cap. If PG
+          # never becomes ready, fail fast with logs rather than hanging
+          # until the job timeout.
+          for attempt in $(seq 1 60); do
+            if sudo runuser -l postgres -c "pg_isready -p 59${PG_VER}" 2>/dev/null; then
+              break
+            fi
+            >&2 echo "Postgres is unavailable (attempt ${attempt}/60) - sleeping for 2 seconds"
             sleep 2
+            if [ "$attempt" -eq 60 ]; then
+              >&2 echo "Postgres failed to become ready within 120 seconds"
+              sudo tail -n 200 /var/log/postgresql/postgresql-${PG_VER}-main.log || true
+              exit 1
+            fi
           done
 
       - name: Install Python dependencies

--- a/.github/workflows/run-python-tests-server-mode.yml
+++ b/.github/workflows/run-python-tests-server-mode.yml
@@ -1,0 +1,176 @@
+name: Run Python tests in server mode (data isolation)
+
+# This workflow runs the data-isolation tests with SERVER_MODE=True.
+# The main run-python-tests-pg.yml workflow runs everything with
+# SERVER_MODE=False, so any test that gates itself on `config.SERVER_MODE`
+# (notably web/pgadmin/browser/server_groups/tests/test_sg_data_isolation.py
+# and web/pgadmin/browser/server_groups/servers/tests/test_server_data_isolation.py)
+# skips itself in CI. That gap allowed the admin-bypass regression in
+# 9a76ed8 to ship; this workflow exists so regressions to the centralized
+# access-control helpers in web/pgadmin/utils/server_access.py are caught.
+#
+# Scope is intentionally narrow: one OS, one PG version, only the
+# data-isolation modules. Keep it cheap to run on every PR.
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  run-python-tests-server-mode:
+    runs-on: ubuntu-24.04
+
+    env:
+      PG_VER: 18
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update python version
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup the PGDG APT repo
+        # apt-key is deprecated on Ubuntu 24.04+; install the key into
+        # /etc/apt/keyrings/ and reference it via signed-by= in the
+        # sources.list entry instead.
+        run: |
+          sudo install -d -m 0755 /etc/apt/keyrings
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/pgdg.gpg
+          sudo sh -c 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+      - name: Uninstall PostgreSQL if already present
+        run: |
+          if [ -n "$(ls /etc/postgresql/*/*/postgresql.conf 2>/dev/null)" ]; then
+            installed_pg_version=$( pg_config --version | cut -d ' ' -f 2 | cut -d '.' -f 1 )
+            echo "Installed PostgreSQL version: $installed_pg_version"
+            if [ $installed_pg_version != ${PG_VER} ]; then
+              sudo pg_dropcluster $installed_pg_version main --stop
+              sudo apt-get -y remove "postgresql-${installed_pg_version}"
+            fi
+          fi
+
+      - name: Install platform dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libpq-dev libffi-dev libssl-dev libkrb5-dev zlib1g-dev postgresql-${PG_VER}
+
+      - name: Start PostgreSQL
+        run: |
+          sudo su -c "echo local all all trust > /etc/postgresql/${PG_VER}/main/pg_hba.conf"
+          sudo sed -i "s/port = 543[0-9]/port = 59${PG_VER}/g" /etc/postgresql/${PG_VER}/main/postgresql.conf
+          sudo su - postgres -c "/usr/lib/postgresql/${PG_VER}/bin/postgres -D /var/lib/postgresql/${PG_VER}/main -c config_file=/etc/postgresql/${PG_VER}/main/postgresql.conf &"
+
+          until sudo runuser -l postgres -c "pg_isready -p 59${PG_VER}" 2>/dev/null; do
+            >&2 echo "Postgres is unavailable - sleeping for 2 seconds"
+            sleep 2
+          done
+
+      - name: Install Python dependencies
+        run: make install-python-testing
+
+      - name: Create the test configuration (SERVER_MODE=True)
+        run: |
+          mkdir -p var
+          cat <<EOF > web/config_local.py
+          from config import *
+
+          # Debug mode
+          DEBUG = True
+
+          # App mode — this is the whole point of this workflow.
+          SERVER_MODE = True
+
+          # Log
+          CONSOLE_LOG_LEVEL = DEBUG
+          FILE_LOG_LEVEL = DEBUG
+
+          DEFAULT_SERVER = '127.0.0.1'
+
+          UPGRADE_CHECK_ENABLED = False
+
+          LOG_FILE = "$(pwd)/var/pgadmin4.log"
+          SESSION_DB_PATH = "$(pwd)/var/sessions"
+          STORAGE_DIR = "$(pwd)/var/storage"
+          SQLITE_PATH = "$(pwd)/var/pgadmin4.db"
+          TEST_SQLITE_PATH = "$(pwd)/var/pgadmin4.db"
+          AZURE_CREDENTIAL_CACHE_DIR = "$(pwd)/var/azurecredentialcache"
+          EOF
+
+          cat <<EOF > web/regression/test_config.json
+          {
+            "pgAdmin4_login_credentials": {
+              "new_password": "NEWPASSWORD",
+              "login_password": "PASSWORD",
+              "login_username": "USER@EXAMPLE.COM"
+            },
+            "pgAdmin4_test_user_credentials": {
+              "new_password": "NEWPASSWORD",
+              "login_password": "PASSWORD",
+              "login_username": "USER2@EXAMPLE.COM"
+            },
+            "pgAdmin4_test_non_admin_credentials": {
+              "new_password": "NEWPASSWORD",
+              "login_password": "PASSWORD",
+              "login_username": "USER3@EXAMPLE.COM"
+            },
+            "server_group": 1,
+            "server_credentials": [
+              {
+                "name": "PostgreSQL ${{ env.PG_VER }}",
+                "comment": "PostgreSQL ${{ env.PG_VER }} Server",
+                "db_username": "postgres",
+                "host": "/var/run/postgresql",
+                "db_password": "postgres",
+                "db_port": 59${{ env.PG_VER }},
+                "maintenance_db": "postgres",
+                "sslmode": "prefer",
+                "tablespace_path": "/var/lib/postgresql/tablespaces/${{ env.PG_VER }}",
+                "enabled": true,
+                "default_binary_paths": {
+                  "pg": "/usr/lib/postgresql/${{ env.PG_VER }}/bin",
+                  "ppas": ""
+                }
+              }
+            ],
+            "server_update_data": [
+              {
+                "comment": "This is test update comment"
+              }
+            ]
+          }
+          EOF
+
+      - name: Run server-group data isolation tests
+        run: |
+          . venv/bin/activate
+          python web/regression/runtests.py --pkg browser.server_groups.tests --modules test_sg_data_isolation
+
+      - name: Run server data isolation tests
+        run: |
+          . venv/bin/activate
+          python web/regression/runtests.py --pkg browser.server_groups.servers.tests --modules test_server_data_isolation
+
+      - name: Archive server log
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-log-server-mode
+          path: var/pgadmin4.log
+
+      - name: Archive regression log
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-log-server-mode
+          path: web/regression/regression.log


### PR DESCRIPTION
## Summary

Adds a narrow GitHub Actions workflow that runs the data-isolation test modules with `SERVER_MODE = True`. The existing `run-python-tests-pg.yml` hardcodes `SERVER_MODE = False` for the entire matrix, so every test that gates itself on `config.SERVER_MODE` — including the data-isolation suites — currently skips itself in CI.

This is exactly the gap that allowed the admin-bypass regression in 9a76ed8 to ship: that change touched `web/pgadmin/utils/server_access.py` (centralized access-control helpers) but the only tests covering the affected behaviour were server-mode-only and therefore never ran. The follow-up fix landed in #10006 along with a regression test for the admin → non-admin direction — but that test will silently skip in CI just like the original ones unless a server-mode workflow exists.

## Design

Deliberately narrow to keep CI cost low:

- Single OS (`ubuntu-24.04`) and single PG version (18) — no matrix
- `SERVER_MODE = True` in `config_local.py`
- Runs only the two data-isolation modules:
  - `browser.server_groups.tests.test_sg_data_isolation` (3 tests)
  - `browser.server_groups.servers.tests.test_server_data_isolation` (6 tests)
- Modernised PGDG key handling (`/etc/apt/keyrings/` + `signed-by=` instead of deprecated `apt-key add`) since 24.04 has phased the old approach out

Locally both modules together finish in well under half a second; the marginal CI cost is the apt + python + PG setup, not the tests themselves.

## Why a separate workflow

Two reasons rather than adding a second matrix entry to the existing PG workflow:

1. **Failure attribution** — when this fails, the failure is unambiguous: an access-control regression. Mixing it into the main PG matrix would dilute that signal.
2. **Scope** — running the full test suite in server mode is a much bigger project (tracked in our follow-up work). This workflow does only the part that protects against the specific regression that already happened.

## Test plan

- [x] Locally verified both invocations pass against `SERVER_MODE=True`
- [x] Locally confirmed the new test in #10006 fails (`AssertionError: 200 != 410`) on pre-fix code and passes on post-fix code
- [x] YAML syntax validated
- [x] Workflow security audit: only `${{ env.PG_VER }}` (literal `18`) appears in `run:` blocks; no untrusted inputs
- [ ] First CI run on this PR confirms the GitHub Actions environment behaves as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to run targeted server-mode regression tests for data isolation.
  * Workflow runs on CI for relevant changes or manual runs, and uploads test logs/artifacts for diagnostics and faster issue resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->