### PR TITLE
fix(schema-diff): reverse-engineer SERIAL columns by default

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/__init__.py
@@ -1706,7 +1706,7 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
         return sql
 
     @BaseTableView.check_precondition
-    def fetch_tables(self, sid, did, scid, tid=None, with_serial_cols=False):
+    def fetch_tables(self, sid, did, scid, tid=None, with_serial_cols=True):
         """
         This function will fetch the list of all the tables
         and will be used by schema diff.
@@ -1715,7 +1715,9 @@ class TableView(BaseTableView, DataTypeReader, SchemaDiffTableCompare):
         :param did: Database Id
         :param scid: Schema Id
         :param tid: Table Id
-        :param with_serial_cols:
+        :param with_serial_cols: when True (default), reverse-engineer
+            SERIAL columns back to ``serial`` / ``smallserial`` /
+            ``bigserial`` so emitted DDL is round-trippable. Issue #9896.
         :return: Table dataset
         """
 

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/columns/utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/columns/utils.py
@@ -229,10 +229,20 @@ def parse_options_for_column(db_variables):
 @get_template_path
 def get_formatted_columns(conn, tid, data, other_columns,
                           table_or_type, template_path=None,
-                          with_serial=False):
+                          with_serial=True):
     """
     This function will iterate and return formatted data for all
     the columns.
+
+    Serial-column detection is on by default: a column whose default
+    is ``nextval('<table>_<col>_seq'...)`` with an integer/smallint/
+    bigint type is the reverse-engineered form of a SERIAL declaration,
+    and we reproject it back to ``serial`` / ``smallserial`` /
+    ``bigserial`` so callers can emit valid round-trippable DDL. Pass
+    ``with_serial=False`` only if you genuinely need the raw libpq
+    representation (e.g. a low-level introspection caller that handles
+    the sequence itself). Issue #9896.
+
     :param conn: Connection Object
     :param tid: Table ID
     :param data: Data

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/12_plus/create_table_with_serial_cols.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/12_plus/create_table_with_serial_cols.sql
@@ -1,0 +1,19 @@
+-- Table: public.table_with_serial_cols
+
+-- DROP TABLE IF EXISTS public.table_with_serial_cols;
+
+CREATE TABLE IF NOT EXISTS public.table_with_serial_cols
+(
+    id_serial serial NOT NULL,
+    id_bigserial bigserial NOT NULL,
+    id_smallserial smallserial NOT NULL,
+    payload text COLLATE pg_catalog."default"
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.table_with_serial_cols
+    OWNER to <OWNER>;
+
+COMMENT ON TABLE public.table_with_serial_cols
+    IS 'round-trip SERIAL columns (issue #9896)';

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/12_plus/create_table_with_serial_cols_msql.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/12_plus/create_table_with_serial_cols_msql.sql
@@ -1,0 +1,13 @@
+CREATE TABLE public.table_with_serial_cols
+(
+    id_serial serial NOT NULL,
+    id_bigserial bigserial NOT NULL,
+    id_smallserial smallserial NOT NULL,
+    payload text
+);
+
+ALTER TABLE IF EXISTS public.table_with_serial_cols
+    OWNER to <OWNER>;
+
+COMMENT ON TABLE public.table_with_serial_cols
+    IS 'round-trip SERIAL columns (issue #9896)';

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/12_plus/test.json
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/12_plus/test.json
@@ -2151,6 +2151,105 @@
       "data": {
         "name": "partition_table_with_collate_$%{}[]()&*^!@\"'`\\/#"
       }
+    },
+    {
+      "type": "create",
+      "name": "Create Table with serial columns",
+      "endpoint": "NODE-table.obj",
+      "sql_endpoint": "NODE-table.sql_id",
+      "msql_endpoint": "NODE-table.msql",
+      "data": {
+        "name": "table_with_serial_cols",
+        "relowner": "<OWNER>",
+        "relacl": [],
+        "description": "round-trip SERIAL columns (issue #9896)",
+        "coll_inherits": "[]",
+        "hastoasttable": true,
+        "primary_key": [],
+        "partitions": [],
+        "partition_type": "range",
+        "is_partitioned": false,
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id_serial",
+            "cltype": "serial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "id_bigserial",
+            "cltype": "bigserial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "id_smallserial",
+            "cltype": "smallserial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "payload",
+            "cltype": "text",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": false,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "a",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          }
+        ],
+        "foreign_key": [],
+        "check_constraint": [],
+        "unique_constraint": [],
+        "exclude_constraint": [],
+        "partition_keys": [],
+        "seclabels": [],
+        "forcerlspolicy": false,
+        "like_default_value": false,
+        "like_constraints": false,
+        "like_indexes": false,
+        "like_storage": false,
+        "like_comments": false,
+        "like_identity": false,
+        "like_statistics": false
+      },
+      "store_object_id": true,
+      "expected_sql_file": "create_table_with_serial_cols.sql",
+      "expected_msql_file": "create_table_with_serial_cols_msql.sql"
+    },
+    {
+      "type": "delete",
+      "name": "Delete Table with serial columns",
+      "endpoint": "NODE-table.obj_id",
+      "data": {
+        "name": "table_with_serial_cols"
+      }
     }
   ]
 }

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/14_plus/create_table_with_serial_cols.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/14_plus/create_table_with_serial_cols.sql
@@ -1,0 +1,19 @@
+-- Table: public.table_with_serial_cols
+
+-- DROP TABLE IF EXISTS public.table_with_serial_cols;
+
+CREATE TABLE IF NOT EXISTS public.table_with_serial_cols
+(
+    id_serial serial NOT NULL,
+    id_bigserial bigserial NOT NULL,
+    id_smallserial smallserial NOT NULL,
+    payload text COLLATE pg_catalog."default"
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.table_with_serial_cols
+    OWNER to <OWNER>;
+
+COMMENT ON TABLE public.table_with_serial_cols
+    IS 'round-trip SERIAL columns (issue #9896)';

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/14_plus/create_table_with_serial_cols_msql.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/14_plus/create_table_with_serial_cols_msql.sql
@@ -1,0 +1,13 @@
+CREATE TABLE public.table_with_serial_cols
+(
+    id_serial serial NOT NULL,
+    id_bigserial bigserial NOT NULL,
+    id_smallserial smallserial NOT NULL,
+    payload text
+);
+
+ALTER TABLE IF EXISTS public.table_with_serial_cols
+    OWNER to <OWNER>;
+
+COMMENT ON TABLE public.table_with_serial_cols
+    IS 'round-trip SERIAL columns (issue #9896)';

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/14_plus/test.json
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/14_plus/test.json
@@ -2283,6 +2283,105 @@
       "data": {
         "name": "simple_table_comp_$%{}[]()&*^!@\"'`\\/#"
       }
+    },
+    {
+      "type": "create",
+      "name": "Create Table with serial columns",
+      "endpoint": "NODE-table.obj",
+      "sql_endpoint": "NODE-table.sql_id",
+      "msql_endpoint": "NODE-table.msql",
+      "data": {
+        "name": "table_with_serial_cols",
+        "relowner": "<OWNER>",
+        "relacl": [],
+        "description": "round-trip SERIAL columns (issue #9896)",
+        "coll_inherits": "[]",
+        "hastoasttable": true,
+        "primary_key": [],
+        "partitions": [],
+        "partition_type": "range",
+        "is_partitioned": false,
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id_serial",
+            "cltype": "serial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "id_bigserial",
+            "cltype": "bigserial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "id_smallserial",
+            "cltype": "smallserial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "payload",
+            "cltype": "text",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": false,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "a",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          }
+        ],
+        "foreign_key": [],
+        "check_constraint": [],
+        "unique_constraint": [],
+        "exclude_constraint": [],
+        "partition_keys": [],
+        "seclabels": [],
+        "forcerlspolicy": false,
+        "like_default_value": false,
+        "like_constraints": false,
+        "like_indexes": false,
+        "like_storage": false,
+        "like_comments": false,
+        "like_identity": false,
+        "like_statistics": false
+      },
+      "store_object_id": true,
+      "expected_sql_file": "create_table_with_serial_cols.sql",
+      "expected_msql_file": "create_table_with_serial_cols_msql.sql"
+    },
+    {
+      "type": "delete",
+      "name": "Delete Table with serial columns",
+      "endpoint": "NODE-table.obj_id",
+      "data": {
+        "name": "table_with_serial_cols"
+      }
     }
   ]
 }

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/16_plus/create_table_with_serial_cols.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/16_plus/create_table_with_serial_cols.sql
@@ -1,0 +1,19 @@
+-- Table: public.table_with_serial_cols
+
+-- DROP TABLE IF EXISTS public.table_with_serial_cols;
+
+CREATE TABLE IF NOT EXISTS public.table_with_serial_cols
+(
+    id_serial serial NOT NULL,
+    id_bigserial bigserial NOT NULL,
+    id_smallserial smallserial NOT NULL,
+    payload text COLLATE pg_catalog."default"
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.table_with_serial_cols
+    OWNER to <OWNER>;
+
+COMMENT ON TABLE public.table_with_serial_cols
+    IS 'round-trip SERIAL columns (issue #9896)';

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/16_plus/create_table_with_serial_cols_msql.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/16_plus/create_table_with_serial_cols_msql.sql
@@ -1,0 +1,13 @@
+CREATE TABLE public.table_with_serial_cols
+(
+    id_serial serial NOT NULL,
+    id_bigserial bigserial NOT NULL,
+    id_smallserial smallserial NOT NULL,
+    payload text
+);
+
+ALTER TABLE IF EXISTS public.table_with_serial_cols
+    OWNER to <OWNER>;
+
+COMMENT ON TABLE public.table_with_serial_cols
+    IS 'round-trip SERIAL columns (issue #9896)';

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/16_plus/test.json
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/tests/pg/16_plus/test.json
@@ -2338,6 +2338,105 @@
       "data": {
         "name": "simple_table_storage_$%{}[]()&*^!@\"'`\\/#"
       }
+    },
+    {
+      "type": "create",
+      "name": "Create Table with serial columns",
+      "endpoint": "NODE-table.obj",
+      "sql_endpoint": "NODE-table.sql_id",
+      "msql_endpoint": "NODE-table.msql",
+      "data": {
+        "name": "table_with_serial_cols",
+        "relowner": "<OWNER>",
+        "relacl": [],
+        "description": "round-trip SERIAL columns (issue #9896)",
+        "coll_inherits": "[]",
+        "hastoasttable": true,
+        "primary_key": [],
+        "partitions": [],
+        "partition_type": "range",
+        "is_partitioned": false,
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id_serial",
+            "cltype": "serial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "id_bigserial",
+            "cltype": "bigserial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "id_smallserial",
+            "cltype": "smallserial",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": true,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          },
+          {
+            "name": "payload",
+            "cltype": "text",
+            "attacl": [],
+            "is_primary_key": false,
+            "attnotnull": false,
+            "attlen": null,
+            "attprecision": null,
+            "attidentity": "a",
+            "colconstype": "n",
+            "attoptions": [],
+            "seclabels": []
+          }
+        ],
+        "foreign_key": [],
+        "check_constraint": [],
+        "unique_constraint": [],
+        "exclude_constraint": [],
+        "partition_keys": [],
+        "seclabels": [],
+        "forcerlspolicy": false,
+        "like_default_value": false,
+        "like_constraints": false,
+        "like_indexes": false,
+        "like_storage": false,
+        "like_comments": false,
+        "like_identity": false,
+        "like_statistics": false
+      },
+      "store_object_id": true,
+      "expected_sql_file": "create_table_with_serial_cols.sql",
+      "expected_msql_file": "create_table_with_serial_cols_msql.sql"
+    },
+    {
+      "type": "delete",
+      "name": "Delete Table with serial columns",
+      "endpoint": "NODE-table.obj_id",
+      "data": {
+        "name": "table_with_serial_cols"
+      }
     }
   ]
 }

--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/utils.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/utils.py
@@ -165,12 +165,19 @@ class BaseTableView(PGChildNodeView, BasePartitionTable, VacuumSettings):
 
         return wrap
 
-    def _formatter(self, did, scid, tid, data, with_serial_cols=False):
+    def _formatter(self, did, scid, tid, data, with_serial_cols=True):
         """
         Args:
             data: dict of query result
             scid: schema oid
             tid: table oid
