### PR TITLE
Disable SSH agent when a tunnel identity file/password is provided (#9814)

### DIFF
--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -25,3 +25,5 @@ Housekeeping
 
 Bug fixes
 *********
+
+  | `Issue #9814 <https://github.com/pgadmin-org/pgadmin4/issues/9814>`_ -  Disable SSH agent probing for SSH tunnels when an identity file or password is provided, preventing repeated authentication prompts/denials from the agent.

--- a/web/pgadmin/utils/driver/psycopg3/server_manager.py
+++ b/web/pgadmin/utils/driver/psycopg3/server_manager.py
@@ -593,6 +593,7 @@ WHERE db.oid = {0}""".format(did))
                     ssh_username=self.tunnel_username,
                     ssh_pkey=get_complete_file_path(self.tunnel_identity_file),
                     ssh_private_key_password=tunnel_password,
+                    allow_agent=False,
                     remote_bind_address=(self.host, self.port),
                     logger=ssh_logger,
                     set_keepalive=int(self.tunnel_keep_alive)
@@ -602,6 +603,7 @@ WHERE db.oid = {0}""".format(did))
                     (self.tunnel_host, int(self.tunnel_port)),
                     ssh_username=self.tunnel_username,
                     ssh_password=tunnel_password,
+                    allow_agent=False,
                     remote_bind_address=(self.host, self.port),
                     logger=ssh_logger,
                     set_keepalive=int(self.tunnel_keep_alive)

--- a/web/pgadmin/utils/driver/psycopg3/server_manager.py
+++ b/web/pgadmin/utils/driver/psycopg3/server_manager.py
@@ -587,13 +587,22 @@ WHERE db.oid = {0}""".format(did))
                 ssh_logger.setLevel(logging.DEBUG)
                 for h in current_app.logger.handlers:
                     ssh_logger.addHandler(h)
+            # Only keep sshtunnel away from the agent when we have a
+            # credential of our own for it to use (#9814). Given neither a
+            # usable key nor a password it raises ValueError from
+            # _consolidate_auth() before it ever connects, so leaving the
+            # agent enabled in that case preserves the previous behaviour
+            # for anyone relying on "Prompt for Password?" or on the agent
+            # itself to authenticate.
             if self.tunnel_authentication == 1:
+                tunnel_identity_file = get_complete_file_path(
+                    self.tunnel_identity_file)
                 self.tunnel_object = SSHTunnelForwarder(
                     (self.tunnel_host, int(self.tunnel_port)),
                     ssh_username=self.tunnel_username,
-                    ssh_pkey=get_complete_file_path(self.tunnel_identity_file),
+                    ssh_pkey=tunnel_identity_file,
                     ssh_private_key_password=tunnel_password,
-                    allow_agent=False,
+                    allow_agent=not tunnel_identity_file,
                     remote_bind_address=(self.host, self.port),
                     logger=ssh_logger,
                     set_keepalive=int(self.tunnel_keep_alive)
@@ -603,7 +612,7 @@ WHERE db.oid = {0}""".format(did))
                     (self.tunnel_host, int(self.tunnel_port)),
                     ssh_username=self.tunnel_username,
                     ssh_password=tunnel_password,
-                    allow_agent=False,
+                    allow_agent=not tunnel_password,
                     remote_bind_address=(self.host, self.port),
                     logger=ssh_logger,
                     set_keepalive=int(self.tunnel_keep_alive)
