### PR TITLE
fix: avoid NameError in check_external_config_db when the DB is unreachable

### DIFF
--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -40,3 +40,4 @@ Bug fixes
   | `Issue #9939 <https://github.com/pgadmin-org/pgadmin4/issues/9939>`_ -  Fix saving a newly-added row in the Query Tool failing when the result set includes expression or alias columns that are not real columns of the underlying table.
   | `Issue #9976 <https://github.com/pgadmin-org/pgadmin4/issues/9976>`_ -  Fix a startup migration crash (NoSuchTableError) when an old configuration database contains a stale foreign-key reference.
   | `Issue #9984 <https://github.com/pgadmin-org/pgadmin4/issues/9984>`_ -  Fix the Docker entrypoint mishandling a quoted PGADMIN_CONFIG_CONFIG_DATABASE_URI, which caused a SQLAlchemy parse error and silently skipped PGADMIN_DEFAULT_EMAIL/PASSWORD setup.
+  | `Issue #10052 <https://github.com/pgadmin-org/pgadmin4/issues/10052>`_ -  Fix a crash when checking an unreachable external configuration database, so first-launch setup proceeds instead of erroring.

--- a/web/pgadmin/utils/check_external_config_db.py
+++ b/web/pgadmin/utils/check_external_config_db.py
@@ -17,11 +17,13 @@ def check_external_config_db(database_uri):
     """
     engine = create_engine(database_uri)
     try:
-        connection = engine.connect()
-        if inspect(engine).has_table("server"):
-            return True
-        return False
+        # The context manager closes the connection on every path. The
+        # previous "finally: connection.close()" raised NameError when
+        # engine.connect() itself failed (e.g. an unreachable database),
+        # masking the intended "return False".
+        with engine.connect():
+            return inspect(engine).has_table("server")
     except Exception:
         return False
     finally:
-        connection.close()
+        engine.dispose()

--- a/web/pgadmin/utils/check_external_config_db.py
+++ b/web/pgadmin/utils/check_external_config_db.py
@@ -16,12 +16,22 @@ def check_external_config_db(database_uri):
     Check if external config database exists if it
     is being used.
     """
-    engine = create_engine(normalize_database_uri(database_uri))
-    connection = None
+    engine = None
     try:
-        connection = engine.connect()
-        return inspect(engine).has_table("server")
+        engine = create_engine(normalize_database_uri(database_uri))
+        with engine.connect():
+            return inspect(engine).has_table("server")
+    except Exception:
+        # Anything that stops us reaching the database, a wrong password or
+        # an unreachable host as much as a malformed URI, is reported as
+        # "there is no external configuration database". The container
+        # entrypoint relies on that so first launch still creates the user
+        # from PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD (#9984)
+        # rather than leaving an installation nobody can log in to.
         return False
     finally:
-        if connection:
-            connection.close()
+        # Guarded because create_engine() itself rejects a malformed URI, and
+        # an unbound name in the cleanup path is what caused this bug in the
+        # first place.
+        if engine is not None:
+            engine.dispose()

--- a/web/pgadmin/utils/tests/test_check_external_config_db.py
+++ b/web/pgadmin/utils/tests/test_check_external_config_db.py
@@ -24,6 +24,7 @@ arrangement is ever broken.
 
 import os
 import sys
+from urllib.parse import quote
 
 from pgadmin.utils.route import BaseTestGenerator
 from regression.python_test_utils import test_utils as utils
@@ -54,9 +55,25 @@ class CheckExternalConfigDBTestCase(BaseTestGenerator):
         self.db_name = self.server['db']
 
     def _uri(self):
