### PR TITLE
fix(schema-diff): aggregate child counts at parent group rows

### DIFF
--- a/web/pgadmin/tools/schema_diff/static/js/components/ResultGridComponent.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/ResultGridComponent.jsx
@@ -159,14 +159,38 @@ function useFocusRef(isSelected) {
   };
 }
 
-function setRecordCount(row, filterParams) {
+/*
+ * Recompute the four status counts for ``row`` based on its descendants.
+ *
+ * Three row shapes can appear in the schema-diff results tree:
+ *   - Leaf row:  has a ``status`` (Identical/Different/Source Only/Target
+ *                Only); contributes 1 to the matching count when it's
+ *                visible under ``filterParams``.
+ *   - Mid-level row (object-type group, e.g. "Functions"): children are
+ *     leaves. Counts are the sum of those leaves.
+ *   - Top-level row (object-group, e.g. "Schema Objects"): children are
+ *     mid-level rows. Counts are the sum of the mid-level rows' counts.
+ *
+ * Originally this function only handled the leaf-children case, which
+ * left top-level group rows showing blank counts even when their
+ * descendants had differences. Issue #9892.
+ */
+export function setRecordCount(row, filterParams) {
   row['identicalCount'] = 0;
   row['differentCount'] = 0;
   row['sourceOnlyCount'] = 0;
   row['targetOnlyCount'] = 0;
 
   row.children.map((ch) => {
-    if (filterParams.includes(ch.status)) {
+    if ('identicalCount' in ch) {
+      // Mid-level child: refresh its counts (in case filterParams
+      // changed since the last render) and roll them up.
+      setRecordCount(ch, filterParams);
+      row['identicalCount'] += ch['identicalCount'];
+      row['differentCount'] += ch['differentCount'];
+      row['sourceOnlyCount'] += ch['sourceOnlyCount'];
+      row['targetOnlyCount'] += ch['targetOnlyCount'];
+    } else if (filterParams.includes(ch.status)) {
       if (ch.status == FILTER_NAME.IDENTICAL) {
         row['identicalCount'] = row['identicalCount'] + 1;
       } else if (ch.status == FILTER_NAME.DIFFERENT) {

--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffCompare.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffCompare.jsx
@@ -495,6 +495,13 @@ export function SchemaDiffCompare({ params }) {
         'groupType': record.group_name,
         'isExpanded': false,
         'selected': false,
+        // Seed status counts so the cell expander renders them at the
+        // top-level group too — setRecordCount() will aggregate from
+        // the mid-level children at render time. Issue #9892.
+        'identicalCount': 0,
+        'differentCount': 0,
+        'sourceOnlyCount': 0,
+        'targetOnlyCount': 0,
         'children': {}
       };
       let ch_id = record.id;

--- a/web/regression/javascript/schema_diff/result_grid_count_spec.js
+++ b/web/regression/javascript/schema_diff/result_grid_count_spec.js
@@ -1,0 +1,148 @@
+/////////////////////////////////////////////////////////////
+//
+// pgAdmin 4 - PostgreSQL Tools
+//
+// Copyright (C) 2013 - 2026, The pgAdmin Development Team
+// This software is released under the PostgreSQL Licence
+//
+//////////////////////////////////////////////////////////////
+
+import { setRecordCount } from '../../../pgadmin/tools/schema_diff/static/js/components/ResultGridComponent';
+import { FILTER_NAME } from '../../../pgadmin/tools/schema_diff/static/js/SchemaDiffConstants';
+
+const ALL_FILTERS = [
+  FILTER_NAME.IDENTICAL,
+  FILTER_NAME.DIFFERENT,
+  FILTER_NAME.SOURCE_ONLY,
+  FILTER_NAME.TARGET_ONLY,
+];
+
+function leaf(status) {
+  return { status };
+}
+
+function midGroup(label, children) {
+  return {
+    label,
+    identicalCount: 0,
+    differentCount: 0,
+    sourceOnlyCount: 0,
+    targetOnlyCount: 0,
+    children,
+  };
+}
+
+function topGroup(label, children) {
+  return {
+    label,
+    identicalCount: 0,
+    differentCount: 0,
+    sourceOnlyCount: 0,
+    targetOnlyCount: 0,
+    children,
+  };
+}
+
+describe('setRecordCount', () => {
+  it('counts leaf children by status', () => {
+    const row = midGroup('Functions', [
+      leaf(FILTER_NAME.IDENTICAL),
+      leaf(FILTER_NAME.DIFFERENT),
+      leaf(FILTER_NAME.DIFFERENT),
+      leaf(FILTER_NAME.SOURCE_ONLY),
+      leaf(FILTER_NAME.SOURCE_ONLY),
+      leaf(FILTER_NAME.SOURCE_ONLY),
+      leaf(FILTER_NAME.TARGET_ONLY),
+    ]);
+
+    setRecordCount(row, ALL_FILTERS);
+
+    expect(row.identicalCount).toBe(1);
+    expect(row.differentCount).toBe(2);
+    expect(row.sourceOnlyCount).toBe(3);
+    expect(row.targetOnlyCount).toBe(1);
+  });
+
+  it('skips leaf children whose status is filtered out', () => {
+    const row = midGroup('Functions', [
+      leaf(FILTER_NAME.IDENTICAL),
+      leaf(FILTER_NAME.DIFFERENT),
+      leaf(FILTER_NAME.SOURCE_ONLY),
+      leaf(FILTER_NAME.TARGET_ONLY),
+    ]);
+
+    // Only count DIFFERENT and SOURCE_ONLY.
+    setRecordCount(row, [FILTER_NAME.DIFFERENT, FILTER_NAME.SOURCE_ONLY]);
+
+    expect(row.identicalCount).toBe(0);
+    expect(row.differentCount).toBe(1);
+    expect(row.sourceOnlyCount).toBe(1);
+    expect(row.targetOnlyCount).toBe(0);
+  });
+
+  it('aggregates mid-level child counts into the top-level group (issue #9892)', () => {
+    // Tree mirroring the bug reporter's case: a top-level group whose
+    // children are object-type groups (Functions, Tables, ...) that
+    // each have leaf children with statuses. Before the fix the top
+    // row stayed at 0/0/0/0.
+    const top = topGroup('Schema Objects', [
+      midGroup('Functions', [
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.TARGET_ONLY),
+      ]),
+      midGroup('Tables', Array(6).fill(leaf(FILTER_NAME.SOURCE_ONLY))),
+      midGroup('Procedures', Array(3).fill(leaf(FILTER_NAME.SOURCE_ONLY))),
+      midGroup('Sequences', [
+        leaf(FILTER_NAME.SOURCE_ONLY),
+        leaf(FILTER_NAME.DIFFERENT),
+      ]),
+      midGroup('Types', [leaf(FILTER_NAME.IDENTICAL)]),
+    ]);
+
+    setRecordCount(top, ALL_FILTERS);
+
+    // 7 (Functions src) + 6 (Tables) + 3 (Procedures) + 1 (Sequences) = 17
+    expect(top.sourceOnlyCount).toBe(17);
+    expect(top.targetOnlyCount).toBe(1);
+    expect(top.differentCount).toBe(1);
+    expect(top.identicalCount).toBe(1);
+  });
+
+  it('refreshes mid-level child counts on every call (filter change)', () => {
+    const mid = midGroup('Functions', [
+      leaf(FILTER_NAME.IDENTICAL),
+      leaf(FILTER_NAME.DIFFERENT),
+    ]);
+    const top = topGroup('Schema Objects', [mid]);
+
+    // First pass: include both statuses → mid counts both.
+    setRecordCount(top, ALL_FILTERS);
+    expect(mid.identicalCount).toBe(1);
+    expect(mid.differentCount).toBe(1);
+    expect(top.identicalCount).toBe(1);
+    expect(top.differentCount).toBe(1);
+
+    // Filter changes to DIFFERENT only → top must reflect mid's refreshed
+    // counts, not the stale numbers from the first pass.
+    setRecordCount(top, [FILTER_NAME.DIFFERENT]);
+    expect(mid.identicalCount).toBe(0);
+    expect(mid.differentCount).toBe(1);
+    expect(top.identicalCount).toBe(0);
+    expect(top.differentCount).toBe(1);
+  });
+
+  it('handles an empty children list without throwing', () => {
+    const row = midGroup('Empty', []);
+    setRecordCount(row, ALL_FILTERS);
+    expect(row.identicalCount).toBe(0);
+    expect(row.differentCount).toBe(0);
+    expect(row.sourceOnlyCount).toBe(0);
+    expect(row.targetOnlyCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9892.

In *Tools → Schema Diff*, the top-level group rows ("Schema Objects", "Database Objects") rendered with blank counts even when their child groups had non-trivial differences. A user could see "Schema Objects" at zero/blank while Functions, Tables, and others underneath listed Source-Only / Target-Only objects, with no signal at the parent level that anything was different.

## Root cause

The results tree is three levels: a top-level *object-group* row, mid-level *object-type* rows (Functions, Tables, Sequences…), and leaf *object* rows with a `status` (Identical / Different / Source Only / Target Only).

`ResultGridComponent.jsx::setRecordCount` only knew how to handle leaf children — it iterated `row.children` and bumped counts off each child's `status` field. Mid-level rows correctly counted their leaves, but the top-level rows, whose children are *mid-level rows* (no `status`, only their own counts), got zero.

`ResultGridComponent.jsx`'s render gate `'identicalCount' in row` skipped the count rendering entirely for top-level rows because `SchemaDiffCompare.jsx::generateGridData` never seeded those four fields on the top-level row object.

## Fix

- `ResultGridComponent.jsx`: `setRecordCount` now recognises a third child shape — a counted-group child (has `identicalCount` etc.) instead of a leaf with a `status`. For those children it recurses to refresh the child's counts (so `filterParams` changes propagate) and rolls the four totals up. Leaf-only behavior is unchanged. Exported the function so the regression test can drive it directly.
- `SchemaDiffCompare.jsx`: seed `identicalCount` / `differentCount` / `sourceOnlyCount` / `targetOnlyCount` to 0 on every top-level group row in `generateGridData`, so the render gate fires and counts get drawn.

## Test plan

Adds `regression/javascript/schema_diff/result_grid_count_spec.js` with five Jest scenarios driving the exported `setRecordCount` directly:

- Leaf children counted by status (pre-existing behavior preserved).
- Leaf children skipped when their `status` is outside `filterParams`.
- **Top-level aggregation (the #9892 case)** — builds the reporter's exact tree (Functions src=7/tgt=1, Tables src=6, Procedures src=3, Sequences src=1/diff=1, Types ident=1) and asserts the top-level totals are 17/1/1/1 instead of 0/0/0/0.
- Re-running with a narrower `filterParams` correctly refreshes the mid-level child counts (no stale numbers leak into the top-level total).
- Empty `children` list is a no-op.

- [x] `yarn run eslint` clean on the changed files.
- [x] `yarn run jest -t setRecordCount`: 5/5 new tests pass.
- [x] `yarn run test:js-once`: 829/829 pass (was 824/824).
- [ ] Manual: reproduce the reporter's scenario in *Tools → Schema Diff*, confirm the "Schema Objects" row now shows the aggregated counts (and that changing the status filter chips refreshes them at every level of the tree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema diff comparison to accurately count and display identical, different, source-only, and target-only items. Counts now properly aggregate through nested group hierarchies and update correctly when filters are applied.

* **Tests**
  * Added comprehensive test coverage for schema diff count calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->