@@ -612,7 +621,11 @@ WHERE db.oid = {0}""".format(did))
             self.tunnel_object.daemon_forward_servers = True
             self.tunnel_object.start()
             self.tunnel_created = True
-        except BaseSSHTunnelForwarderError as e:
+        except (BaseSSHTunnelForwarderError, ValueError) as e:
+            # sshtunnel raises a bare ValueError rather than one of its own
+            # exceptions when it finds no credential to authenticate with, so
+            # catch that too and report it the same way instead of letting it
+            # escape as an unhandled exception.
             current_app.logger.exception(e)
             return False, gettext(
                 "Failed to create the SSH tunnel. Possible causes:\n"

--- a/web/pgadmin/utils/tests/test_ssh_tunnel_allow_agent.py
+++ b/web/pgadmin/utils/tests/test_ssh_tunnel_allow_agent.py
@@ -1,0 +1,118 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+"""Tests for the SSH agent handling in ServerManager.create_ssh_tunnel().
+
+Probing the agent when pgAdmin already has an identity file or a password of
+its own produces repeated prompts or denials (#9814), so the agent is disabled
+whenever a credential is available. It must stay enabled when none is, because
+sshtunnel raises ValueError from _consolidate_auth() if it is left with
+nothing at all to authenticate with, and that would be a worse failure than
+the one being fixed: ValueError is not a BaseSSHTunnelForwarderError, so it
+would escape the handler that turns tunnel failures into a friendly message.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import config
+from pgadmin.utils.route import BaseTestGenerator
+
+import pgadmin.utils.driver.psycopg3.server_manager as server_manager
+
+
+class SSHTunnelAllowAgentTestCase(BaseTestGenerator):
+    """allow_agent must follow whether a credential is actually present."""
+
+    scenarios = [
+        ('Identity file present disables the agent', dict(
+            tunnel_authentication=1,
+            resolved_identity_file='/tmp/id_rsa',
+            stored_password=None,
+            expected_allow_agent=False,
+        )),
+        ('Unusable identity file leaves the agent enabled', dict(
+            tunnel_authentication=1,
+            resolved_identity_file=None,
+            stored_password=None,
+            expected_allow_agent=True,
+        )),
+        ('Tunnel password disables the agent', dict(
+            tunnel_authentication=0,
+            resolved_identity_file=None,
+            stored_password='encrypted',
+            expected_allow_agent=False,
+        )),
+        ('No credential at all leaves the agent enabled', dict(
+            tunnel_authentication=0,
+            resolved_identity_file=None,
+            stored_password=None,
+            expected_allow_agent=True,
+        )),
+        ('A missing credential is reported, not raised', dict(
+            tunnel_authentication=0,
+            resolved_identity_file=None,
+            stored_password=None,
+            expected_allow_agent=True,
+            forwarder_error=ValueError(
+                'No password or public key available!'),
+        )),
+    ]
+
+    # Overridden per scenario where the forwarder is meant to fail.
+    forwarder_error = None
+
+    def setUp(self):
+        # Deliberately no server connection: this exercises the argument
+        # marshalling in create_ssh_tunnel(), not a real tunnel.
+        if not config.SUPPORT_SSH_TUNNEL:
+            self.skipTest('SSH tunnelling is disabled in this configuration.')
+
+    def _make_manager(self):
+        manager = server_manager.ServerManager.__new__(
+            server_manager.ServerManager)
+        manager.tunnel_authentication = self.tunnel_authentication
+        manager.tunnel_host = 'tunnel.example.com'
+        manager.tunnel_port = 22
+        manager.tunnel_username = 'tunneluser'
+        manager.tunnel_identity_file = 'id_rsa'
+        manager.tunnel_keep_alive = 0
+        manager.host = 'db.example.com'
+        manager.port = 5432
+        manager.tunnel_object = None
+        manager.tunnel_created = False
+        return manager
+
+    def runTest(self):
+        manager = self._make_manager()
+        forwarder = MagicMock(side_effect=self.forwarder_error) \
+            if self.forwarder_error else MagicMock()
+
+        # A request context, not just an app context: the failure path calls
+        # gettext(), and pgAdmin's locale selector reads the request.
+        with self.app.test_request_context(), \
+            patch.object(server_manager, 'SSHTunnelForwarder', forwarder), \
+            patch.object(server_manager, 'User', MagicMock()), \
+            patch.object(server_manager, 'current_user', MagicMock()), \
+            patch.object(server_manager, 'get_complete_file_path',
+                         return_value=self.resolved_identity_file), \
+            patch.object(server_manager, 'get_crypt_key',
+                         return_value=(True, 'crypt-key')), \
+                patch.object(server_manager, 'decrypt',
+                             return_value=b'tunnelpassword'):
+            success, error = manager.create_ssh_tunnel(self.stored_password)
+
+        forwarder.assert_called_once()
+        self.assertEqual(forwarder.call_args.kwargs['allow_agent'],
+                         self.expected_allow_agent)
+
+        if self.forwarder_error:
+            self.assertFalse(success)
+            self.assertIn('Failed to create the SSH tunnel', error)
+        else:
+            self.assertTrue(success, msg=error)


### PR DESCRIPTION
### Summary

Fixes #9814.

When connecting through an SSH tunnel with an explicit identity file or password, pgAdmin still probed the SSH agent, causing repeated authentication attempts/denials (and prompts) from the agent.

**Root cause:** `SSHTunnelForwarder(...)` was called without `allow_agent`, which defaults to `True` in sshtunnel/paramiko.

**Fix:** pass `allow_agent=False` on both tunnel auth paths (identity file and password), since the user has explicitly supplied credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH tunnel authentication handling when an identity file or password is provided.
  * Preserved SSH agent authentication when no explicit credentials are available.
  * Improved error reporting for invalid or missing SSH tunnel credentials.
  * Resolved identity-file paths before establishing SSH tunnels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->