### PR TITLE
chore(deps): bump JavaScript and Python third-party dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ azure-mgmt-subscription==3.1.1
 bcrypt==5.0.*
 boto3==1.42.*; python_version <= '3.9'
 boto3==1.43.*; python_version > '3.9'
-certifi==2026.4.22
+certifi==2026.5.20
 cryptography==48.0.*
 Flask-Babel==4.0.*
 Flask-Compress==1.*
@@ -29,7 +29,7 @@ Flask-Login==0.*
 Flask-Mail==0.*
 Flask-Migrate==4.*
 Flask-Paranoid==0.*
-Flask-Security-Too==5.4.*; python_version <= '3.9'
+Flask-Security-Too==5.6.*; python_version <= '3.9'
 Flask-Security-Too==5.8.*; python_version > '3.9'
 Flask-SocketIO==5.6.*
 Flask-SQLAlchemy==3.1.*
@@ -60,9 +60,9 @@ SQLAlchemy==2.*
 sqlparse==0.*
 sshtunnel==0.*
 typer[all]==0.23.*; python_version <= '3.9'
-typer==0.25.*; python_version > '3.9'
+typer==0.26.*; python_version > '3.9'
 urllib3==1.26.*; python_version <= '3.9'
-urllib3==2.6.*;  python_version > '3.9'
+urllib3==2.7.*;  python_version > '3.9'
 user-agents==2.2.0
 Werkzeug==3.1.*
 WTForms==3.1.*; python_version <= '3.9'

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -13,8 +13,8 @@
   "packageManager": "yarn@4.9.2",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "electron": "^42.1.0",
-    "eslint": "^10.4.0",
+    "electron": "^42.3.3",
+    "eslint": "^10.4.1",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.6.0"
   },

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -89,13 +89,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@eslint/plugin-kit@npm:0.7.1"
+"@eslint/plugin-kit@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@eslint/plugin-kit@npm:0.7.2"
   dependencies:
     "@eslint/core": "npm:^1.2.1"
     levn: "npm:^0.4.1"
-  checksum: 10c0/335b0c1c46fd906cb50bd5ce442b9cee18dc44342ce35c718ba4a63d1aa51d2797f16a517b2f4fe371ccd777b6862fafb2dc8195e00e69197ef4cb17ab32c01b
+  checksum: 10c0/aafba08077bcd6d7dde6c2e21db18086046a88f914f29971a84cac9ad2d48952ded1b293e665e523805297eff756522dafa16f0062195e2c7143dcd1d47d11ed
   languageName: node
   linkType: hard
 
@@ -474,9 +474,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^42.1.0":
-  version: 42.2.0
-  resolution: "electron@npm:42.2.0"
+"electron@npm:^42.3.3":
+  version: 42.3.3
+  resolution: "electron@npm:42.3.3"
   dependencies:
     "@electron/get": "npm:^5.0.0"
     "@types/node": "npm:^24.9.0"
@@ -484,7 +484,7 @@ __metadata:
   bin:
     electron: cli.js
     install-electron: install.js
-  checksum: 10c0/fda91b08b1119ea2c83c59f7d46ad11569bf8f502a56eb0b7cb54eefe318c7a3d39ae132cbcaf26a8c2e043c673fdb1cde7998b134f2808f3d76dd8151d10a4e
+  checksum: 10c0/9fdb34c23097986e4ed9f328ec36356d78481133a17fdba78312be6dddb5e513f91e727a7802f91ff7302d86f794998085ef6fbc2c2b8ae9bc2d5f8b38711759
   languageName: node
   linkType: hard
 
@@ -606,16 +606,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^10.4.0":
-  version: 10.4.0
-  resolution: "eslint@npm:10.4.0"
+"eslint@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "eslint@npm:10.4.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.8.0"
     "@eslint-community/regexpp": "npm:^4.12.2"
     "@eslint/config-array": "npm:^0.23.5"
     "@eslint/config-helpers": "npm:^0.6.0"
     "@eslint/core": "npm:^1.2.1"
-    "@eslint/plugin-kit": "npm:^0.7.1"
+    "@eslint/plugin-kit": "npm:^0.7.2"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
@@ -647,7 +647,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/6bf644dc08fa5a6b23157d23a4a4638d45823d03a67da1daac8dc1085b03934fa98013efd2eac2cd6ec90fe88d36b336bdf38d5f000325f22d823a15f2031426
+  checksum: 10c0/c5e6bb5158fb0d62f090c8e2671de5c98283bbb37a58b6d871bada63af3018e683483c96c1a92272fedc8f4e5279a273a0451acf0da67c487406639daa05aedb
   languageName: node
   linkType: hard
 
@@ -1201,10 +1201,10 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^10.0.1"
     axios: "npm:^1.16.1"
-    electron: "npm:^42.1.0"
+    electron: "npm:^42.3.3"
     electron-context-menu: "npm:^4.1.2"
     electron-store: "npm:^11.0.2"
