### PR TITLE
fix: accept prepare/binary kwargs in DictCursor.execute

### DIFF
--- a/web/pgadmin/utils/driver/psycopg3/cursor.py
+++ b/web/pgadmin/utils/driver/psycopg3/cursor.py
@@ -185,15 +185,21 @@ class DictCursor(_cursor):
             self._ordered_description()
         return self._odt_desc
 
-    def execute(self, query, params=None):
+    def execute(self, query, params=None, *, prepare=None, binary=None):
         """
         Execute function
+
+        ``prepare`` and ``binary`` are forwarded so this cursor stays
+        substitutable for ``psycopg.Cursor``. ``psycopg.Connection.execute``
+        passes ``prepare=...`` through to its underlying cursor; without
+        accepting it here that high-level call raises ``TypeError``.
         """
         self._odt_desc = None
         if params is not None and len(params) == 0:
             params = None
 
-        return _cursor.execute(self, query, params)
+        return _cursor.execute(self, query, params,
+                               prepare=prepare, binary=binary)
 
     def fetchone(self):
         """
@@ -273,23 +279,30 @@ class AsyncDictCursor(_async_cursor):
         self._ordered_description()
         return self._odt_desc
 
-    def execute(self, query, params=None):
+    def execute(self, query, params=None, *, prepare=None, binary=None):
         """
         Execute function
+
+        Mirrors ``DictCursor.execute`` so this cursor stays substitutable
+        for ``psycopg.AsyncCursor`` when used via ``AsyncConnection.execute``.
         """
         try:
-            return asyncio.run(self._execute(query, params))
+            return asyncio.run(
+                self._execute(query, params, prepare=prepare, binary=binary)
+            )
         except RuntimeError as e:
             current_app.logger.exception(e)
 
-    async def _execute(self, query, params=None):
+    async def _execute(self, query, params=None, *,
+                       prepare=None, binary=None):
         """
         Execute function
         """
         if params is not None and len(params) == 0:
             params = None
 
-        return await self.cursor.execute(self, query, params)
+        return await self.cursor.execute(self, query, params,
+                                         prepare=prepare, binary=binary)
 
     def executemany(self, query, params=None):
         """

--- a/web/pgadmin/utils/tests/test_psycopg3_cursor_signature.py
+++ b/web/pgadmin/utils/tests/test_psycopg3_cursor_signature.py
@@ -9,12 +9,19 @@
 
 """Regression test for DictCursor.execute() signature.
 
-``psycopg.Connection.execute(query, params, *, prepare=None, binary=False)``
-delegates to its underlying cursor as ``cur.execute(query, params,
-prepare=prepare)``. The DictCursor in
-``pgadmin.utils.driver.psycopg3.cursor`` must accept those kwargs or any
-caller that uses the high-level ``Connection.execute`` path raises
+``psycopg.Cursor.execute`` exposes ``prepare`` and ``binary`` as keyword-only
+parameters. For ``DictCursor`` (a ``psycopg.Cursor`` subclass) to remain
+substitutable for the base cursor, its overridden ``execute`` must accept
+those kwargs too.
+
+The most visible failure mode is the ``Connection.execute`` path:
+``psycopg.Connection.execute`` always forwards ``prepare=...`` to the
+underlying cursor (``binary`` is handled by setting ``cur.format`` instead).
+With a ``cursor_factory=DictCursor`` connection the forwarded ``prepare``
+kwarg trips a narrowed ``DictCursor.execute`` signature with
 ``TypeError: execute() got an unexpected keyword argument 'prepare'``.
+``binary`` doesn't break ``Connection.execute`` directly, but is asserted
+here for full ``psycopg.Cursor`` signature parity.
 """
 
 import inspect