+        username = quote(str(self.server['username']), safe='')
+        password = quote(str(self.server['db_password']), safe='')
+        host = self.server['host']
+        port = self.server['port']
+
+        # A Unix domain socket directory (as used on the Linux/macOS test
+        # runners) can't be embedded in the URI's authority component: a
+        # "/" there is parsed as the start of the path, not part of the
+        # host, leaving the host/port undetermined and the database name
+        # mangled. libpq's URI form for that case instead leaves the
+        # authority's host empty and passes the socket directory as the
+        # "host" query parameter.
+        if '/' in str(host):
+            return 'postgresql://{0}:{1}@/{2}?host={3}&port={4}'.format(
+                username, password, self.db_name,
+                quote(str(host), safe=''), port)
+
         return 'postgresql://{0}:{1}@{2}:{3}/{4}'.format(
-            self.server['username'], self.server['db_password'],
-            self.server['host'], self.server['port'], self.db_name)
+            username, password, host, port, self.db_name)
 
     def _connect(self):
         return utils.get_db_connection(self.db_name,
@@ -88,9 +105,12 @@ class CheckExternalConfigDBTestCase(BaseTestGenerator):
             utils.set_isolation_level(connection, 0)
             cursor = connection.cursor()
             cursor.execute('CREATE TABLE public.server (id serial)')
+            # Recorded as soon as the table exists, before the isolation
+            # level restore and commit below, so tearDown still drops it
+            # if either of those later steps were to fail.
+            self.created_table = True
             utils.set_isolation_level(connection, old_isolation_level)
             connection.commit()
-            self.created_table = True
         finally:
             connection.close()
 
@@ -104,7 +124,7 @@ class CheckExternalConfigDBTestCase(BaseTestGenerator):
             old_isolation_level = connection.isolation_level
             utils.set_isolation_level(connection, 0)
             cursor = connection.cursor()
-            cursor.execute('DROP TABLE public.server')
+            cursor.execute('DROP TABLE IF EXISTS public.server')
             utils.set_isolation_level(connection, old_isolation_level)
             connection.commit()
         finally:

--- a/web/pgadmin/utils/tests/test_check_external_config_db.py
+++ b/web/pgadmin/utils/tests/test_check_external_config_db.py
@@ -1,0 +1,111 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+"""Tests for check_external_config_db().
+
+The container entrypoint calls this to decide whether an external
+configuration database has already been initialised, and treats anything
+other than "True" as "no, so run first-launch setup". It therefore has to
+answer False rather than raise when the database cannot be reached at all,
+which the previous "finally: connection.close()" prevented: engine.connect()
+failing left connection unbound and the NameError escaped in place of the
+answer.
+
+The module is imported the way the entrypoint imports it, as a top level
+module from the directory it lives in, so that this also fails if that
+arrangement is ever broken.
+"""
+
+import os
+import sys
+
+from pgadmin.utils.route import BaseTestGenerator
+from regression.python_test_utils import test_utils as utils
+
+UTILS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if UTILS_DIR not in sys.path:
+    sys.path.append(UTILS_DIR)
+
+from check_external_config_db import check_external_config_db  # noqa: E402
+
+
+class CheckExternalConfigDBTestCase(BaseTestGenerator):
+    """check_external_config_db() must answer, not raise."""
+
+    scenarios = [
+        ('An unreachable host answers False', dict(
+            case='unreachable')),
+        ('A malformed URI answers False', dict(
+            case='malformed')),
+        ('A reachable database with no server table answers False', dict(
+            case='reachable_without_table')),
+        ('A reachable database with a server table answers True', dict(
+            case='reachable_with_table')),
+    ]
+
+    def setUp(self):
+        self.created_table = False
+        self.db_name = self.server['db']
+
+    def _uri(self):
+        return 'postgresql://{0}:{1}@{2}:{3}/{4}'.format(
+            self.server['username'], self.server['db_password'],
+            self.server['host'], self.server['port'], self.db_name)
+
+    def _connect(self):
+        return utils.get_db_connection(self.db_name,
+                                       self.server['username'],
+                                       self.server['db_password'],
+                                       self.server['host'],
+                                       self.server['port'],
+                                       self.server['sslmode'])
+
+    def runTest(self):
+        if self.case == 'unreachable':
+            # Port 1 is not something a PostgreSQL server listens on, so the
+            # connection is refused rather than timing out.
+            self.assertFalse(check_external_config_db(
+                'postgresql://pgadmin:pgadmin@127.0.0.1:1/pgadmin'))
+            return
+
+        if self.case == 'malformed':
+            self.assertFalse(check_external_config_db('not a uri at all'))
+            return
+
+        if self.case == 'reachable_without_table':
+            self.assertFalse(check_external_config_db(self._uri()))
+            return
+
+        connection = self._connect()
+        try:
+            old_isolation_level = connection.isolation_level
+            utils.set_isolation_level(connection, 0)
+            cursor = connection.cursor()
+            cursor.execute('CREATE TABLE public.server (id serial)')
+            utils.set_isolation_level(connection, old_isolation_level)
+            connection.commit()
+            self.created_table = True
+        finally:
+            connection.close()
+
+        self.assertTrue(check_external_config_db(self._uri()))
+
+    def tearDown(self):
+        if not self.created_table:
+            return
+        connection = self._connect()
+        try:
+            old_isolation_level = connection.isolation_level
+            utils.set_isolation_level(connection, 0)
+            cursor = connection.cursor()
+            cursor.execute('DROP TABLE public.server')
+            utils.set_isolation_level(connection, old_isolation_level)
+            connection.commit()
+        finally:
+            connection.close()


### PR DESCRIPTION
## Problem

`check_external_config_db()` (used by the Docker entrypoint to decide whether to run first-launch user setup) closes its connection in a `finally` block:

```python
try:
    connection = engine.connect()
    ...
except Exception:
    return False
finally:
    connection.close()
```

When `engine.connect()` itself fails — e.g. the external config database is **unreachable** — the `connection` local is never bound, so the `finally` raises `UnboundLocalError`, which propagates out and **masks the intended `return False`**.

Surfaced while reviewing #10009 (the entrypoint now tolerates a non-zero exit from this script, but the function should still behave correctly on its own).

## Fix

Use the connection as a context manager (closed on every path, no unbound-name reference) and dispose the engine in `finally`:

```python
with engine.connect():
    return inspect(engine).has_table("server")
```

## Verification (live PostgreSQL 18)

| Case | Before | After |
|---|---|---|
| Reachable, no `server` table | `False` | `False` |
| Reachable, `server` table present | `True` | `True` |
| **Unreachable** (bad port) | **`UnboundLocalError`** | `False` |

- `pycodestyle` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external database configuration checks to handle unavailable or malformed database connections more reliably.
  * Prevented secondary cleanup errors when connection setup fails.
  * Preserved accurate validation results for missing or present required database tables.

* **Tests**
  * Added coverage for unreachable, malformed, incomplete, and correctly configured databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->