-    eslint: "npm:^10.4.0"
+    eslint: "npm:^10.4.1"
     eslint-plugin-unused-imports: "npm:^4.4.1"
     globals: "npm:^17.6.0"
   languageName: unknown

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,6 +2,6 @@ requests>=2.32.5,<2.33; python_version <= '3.9'
 requests>=2.34.2; python_version > '3.9'
 requests[security]>=2.32.5,<2.33; python_version <= '3.9'
 requests[security]>=2.34.2; python_version > '3.9'
-safety>=3.7.0
+safety>=3.8.1
 Sphinx==7.4.7
 sphinxcontrib-youtube==1.5.0

--- a/web/package.json
+++ b/web/package.json
@@ -157,7 +157,15 @@
     "zustand": "^5.0.12"
   },
   "resolutions": {
-    "rc-resize-observer": "1.4.0"
+    "rc-resize-observer": "1.4.0",
+    "@xmldom/xmldom": "^0.8.13",
+    "serialize-javascript": "^7.0.5",
+    "ip-address": "^10.1.1",
+    "postcss": "^8.5.10",
+    "ws": "^8.20.1",
+    "qs": "^6.15.2",
+    "@tootallnate/once": "^2.0.1",
+    "tar@npm:^7.5.4": "^7.5.15"
   },
   "scripts": {
     "linter": "yarn run eslint -c .eslintrc.js .",

--- a/web/regression/requirements.txt
+++ b/web/regression/requirements.txt
@@ -29,7 +29,7 @@ pycodestyle>=2.14.0
 python-mimeparse==2.0.0
 selenium==4.44.0
 testscenarios==0.5.0; python_version <= '3.9'
-testscenarios==0.6.1; python_version > '3.9'
+testscenarios==0.6.2; python_version > '3.9'
 testtools==2.7.2; python_version <= '3.9'
 testtools==2.9.1; python_version > '3.9'
 traceback2==1.4.0

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3701,10 +3701,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
+"@tootallnate/once@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@tootallnate/once@npm:2.0.1"
+  checksum: 10c0/23b01a341485be711c602077936d70f8e695405bb88ab4433dc6d1e6cb4556401518789574d399eded790b70b27738136c9a8f02df7ae4219f4ba28bb22d586b
   languageName: node
   linkType: hard
 
@@ -4522,10 +4522,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.7.2":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: 10c0/cb02e4e8d986acf18578a5f25d1bce5e18d08718f40d8a0cdd922a4c112c8e00daf94de4e43f9556ed147c696b135f2ab81fa9a2a8a0416f60af15d156b60e40
+"@xmldom/xmldom@npm:^0.8.13":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
   languageName: node
   linkType: hard
 
@@ -8760,13 +8760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
-  languageName: node
-  linkType: hard
-
 "ip-address@npm:^10.1.1":
   version: 10.2.0
   resolution: "ip-address@npm:10.2.0"
@@ -10899,15 +10892,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
@@ -11988,18 +11972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.40":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.14":
+"postcss@npm:^8.5.10":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -12144,12 +12117,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.12.3":
-  version: 6.15.0
-  resolution: "qs@npm:6.15.0"
+"qs@npm:^6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 
@@ -13278,16 +13251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
-  languageName: node
-  linkType: hard
-
-"serialize-javascript@npm:^7.0.3":
+"serialize-javascript@npm:^7.0.5":
   version: 7.0.5
   resolution: "serialize-javascript@npm:7.0.5"
   checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
@@ -14311,16 +14275,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.4":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+"tar@npm:^7.5.15":
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 
@@ -15461,9 +15425,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0, ws@npm:^8.19.0":
-  version: 8.20.0
-  resolution: "ws@npm:8.20.0"
+"ws@npm:^8.20.1":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -15472,22 +15436,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.18.3":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Combined dependency bump across `web/` (npm), `runtime/` (npm), `tools/` (pip), and root + `web/regression/` (pip). Bundling these into a single PR runs CI once instead of 12 times across the equivalent open Dependabot PRs.

## What's bumped

### web/ (npm, via `resolutions`)

All eight are transitive — declared via the existing `resolutions` block in `web/package.json`. `yarn install` then collapses duplicate-version entries in `yarn.lock` (net -64 lines).

| Package | Before | After | Patched | Severity |
|---|---|---|---|---|
| ws | 8.20.0 | 8.21.0 | 8.20.1 | medium (runtime) |
| @xmldom/xmldom | 0.7.13 | 0.8.13 | 0.8.13 | high |
| serialize-javascript | 6.0.2, 7.0.5 | 7.0.5 | 7.0.5 | high |
| ip-address | 10.1.0, 10.2.0 | 10.2.0 | 10.1.1 | medium |
| postcss | 8.5.8, 8.5.15 | 8.5.15 | 8.5.10 | medium |
| qs | 6.15.0 | 6.15.2 | 6.15.2 | medium |
| @tootallnate/once | 2.0.0 | 2.0.1 | 2.0.1 | low |
| tar (7.x lineage) | 7.5.13 | 7.5.16 | 7.5.11 | high |

The tar 6.x lineage (consumed via `^6.1.2`/`^6.1.11`) is unaffected by these CVEs (alert ranges are 7.x-only), so the resolution is scoped `tar@npm:^7.5.4` to leave it on 6.2.1.

### Root + web/regression (pip)

| Package | Row | Before | After | Notes |
|---|---|---|---|---|
| certifi | both | 2026.4.22 | 2026.5.20 | CA bundle refresh |
| typer | `py > 3.9` | 0.25.* | 0.26.* | 0.26.7 latest still drops 3.9 → row stays split |
| testscenarios | `py > 3.9` | 0.6.1 | 0.6.2 | patch bump |
| **urllib3** | `py > 3.9` | 2.6.* | **2.7.*** | **Picks up two HIGH-severity fixes**: GHSA-mf9v-mfxr-j63j (decompression-bomb safeguards bypassed under `drain_conn` / Brotli stream patterns) and GHSA-qccp-gfcp-xxvc (`ProxyManager.connection_from_url` did not strip sensitive headers on cross-host redirects). 2.7.0 requires Python >=3.10 which the existing gate already enforces. |
| Flask-Security-Too | `py <= 3.9` | 5.4.* | 5.6.* | Closes a ~2-year gap between the 3.9 row (March 2024) and the `> 3.9` row (5.8.*). 5.5/5.6 only touched flows pgAdmin doesn't use (register V2, MFA / WebAuthn templates, username recovery/changing, secret_key rotation) and config pgAdmin overrides (default hash bcrypt → argon2 sidestepped by `SECURITY_PASSWORD_HASH = 'pbkdf2_sha512'`). The contract changes that mattered (`LoginForm.validate → is_active`, `UserMixin.is_locked` hook, single-kwarg `find_user`) are already exercised in production via the existing FST 5.8.* / Python 3.10+ deployments. |

### runtime/ (npm)

| Package | Before | After | Notes |
|---|---|---|---|
| electron | 42.2.0 | 42.3.3 | Patch within v42 series |
| eslint | 10.4.0 | 10.4.1 | Patch bump |

### tools/ (pip)

| Package | Before | After | Notes |
|---|---|---|---|
| safety | >=3.7.0 | >=3.8.1 | Dev-only security scanner |

## Supersedes (12 open Dependabot PRs)

- npm: #9956, #9962, #9966, #9974, #9996, #9998
- pip: #9977, #9979, #9980, #9995, #9997, #9999, #10000

These can be closed after this lands.

## Deliberately out of scope

- **paramiko** (#9927, #9930): sshtunnel 0.4.0 still references `paramiko.DSSKey` (removed in paramiko 4), so bumping reintroduces #9090. sshtunnel hasn't shipped since 2021-01.
- **urllib3 1.26.* on the 3.9 row**: structurally blocked — boto3 1.42 (the last to support Python 3.9) bundles botocore 1.42.x, which pins `urllib3<1.27` for `python_version<"3.10"`.
- **Flask-Security-Too on the 3.9 row beyond 5.6**: 5.7 dropped Python 3.9.
- **@mui/material 7→9 (#9843)**: two majors at once; needs API/UI review.
- **@mui/x-date-pickers 8→9 (#9888)**: one major; needs UI smoke test of date/time editors.

The MUI majors deserve their own focused PR with smoke testing through the UI.

## Verification

- [x] `yarn install` in `web/` — resolves cleanly; 8 packages collapsed to safe versions, lockfile net -64 lines
- [x] `yarn install` in `runtime/` — resolves cleanly; electron 42.2.0 → 42.3.3, eslint 10.4.0 → 10.4.1
- [x] `pip install -r web/regression/requirements.txt` — installs urllib3 2.7.0, certifi 2026.5.20, typer 0.26.7, testscenarios 0.6.2
- [x] Smoke imports of all bumped Python packages
- [x] `yarn run test:js-once` — 824 / 824 pass across 140 suites
- [x] `yarn run bundle:dev` — webpack compiles successfully
- [x] Python data-isolation suite in `SERVER_MODE=True` — 44 / 44 pass (exercises Flask-Security-Too 5.8.* auth flow + urllib3 in the loop)
- [x] `tools/user_management.test_locked_user` (Flask-Security `LoginForm.validate` contract) — 4 / 4 pass
- [x] `runtime/` ESLint — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies across Python and JavaScript development environments to latest stable versions. Changes include security-related packages (certifi, urllib3, safety), web framework components (Flask-Security-Too, typer), development and build tools (Electron, ESLint), and JavaScript runtime dependencies. Version constraints have been adjusted for Python 3.9+ compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->