+            with_serial_cols: when True (default), reverse-engineer
+                ``integer + nextval('<table>_<col>_seq')`` columns back
+                to their ``serial`` / ``smallserial`` / ``bigserial``
+                declaration so emitted DDL round-trips on a clean
+                target. Pass ``False`` only for low-level introspection
+                callers that handle the sequence themselves.
+                Issue #9896.
 
         Returns:
             It will return formatted output of query result
@@ -488,7 +495,7 @@ class BaseTableView(PGChildNodeView, BasePartitionTable, VacuumSettings):
 
         return condition
 
-    def fetch_tables(self, sid, did, scid, tid=None, with_serial_cols=False):
+    def fetch_tables(self, sid, did, scid, tid=None, with_serial_cols=True):
         """
         This function will fetch the list of all the tables
         and will be used by schema diff.


### PR DESCRIPTION
## Summary

Fixes #9896.

Schema Diff's *Generate Script* emitted CREATE TABLE DDL with the libpq-expanded form of SERIAL columns:

```sql
col integer NOT NULL DEFAULT nextval('table_col_seq'::regclass)
```

instead of preserving `SERIAL`. Applied to a clean target, that script fails with `relation "table_col_seq" does not exist` because the sequence is never created — exactly what the reporter ran into.

## Root cause

SERIAL detection already existed in `columns/utils.py:get_formatted_columns` (added in `115208c8d`, Nov 2023, for ERD generation), but was gated behind a `with_serial_cols` parameter that defaulted to `False`. Only ERD and the Schema Diff *comparison* phase opted in via explicit `True`. The *Generate Script* path and the browser tree's *CREATE Script* view went through `_get_resql_for_table` → `_formatter(data)` without specifying the flag, so SERIAL detection was skipped and #9896 reproduced.

There's no legitimate use case where pgAdmin should knowingly emit the expanded libpq form: `SERIAL` is purely a CREATE-time macro that PostgreSQL expands into an integer column plus an implicit sequence owned by the column. The detection logic is reversing that expansion, which is the correct interpretation in every context (DDL emission, comparison, ERD, properties dialog).

## Fix

Flip the default to `True` at all four declaration sites:

- `columns/utils.py: get_formatted_columns`
- `utils.py: BaseTableView._formatter`
- `utils.py: BaseTableView.fetch_tables`
- `__init__.py: TableView.fetch_tables`

All four existing explicit-`True` callers (ERD × 2, Schema Diff compare × 2) are unaffected. Silent callers that previously got the buggy `False` now correctly get SERIAL detection:

| Caller | What it does | Why it's safe |
|---|---|---|
| `_get_resql_for_table` (utils.py:682) | Schema Diff *Generate Script* + browser tree *CREATE Script* | The intended fix. |
| `select_sql` / `insert_sql` / `update_sql` (tables/__init__.py) | Sample SELECT/INSERT/UPDATE templates | They decide whether to include a column based on `has_default_val`, computed from `att.atthasdef` in the column SQL template — not from the `defval` string that SERIAL detection clears. SERIAL columns continue to be correctly excluded from INSERT/UPDATE samples. |
| Partition path (utils.py:1470) | Partition reverse-engineered SQL | Same template, same SERIAL detection behavior. |

## Regression test

Added a CREATE TABLE scenario covering `serial` / `bigserial` / `smallserial` columns plus a plain `text` column to `pg/12_plus`, `pg/14_plus`, and `pg/16_plus` test dirs, with the expected reverse-engineered DDL preserving the SERIAL keywords. Without this fix the test fails with the `nextval('…_seq')` form.

## Known coverage gaps (deliberately not in this PR)

- **PG11** — source fix applies, regression not locked. PG11 still emits `WITH (OIDS = FALSE)` in CREATE TABLE; without a live PG11 instance I can't confidently produce the expected SQL variant. Test scenario therefore not added to `pg/11_plus` or `pg/default`.
- **PPAS** (`ppas/*` test dirs) — source fix applies, regression not locked. PPAS DDL output can diverge from vanilla PG in subtle ways (oraplus, hyphenated identifiers). No PPAS instance available to verify.
- The SERIAL detection heuristic is name-based (looks for `<table>_<col>_seq` in `defval`). Sequence renames, table renames, column renames, and pathological substring collisions all break detection. Pre-existing from `115208c8d`; worth a follow-up that uses `pg_depend` to derive the linkage directly rather than reconstructing the conventional name.

## Test plan

- [x] `pycodestyle --config=.pycodestyle` clean on the four modified Python files.
- [x] `python regression/runtests.py --pkg resql` — `Create Table with serial columns (MSQL)/(SQL)/Delete` all pass on PG18; full resql suite 0 failures.
- [x] `python regression/runtests.py --pkg tools.schema_diff` — 2/2 pass.
- [x] `python regression/runtests.py --pkg browser.server_groups.servers.databases.schemas.tables` — 464/464 pass.
- [ ] Manual: run the issue's reproducer (`SERIAL` column on source, empty target) through Schema Diff → *Generate Script* → confirm the emitted DDL says `SERIAL` and applies cleanly to the target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced schema reverse-engineering to properly detect and preserve SERIAL, BIGSERIAL, and SMALLSERIAL column definitions, generating DDL that can be re-executed without modification.
  * Improved schema diff functionality to correctly handle serial column detection by default across PostgreSQL versions.

* **Tests**
  * Added comprehensive test coverage for serial column handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->