--- a/web/pgadmin/utils/tests/test_psycopg3_cursor_signature.py
+++ b/web/pgadmin/utils/tests/test_psycopg3_cursor_signature.py
@@ -1,0 +1,44 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+"""Regression test for DictCursor.execute() signature.
+
+``psycopg.Connection.execute(query, params, *, prepare=None, binary=False)``
+delegates to its underlying cursor as ``cur.execute(query, params,
+prepare=prepare)``. The DictCursor in
+``pgadmin.utils.driver.psycopg3.cursor`` must accept those kwargs or any
+caller that uses the high-level ``Connection.execute`` path raises
+``TypeError: execute() got an unexpected keyword argument 'prepare'``.
+"""
+
+import inspect
+
+from pgadmin.utils.driver.psycopg3.cursor import AsyncDictCursor, DictCursor
+from pgadmin.utils.route import BaseTestGenerator
+
+
+class TestDictCursorExecuteSignature(BaseTestGenerator):
+    """Verify (Async)DictCursor.execute exposes ``prepare`` and ``binary``."""
+
+    scenarios = [
+        ('DictCursor.execute accepts prepare/binary',
+         dict(cls=DictCursor)),
+        ('AsyncDictCursor.execute accepts prepare/binary',
+         dict(cls=AsyncDictCursor)),
+    ]
+
+    def runTest(self):
+        params = inspect.signature(self.cls.execute).parameters
+        self.assertIn('prepare', params)
+        self.assertIn('binary', params)
+        # Must be keyword-only — psycopg passes them as kwargs.
+        self.assertEqual(params['prepare'].kind,
+                         inspect.Parameter.KEYWORD_ONLY)
+        self.assertEqual(params['binary'].kind,
+                         inspect.Parameter.KEYWORD_ONLY)


### PR DESCRIPTION
## Problem

`psycopg.Connection.execute(query, params, *, prepare=None, binary=False)` delegates to its underlying cursor as `cur.execute(query, params, prepare=prepare)`. pgAdmin's `DictCursor` / `AsyncDictCursor` (in `web/pgadmin/utils/driver/psycopg3/cursor.py`) narrowed the signature to `(self, query, params=None)`, so any caller that uses the high-level `Connection.execute()` path with a `cursor_factory=DictCursor` connection trips:

```
TypeError: DictCursor.execute() got an unexpected keyword argument 'prepare'
```

### Concrete failure mode

The most visible victim is `psycopg_pool.ConnectionPool.check_connection`, which sends `conn.execute("")` to validate every checkout. With a `DictCursor`-using pool every connection looks broken to the pool — checkouts loop in the recovery path until `PoolTimeout`. This blocks `check=ConnectionPool.check_connection` from being usable at all when the pool is built with `connection_class` that sets `cursor_factory=DictCursor`.

Minimal reproducer:

```python
import psycopg
from pgadmin.utils.driver.psycopg3.cursor import DictCursor

conn = psycopg.connect("…", cursor_factory=DictCursor)
conn.execute("SELECT 1")
# -> TypeError: DictCursor.execute() got an unexpected keyword argument 'prepare'
```

## Fix

Forward `prepare` and `binary` (keyword-only) to the underlying `psycopg.Cursor` / `psycopg.AsyncCursor`. Defaults match psycopg's own (`prepare=None`, `binary=None`), so existing callers see no behavior change. Restores `Liskov`-substitutability with the standard psycopg cursors.

## Test plan

- [x] `make check-pep8` — clean
- [x] AST verification: both `DictCursor.execute` and `AsyncDictCursor.execute` expose `prepare` and `binary` as keyword-only parameters
- [x] New regression test `pgadmin.utils.tests.test_psycopg3_cursor_signature` — passes under `regression/runtests.py --pkg utils.tests` (both `DictCursor` and `AsyncDictCursor` scenarios)
- [x] Full `utils.tests` package — 30 passed / 0 failed / 4 unrelated skips
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor execute methods now accept additional keyword-only parameters to control query execution (e.g., preparation and binary modes), improving flexibility for advanced queries.

* **Tests**
  * Added regression tests to ensure the execute methods expose the new keyword-only parameters in their public signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->