### PR TITLE
Add release notes scaffold for 9.16

### DIFF
--- a/docs/en_US/release_notes.rst
+++ b/docs/en_US/release_notes.rst
@@ -12,6 +12,7 @@ notes for it.
    :maxdepth: 1
 
 
+   release_notes_9_16
    release_notes_9_15
    release_notes_9_14
    release_notes_9_13

--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -1,0 +1,27 @@
+************
+Version 9.16
+************
+
+Release date: TBD
+
+This release contains a number of bug fixes and new features since the release of pgAdmin 4 v9.15.
+
+Supported Database Servers
+**************************
+**PostgreSQL**: 13, 14, 15, 16, 17 and 18
+
+**EDB Advanced Server**: 13, 14, 15, 16, 17 and 18
+
+Bundled PostgreSQL Utilities
+****************************
+**psql**, **pg_dump**, **pg_dumpall**, **pg_restore**: 18.4
+
+
+New features
+************
+
+Housekeeping
+************
+
+Bug fixes
+*********


### PR DESCRIPTION
### Summary

Creates `docs/en_US/release_notes_9_16.rst` (with empty *New features* / *Housekeeping* / *Bug fixes* sections) and adds it to the release-notes toctree.

This is intended to be merged **first**, so that the individual 9.16 fix/feature PRs can each add their one-line entry to the existing file instead of every PR recreating the file and the toctree line (which would conflict pairwise).

Note: this does not bump `version.py` — that can be done separately as part of opening the 9.16 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added v9.16 release notes entry to the documentation navigation.
  * Created initial v9.16 release notes skeleton with "Release date: TBD".
  * Included supported server lists for PostgreSQL and EDB Advanced Server (major versions 13–18).
  * Listed bundled PostgreSQL utilities (psql, pg_dump, pg_dumpall, pg_restore) with version 18.4.
  * Added placeholder sections for New features, Housekeeping, and Bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->