### PR TITLE
Rename server 'Change Password' to 'Change Server Password' (#9230)

### DIFF
--- a/docs/en_US/change_password_dialog.rst
+++ b/docs/en_US/change_password_dialog.rst
@@ -1,8 +1,8 @@
 .. _change_password_dialog:
 
-*******************************
-`Change Password Dialog`:index:
-*******************************
+**************************************
+`Change Server Password Dialog`:index:
+**************************************
 
 It is a good policy to routinely change your password to protect data, even in
 what you may consider a 'safe' environment. In the workplace, failure to apply
@@ -30,7 +30,9 @@ comprehensive list and they **will not guarantee security**.
     :alt: Change database password dialog
     :align: center
 
-Use the *Change Password* dialog to change your password:
+Use the *Change Server Password* dialog to change the password of the role that
+pgAdmin uses to connect to the database server, rather than the password you use
+to log in to pgAdmin itself:
 
 * The name displayed in the *User* field is the role for which you are modifying
   the password; it is the role that is associated with the server connection

--- a/docs/en_US/menu_bar.rst
+++ b/docs/en_US/menu_bar.rst
@@ -72,7 +72,7 @@ following options (in alphabetical order):
 |                             |                                                                                                                          |
 |   2) *Deploy Cloud Instance*| Click to open the :ref:`Cloud Deployment <cloud_deployment>` dialog to deploy an cloud instance.                         |
 +-----------------------------+--------------------------------------------------------------------------------------------------------------------------+
-| *Change Password...*        | Click to open the :ref:`Change Password... <change_password_dialog>` dialog to change your password.                     |
+| *Change Server Password...* | Click to open the :ref:`Change Server Password... <change_password_dialog>` dialog to change the password.               |
 +-----------------------------+--------------------------------------------------------------------------------------------------------------------------+
 | *Clear Saved Password*      | If you have saved the database server password, click to clear the saved password.                                       |
 |                             | Enable only when password is already saved.                                                                              |

--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -25,3 +25,5 @@ Housekeeping
 
 Bug fixes
 *********
+
+  | `Issue #9230 <https://github.com/pgadmin-org/pgadmin4/issues/9230>`_ -  Renamed the server "Change Password" menu option and dialog to "Change Server Password" (including the connected username) to make clear it changes the PostgreSQL server password, not the pgAdmin login password.

--- a/web/pgadmin/browser/server_groups/servers/static/js/server.js
+++ b/web/pgadmin/browser/server_groups/servers/static/js/server.js
@@ -126,7 +126,7 @@ define('pgadmin.node.server', [
         },{
           name: 'change_password', node: 'server', module: this,
           applies: ['object'], callback: 'change_password',
-          label: gettext('Change Password...'), priority: 10,
+          label: gettext('Change Server Password...'), priority: 10,
           enable : 'is_connected',data: {
             data_disabled: gettext('Please connect server to enable change password.'),
           },
@@ -364,7 +364,11 @@ define('pgadmin.node.server', [
               if (res.success && res.data.is_pgpass) {
                 is_pgpass_file_used = true;
               }
-              showChangeServerPassword(gettext('Change Password'), d, obj, i, is_pgpass_file_used);
+              showChangeServerPassword(
+                d.user?.name
+                  ? gettext('Change Server Password (%s)', d.user.name)
+                  : gettext('Change Server Password'),
+                d, obj, i, is_pgpass_file_used);
             }).catch(function(error) {
               pgAdmin.Browser.notifier.pgRespErrorNotify(error);
             });

--- a/web/pgadmin/browser/server_groups/servers/static/js/server.js
+++ b/web/pgadmin/browser/server_groups/servers/static/js/server.js
@@ -128,7 +128,7 @@ define('pgadmin.node.server', [
           applies: ['object'], callback: 'change_password',
           label: gettext('Change Server Password...'), priority: 10,
           enable : 'is_connected',data: {
-            data_disabled: gettext('Please connect server to enable change password.'),
+            data_disabled: gettext('Please connect the server to enable Change Server Password.'),
           },
         },{
           name: 'wal_replay_pause', node: 'server', module: this,

--- a/web/pgadmin/static/js/Dialogs/index.jsx
+++ b/web/pgadmin/static/js/Dialogs/index.jsx
@@ -205,7 +205,7 @@ export function showChangeServerPassword() {
                 // Notify user to update pgpass file
                 if(isPgPassFileUsed) {
                   pgAdmin.Browser.notifier.alert(
-                    gettext('Change Password'),
+                    gettext('Change Server Password'),
                     gettext('Please make sure to disconnect the server'
                     + ' and update the new password in the pgpass file'
                       + ' before performing any other operation')


### PR DESCRIPTION
### Summary

Fixes #9230.

The *Change Password...* menu option on a server node (and its dialog) is ambiguous — it changes the **PostgreSQL server** password, but reads as if it might change the pgAdmin login password. As discussed on the issue, this renames the menu option and dialog to **Change Server Password** and includes the connected username in the dialog title to make the target unmistakable.

### Changes
- `server.js`: menu label `Change Password...` → `Change Server Password...`; dialog title → `Change Server Password (<username>)`.
- Added release note (9.16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed the server password action to **“Change Server Password...”** for improved clarity.
  * Added user-specific titles when changing a database role password.

* **Bug Fixes**
  * Clarified the disabled-state message and password-change dialog wording.
  * Updated notifications to distinguish server passwords from pgAdmin login passwords.

* **Documentation**
  * Updated the change-password and Object menu documentation to reflect the revised terminology and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->