### PR TITLE
Keyboard shortcut improvements: tab switching, editor duplicate-line, dialog Enter/Escape

### DIFF
--- a/docs/en_US/keyboard_shortcuts.rst
+++ b/docs/en_US/keyboard_shortcuts.rst
@@ -44,9 +44,9 @@ When using main browser window, the following keyboard shortcuts are available:
    +----------------------------+--------------------+------------------------------------+
    | Shift + Alt + s            | Shift + Option + s | Search objects                     |
    +----------------------------+--------------------+------------------------------------+
-   | Shift + Alt + [            | Shift + Option + [ | Tabbed panel backward              |
+   | Ctrl + Alt + [             | Ctrl + Option + [  | Tabbed panel backward              |
    +----------------------------+--------------------+------------------------------------+
-   | Shift + Alt + ]            | Shift + Option + ] | Tabbed panel forward               |
+   | Ctrl + Alt + ]             | Ctrl + Option + ]  | Tabbed panel forward               |
    +----------------------------+--------------------+------------------------------------+
    | Shift + Alt + w            | Shift + Ctrl + w   | Close tab panel                    |
    +----------------------------+--------------------+------------------------------------+
@@ -97,6 +97,8 @@ When using the syntax-highlighting SQL editors, the following shortcuts are avai
    | Ctrl + Alt + Right       | Cmd + Option + Right | Move right one word                 |
    +--------------------------+----------------------+-------------------------------------+
    | Ctrl + /                 | Cmd + /              | Comment/Uncomment code (Block)      |
+   +--------------------------+----------------------+-------------------------------------+
+   | Ctrl + Shift + d         | Cmd + Shift + d      | Duplicate current line/selection    |
    +--------------------------+----------------------+-------------------------------------+
    | Ctrl + a                 | Cmd + a              | Select all                          |
    +--------------------------+----------------------+-------------------------------------+

--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -44,7 +44,7 @@ Bug fixes
 *********
 
   | `Issue #6308 <https://github.com/pgadmin-org/pgadmin4/issues/6308>`_ -  Fix the infinite loading spinner after an idle database connection is silently dropped, by detecting stale connections and offering a reconnect dialog.
-  | `Issue #7232 <https://github.com/pgadmin-org/pgadmin4/issues/7232>`_ -  Fix the tabbed panel forward/backward shortcut not switching the main tabs when keyboard focus is inside a tool (SQL editor, PSQL terminal, ERD or Schema Diff). The default shortcut is now Ctrl/Cmd+Alt+] / [ to avoid colliding with the Query Tool's inner-panel navigation.
+  | `Issue #7232 <https://github.com/pgadmin-org/pgadmin4/issues/7232>`_ -  Fix the tabbed panel forward/backward shortcut not switching the main tabs when keyboard focus is inside a tool (SQL editor, PSQL terminal, ERD or Schema Diff). The default shortcut is now Ctrl+Alt+] / [ (Ctrl+Option on macOS) to avoid colliding with the Query Tool's inner-panel navigation.
   | `Issue #9595 <https://github.com/pgadmin-org/pgadmin4/issues/9595>`_ -  Fix missing ALTER ... SET DEFAULT statements for inherited columns in the generated table SQL/EDIT script.
   | `Issue #9677 <https://github.com/pgadmin-org/pgadmin4/issues/9677>`_ -  Fix the Unlogged table toggle in table properties not generating any ALTER TABLE ... SET LOGGED/UNLOGGED statement.
   | `Issue #9828 <https://github.com/pgadmin-org/pgadmin4/issues/9828>`_ -  Fix tool calls failing against OpenAI-compatible providers that emit empty/null name, arguments, or id fields in streaming continuation deltas.

--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -26,6 +26,10 @@ Bundled PostgreSQL Utilities
 New features
 ************
 
+  | `Issue #3834 <https://github.com/pgadmin-org/pgadmin4/issues/3834>`_ -  Add a keyboard shortcut (Ctrl/Cmd+Shift+D) to duplicate the current line or selection in the SQL editor.
+  | `Issue #5196 <https://github.com/pgadmin-org/pgadmin4/issues/5196>`_ -  Allow the close/unsaved-changes confirmation and other dialogs to be operated from the keyboard (Enter to confirm/save, Escape to cancel) without tabbing to the buttons.
+  | `Issue #5691 <https://github.com/pgadmin-org/pgadmin4/issues/5691>`_ -  Allow closing the Properties, Backup and other object/utility dialogs with the Escape key.
+  | `Issue #7167 <https://github.com/pgadmin-org/pgadmin4/issues/7167>`_ -  Add Ctrl/Cmd+Enter to save and close object and utility dialogs, including the Query Tool sort/filter dialog.
   | `Issue #9626 <https://github.com/pgadmin-org/pgadmin4/issues/9626>`_ -  Add support for the TOAST tuple target storage parameter in the Materialized View dialog.
   | `Issue #9646 <https://github.com/pgadmin-org/pgadmin4/issues/9646>`_ -  Make the init container security context in the Helm chart configurable via containerSecurityContext, consistent with the main container.
   | `Issue #9699 <https://github.com/pgadmin-org/pgadmin4/issues/9699>`_ -  Add support for closing a tab with a middle-click on its title.
@@ -40,6 +44,7 @@ Bug fixes
 *********
 
   | `Issue #6308 <https://github.com/pgadmin-org/pgadmin4/issues/6308>`_ -  Fix the infinite loading spinner after an idle database connection is silently dropped, by detecting stale connections and offering a reconnect dialog.
+  | `Issue #7232 <https://github.com/pgadmin-org/pgadmin4/issues/7232>`_ -  Fix the tabbed panel forward/backward shortcut not switching the main tabs when keyboard focus is inside a tool (SQL editor, PSQL terminal, ERD or Schema Diff). The default shortcut is now Ctrl/Cmd+Alt+] / [ to avoid colliding with the Query Tool's inner-panel navigation.
   | `Issue #9595 <https://github.com/pgadmin-org/pgadmin4/issues/9595>`_ -  Fix missing ALTER ... SET DEFAULT statements for inherited columns in the generated table SQL/EDIT script.
   | `Issue #9677 <https://github.com/pgadmin-org/pgadmin4/issues/9677>`_ -  Fix the Unlogged table toggle in table properties not generating any ALTER TABLE ... SET LOGGED/UNLOGGED statement.
   | `Issue #9828 <https://github.com/pgadmin-org/pgadmin4/issues/9828>`_ -  Fix tool calls failing against OpenAI-compatible providers that emit empty/null name, arguments, or id fields in streaming continuation deltas.

--- a/web/pgadmin/browser/register_browser_preferences.py
+++ b/web/pgadmin/browser/register_browser_preferences.py
@@ -170,9 +170,9 @@ def register_browser_preferences(self):
         'keyboardshortcut',
         {
             'alt': True,
-            'shift': True,
-            'control': False,
-            'key': {'key_code': 91, 'char': '['}
+            'shift': False,
+            'control': True,
+            'key': {'key_code': 219, 'char': '['}
         },
         category_label=PREF_LABEL_KEYBOARD_SHORTCUTS,
         fields=fields
@@ -200,9 +200,9 @@ def register_browser_preferences(self):
         'keyboardshortcut',
         {
             'alt': True,
-            'shift': True,
-            'control': False,
-            'key': {'key_code': 93, 'char': ']'}
+            'shift': False,
+            'control': True,
+            'key': {'key_code': 221, 'char': ']'}
         },
         category_label=PREF_LABEL_KEYBOARD_SHORTCUTS,
         fields=fields

--- a/web/pgadmin/browser/static/js/keyboard.js
+++ b/web/pgadmin/browser/static/js/keyboard.js
@@ -149,42 +149,37 @@ _.extend(pgBrowser.keyboardNavigation, {
   bindRightPanel: function(event, combo) {
     const self = this;
     const shortcutObj = this.keyboardShortcut;
-    const activeElement = document.activeElement;
+    const rootDock = document.getElementById('root');
+    if (!rootDock) return;
 
-    if (activeElement.closest('.dock-tab-btn')) {
-      const currDockTab = activeElement.closest('.dock-tab-btn');
-      const dockLayout = currDockTab.closest('.dock-layout');
-      const dockLayoutTabs = dockLayout ? Array.from(dockLayout.querySelectorAll('.dock-tab-btn')) : null;
+    // Find the active workspace tab independently of where the keyboard focus
+    // currently sits. Previously this relied on document.activeElement, which
+    // breaks when focus is inside a tool's own (nested) dock layout - the SQL
+    // editor, an ERD/Schema Diff canvas - or inside the PSQL iframe, because
+    // the resolved tab id then belonged to the tool's inner tab rather than a
+    // main workspace tab (issue #7232).
+    //
+    // rc-dock renders the object explorer and the workspace as separate
+    // tab-sets, and each marks its own active tab with `dock-tab-active`, so
+    // prefer the active tab that is not the object explorer.
+    const activeTabBtns = Array.from(
+      rootDock.querySelectorAll('.dock-tab.dock-tab-active .dock-tab-btn'));
+    const activeTabBtn =
+      activeTabBtns.find(tab => !tab.id.includes('id-object-explorer')) ||
+      activeTabBtns[0];
+    if (!activeTabBtn) return;
 
-      if (dockLayoutTabs && dockLayoutTabs.length > 1) {
-        const activeTabIndex = dockLayoutTabs.indexOf(currDockTab);
-        self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
-      }
-    }
-    else if (activeElement.nodeName === 'IFRAME' || activeElement.closest('.dock-tabpane.dock-tabpane-active')) {
-      let activeTabId = '';
-      activeTabId = (activeElement.nodeName === 'IFRAME') ? activeElement.id : activeElement.closest('.dock-tabpane.dock-tabpane-active').id;
-      const dockLayout = document.getElementById('root');
-      const dockLayoutTabs = dockLayout ? Array.from(dockLayout.querySelectorAll('.dock-tab-btn')) : null;
+    // Restrict navigation to the tabs of the same tab-set (dock panel) as the
+    // active tab, so cycling stays within the workspace tabs and does not
+    // include the object explorer or a tool's nested tabs.
+    const panel = activeTabBtn.closest('.dock-panel');
+    const dockLayoutTabs = panel ? Array.from(
+      panel.querySelectorAll('.dock-tab-btn'))
+      .filter(tab => tab.closest('.dock-panel') === panel) : [];
 
-      if (dockLayoutTabs && dockLayoutTabs.length > 1 && activeTabId) {
-        const activeTabIndex = dockLayoutTabs.findIndex(tab => tab.id.slice(14) === activeTabId);
-        self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
-      }
-    }
-    else if (activeElement === document.body || document.querySelector('div[data-test="app-menu-bar"]')) {
-      const activeTabs = document.getElementsByClassName('dock-tabpane dock-tabpane-active');
-
-      if (activeTabs.length > 1) {
-        const activeTabId = activeTabs[1].id;
-        const dockLayout = document.getElementById('root');
-        const dockLayoutTabs = dockLayout ? Array.from(dockLayout.querySelectorAll('.dock-tab-btn')) : null;
-
-        if (dockLayoutTabs && dockLayoutTabs.length > 1 && activeTabId) {
-          const activeTabIndex = dockLayoutTabs.findIndex(tab => tab.id.slice(14) === activeTabId);
-          self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
-        }
-      }
+    if (dockLayoutTabs.length > 1) {
+      const activeTabIndex = dockLayoutTabs.indexOf(activeTabBtn);
+      self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
     }
   },
   _focusTab: function(dockLayoutTabs, activeTabIdx, shortcut_obj, combo){

--- a/web/pgadmin/browser/static/js/keyboard.js
+++ b/web/pgadmin/browser/static/js/keyboard.js
@@ -163,8 +163,19 @@ _.extend(pgBrowser.keyboardNavigation, {
     // rc-dock renders the object explorer and the workspace as separate
     // tab-sets, and each marks its own active tab with `dock-tab-active`, so
     // prefer the active tab that is not the object explorer.
+    //
+    // Only the outermost dock layout is considered. The SQL editor, ERD and
+    // Schema Diff each render a DockLayout of their own inside a workspace
+    // tab, and their active tabs (Data Output, Messages, Notifications and
+    // so on) carry the same `dock-tab-active` class, so a search across the
+    // whole tree can land on one of those and cycle a tool's inner tabs
+    // instead of the workspace tabs it was asked to move between.
+    const topDockLayout = rootDock.querySelector('.dock-layout');
+    if (!topDockLayout) return;
+
     const activeTabBtns = Array.from(
-      rootDock.querySelectorAll('.dock-tab.dock-tab-active .dock-tab-btn'));
+      topDockLayout.querySelectorAll('.dock-tab.dock-tab-active .dock-tab-btn')
+    ).filter(tab => tab.closest('.dock-layout') === topDockLayout);
     const activeTabBtn =
       activeTabBtns.find(tab => !tab.id.includes('id-object-explorer')) ||
       activeTabBtns[0];
@@ -176,7 +187,8 @@ _.extend(pgBrowser.keyboardNavigation, {
     const panel = activeTabBtn.closest('.dock-panel');
     const dockLayoutTabs = panel ? Array.from(
       panel.querySelectorAll('.dock-tab-btn'))
-      .filter(tab => tab.closest('.dock-panel') === panel) : [];
+      .filter(tab => tab.closest('.dock-panel') === panel &&
+        tab.closest('.dock-layout') === topDockLayout) : [];
 
     if (dockLayoutTabs.length > 1) {
       const activeTabIndex = dockLayoutTabs.indexOf(activeTabBtn);

--- a/web/pgadmin/browser/static/js/keyboard.js
+++ b/web/pgadmin/browser/static/js/keyboard.js
@@ -150,42 +150,37 @@ _.extend(pgBrowser.keyboardNavigation, {
   bindRightPanel: function(event, combo) {
     const self = this;
     const shortcutObj = this.keyboardShortcut;
-    const activeElement = document.activeElement;
+    const rootDock = document.getElementById('root');
+    if (!rootDock) return;
 
-    if (activeElement.closest('.dock-tab-btn')) {
-      const currDockTab = activeElement.closest('.dock-tab-btn');
-      const dockLayout = currDockTab.closest('.dock-layout');
-      const dockLayoutTabs = dockLayout ? Array.from(dockLayout.querySelectorAll('.dock-tab-btn')) : null;
+    // Find the active workspace tab independently of where the keyboard focus
+    // currently sits. Previously this relied on document.activeElement, which
+    // breaks when focus is inside a tool's own (nested) dock layout - the SQL
+    // editor, an ERD/Schema Diff canvas - or inside the PSQL iframe, because
+    // the resolved tab id then belonged to the tool's inner tab rather than a
+    // main workspace tab (issue #7232).
+    //
+    // rc-dock renders the object explorer and the workspace as separate
+    // tab-sets, and each marks its own active tab with `dock-tab-active`, so
+    // prefer the active tab that is not the object explorer.
+    const activeTabBtns = Array.from(
+      rootDock.querySelectorAll('.dock-tab.dock-tab-active .dock-tab-btn'));
+    const activeTabBtn =
+      activeTabBtns.find(tab => !tab.id.includes('id-object-explorer')) ||
+      activeTabBtns[0];
+    if (!activeTabBtn) return;
 
-      if (dockLayoutTabs && dockLayoutTabs.length > 1) {
-        const activeTabIndex = dockLayoutTabs.indexOf(currDockTab);
-        self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
-      }
-    }
-    else if (activeElement.nodeName === 'IFRAME' || activeElement.closest('.dock-tabpane.dock-tabpane-active')) {
-      let activeTabId = '';
-      activeTabId = (activeElement.nodeName === 'IFRAME') ? activeElement.id : activeElement.closest('.dock-tabpane.dock-tabpane-active').id;
-      const dockLayout = document.getElementById('root');
-      const dockLayoutTabs = dockLayout ? Array.from(dockLayout.querySelectorAll('.dock-tab-btn')) : null;
+    // Restrict navigation to the tabs of the same tab-set (dock panel) as the
+    // active tab, so cycling stays within the workspace tabs and does not
+    // include the object explorer or a tool's nested tabs.
+    const panel = activeTabBtn.closest('.dock-panel');
+    const dockLayoutTabs = panel ? Array.from(
+      panel.querySelectorAll('.dock-tab-btn'))
+      .filter(tab => tab.closest('.dock-panel') === panel) : [];
 
-      if (dockLayoutTabs && dockLayoutTabs.length > 1 && activeTabId) {
-        const activeTabIndex = dockLayoutTabs.findIndex(tab => tab.id.slice(14) === activeTabId);
-        self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
-      }
-    }
-    else if (activeElement === document.body || document.querySelector('div[data-test="app-menu-bar"]')) {
-      const activeTabs = document.getElementsByClassName('dock-tabpane dock-tabpane-active');
-
-      if (activeTabs.length > 1) {
-        const activeTabId = activeTabs[1].id;
-        const dockLayout = document.getElementById('root');
-        const dockLayoutTabs = dockLayout ? Array.from(dockLayout.querySelectorAll('.dock-tab-btn')) : null;
-
-        if (dockLayoutTabs && dockLayoutTabs.length > 1 && activeTabId) {
-          const activeTabIndex = dockLayoutTabs.findIndex(tab => tab.id.slice(14) === activeTabId);
-          self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
-        }
-      }
+    if (dockLayoutTabs.length > 1) {
+      const activeTabIndex = dockLayoutTabs.indexOf(activeTabBtn);
+      self._focusTab(dockLayoutTabs, activeTabIndex, shortcutObj, combo);
     }
   },
   _focusTab: function(dockLayoutTabs, activeTabIdx, shortcut_obj, combo){

--- a/web/pgadmin/static/js/SchemaView/SchemaDialogView.jsx
+++ b/web/pgadmin/static/js/SchemaView/SchemaDialogView.jsx
@@ -177,9 +177,32 @@ export default function SchemaDialogView({
     return <SaveIcon />;
   };
 
+  const onKeyDown = (e) => {
+    // Ctrl/Cmd+Enter saves and closes the dialog from anywhere within it
+    // (issue #7167). onSaveClick is a no-op when there is nothing to save or
+    // there is a validation error, so this is safe to call unconditionally.
+    if ((e.ctrlKey || e.metaKey) && !e.altKey && e.key === 'Enter') {
+      e.preventDefault();
+      onSaveClick();
+      return;
+    }
+
+    // Escape closes the dialog, mirroring the Close button (issue #5691).
+    // This is needed for dialogs rendered as dockable panels (Properties,
+    // Backup, and other utility dialogs); dialogs rendered inside a MUI modal
+    // already close on Escape, so skip those to avoid a double close. The
+    // !e.defaultPrevented guard lets an inner control that handles Escape
+    // (e.g. an open dropdown) consume it first.
+    if (e.key === 'Escape' && !e.defaultPrevented && props.onClose &&
+        !e.currentTarget.closest('.MuiDialog-root')) {
+      e.preventDefault();
+      props.onClose();
+    }
+  };
+
   /* I am Groot */
   return useMemo(() =>
-    <StyledBox>
+    <StyledBox onKeyDown={onKeyDown}>
       <SchemaStateContext.Provider value={schemaState}>
         <Box className='Dialog-form'>
           <FormLoader/>

--- a/web/pgadmin/static/js/SchemaView/SchemaDialogView.jsx
+++ b/web/pgadmin/static/js/SchemaView/SchemaDialogView.jsx
@@ -97,7 +97,7 @@ export default function SchemaDialogView({
     );
   };
 
-  const save = (changeData) => {
+  const save = (changeData, onSaved) => {
     props.onSave(schemaState.isNew, changeData)
       .then(()=>{
         if(schema.informText) {
@@ -106,6 +106,7 @@ export default function SchemaDialogView({
             schema.informText,
           );
         }
+        onSaved?.();
       }).catch((err)=>{
         schemaState.setError({
           name: 'apierror',
@@ -119,7 +120,11 @@ export default function SchemaDialogView({
       });
   };
 
-  const onSaveClick = () => {
+  // closeOnSave is only ever passed explicitly as true, by the Ctrl/Cmd+Enter
+  // handler below. The Save button's onClick passes its click event instead,
+  // which is never === true, so a plain Save click keeps its existing
+  // behaviour (some dialogs, e.g. object properties, stay open after Save).
+  const onSaveClick = (closeOnSave) => {
     // Do nothing when there is no change or there is an error
     if (
       !schemaState._changes || Object.keys(schemaState._changes).length === 0 ||
@@ -129,15 +134,17 @@ export default function SchemaDialogView({
     setSaving(true);
     setLoaderText(schemaState.customLoadingText || gettext('Saving...'));
 
+    const onSaved = closeOnSave === true ? () => props.onClose?.() : undefined;
+
     if (!schema.warningText) {
-      save(schemaState.changes(true));
+      save(schemaState.changes(true), onSaved);
       return;
     }
 
     Notifier.confirm(
       gettext('Warning'),
       schema.warningText,
-      () => { save(schemaState.changes(true)); },
+      () => { save(schemaState.changes(true), onSaved); },
       () => {
         setSaving(false);
         setLoaderText('');
@@ -183,7 +190,7 @@ export default function SchemaDialogView({
     // there is a validation error, so this is safe to call unconditionally.
     if ((e.ctrlKey || e.metaKey) && !e.altKey && e.key === 'Enter') {
       e.preventDefault();
-      onSaveClick();
+      onSaveClick(true);
       return;
     }
 

--- a/web/pgadmin/static/js/SchemaView/SchemaDialogView.jsx
+++ b/web/pgadmin/static/js/SchemaView/SchemaDialogView.jsx
@@ -201,8 +201,11 @@ export default function SchemaDialogView({
   };
 
   /* I am Groot */
-  return useMemo(() =>
-    <StyledBox onKeyDown={onKeyDown}>
+  // Only the children are memoized: the wrapper carries onKeyDown, which
+  // closes over props.onClose and onSaveClick, and memoizing it would pin
+  // whichever versions of those existed when the deps last changed.
+  const dialogContent = useMemo(() =>
+    <>
       <SchemaStateContext.Provider value={schemaState}>
         <Box className='Dialog-form'>
           <FormLoader/>
@@ -257,8 +260,10 @@ export default function SchemaDialogView({
           </Box>
         }
       </SchemaStateContext.Provider>
-    </StyledBox>, [schema._id, viewHelperProps.mode, resetKey]
+    </>, [schema._id, viewHelperProps.mode, resetKey]
   );
+
+  return <StyledBox onKeyDown={onKeyDown}>{dialogContent}</StyledBox>;
 }
 
 SchemaDialogView.propTypes = {

--- a/web/pgadmin/static/js/components/ReactCodeMirror/components/Editor.jsx
+++ b/web/pgadmin/static/js/components/ReactCodeMirror/components/Editor.jsx
@@ -31,7 +31,7 @@ import {
   keymap,
 } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
-import { history, defaultKeymap, historyKeymap, indentLess, indentMore, deleteCharBackwardStrict } from '@codemirror/commands';
+import { history, defaultKeymap, historyKeymap, indentLess, indentMore, deleteCharBackwardStrict, copyLineDown } from '@codemirror/commands';
 import { closeBrackets, autocompletion, closeBracketsKeymap, completionKeymap, acceptCompletion } from '@codemirror/autocomplete';
 import {
   foldGutter,
@@ -137,6 +137,12 @@ const defaultExtensions = [
     key: 'Backspace',
     preventDefault: true,
     run: deleteCharBackwardStrict,
+  },{
+    // Duplicate the current line, or the selected lines if there is a
+    // selection (issue #3834).
+    key: 'Mod-Shift-d',
+    preventDefault: true,
+    run: copyLineDown,
   }]),
   PgSQL.language.data.of({
     autocomplete: false,

--- a/web/pgadmin/static/js/components/ReactCodeMirror/components/Editor.jsx
+++ b/web/pgadmin/static/js/components/ReactCodeMirror/components/Editor.jsx
@@ -30,7 +30,7 @@ import {
   keymap,
 } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
-import { history, defaultKeymap, historyKeymap, indentLess, indentMore, deleteCharBackwardStrict } from '@codemirror/commands';
+import { history, defaultKeymap, historyKeymap, indentLess, indentMore, deleteCharBackwardStrict, copyLineDown } from '@codemirror/commands';
 import { closeBrackets, autocompletion, closeBracketsKeymap, completionKeymap, acceptCompletion } from '@codemirror/autocomplete';
 import {
   foldGutter,
@@ -140,6 +140,12 @@ const defaultExtensions = [
     key: 'Backspace',
     preventDefault: true,
     run: deleteCharBackwardStrict,
+  },{
+    // Duplicate the current line, or the selected lines if there is a
+    // selection (issue #3834).
+    key: 'Mod-Shift-d',
+    preventDefault: true,
+    run: copyLineDown,
   }]),
   PgSQL.language.data.of({
     autocomplete: false,

--- a/web/regression/javascript/SchemaView/SchemaDialogViewKeyboard.spec.js
+++ b/web/regression/javascript/SchemaView/SchemaDialogViewKeyboard.spec.js
@@ -1,0 +1,102 @@
+/////////////////////////////////////////////////////////////
+//
+// pgAdmin 4 - PostgreSQL Tools
+//
+// Copyright (C) 2013 - 2026, The pgAdmin Development Team
+// This software is released under the PostgreSQL Licence
+//
+//////////////////////////////////////////////////////////////
+
+import { act, fireEvent, render } from '@testing-library/react';
+
+import SchemaView from '../../../pgadmin/static/js/SchemaView';
+import { TestSchema } from './TestSchema.ui';
+import { withBrowser } from '../genericFunctions';
+
+// Escape closes a dialog rendered as a dockable panel (issue #5691). The
+// handler sits on the dialog wrapper, which must not be memoized along with
+// the dialog body: the body only changes with the schema, the mode or the
+// reset key, whereas onClose is a fresh function on most parent renders, and
+// a memoized wrapper would keep calling whichever one it captured first.
+describe('SchemaDialogView keyboard handling', () => {
+  const SchemaViewWithBrowser = withBrowser(SchemaView);
+
+  const dialog = (schema, onClose) => (
+    <SchemaViewWithBrowser
+      formType='dialog'
+      schema={schema}
+      viewHelperProps={{mode: 'create'}}
+      onSave={jest.fn(() => Promise.resolve())}
+      onClose={onClose}
+      onHelp={jest.fn()}
+      onEdit={jest.fn()}
+      onDataChange={jest.fn()}
+      hasSQL={false}
+      disableSqlHelp={true}
+      disableDialogHelp={true}
+    />
+  );
+
+  const renderDialog = async (onClose) => {
+    let ctrl;
+    await act(async () => {
+      ctrl = render(
+        <SchemaViewWithBrowser
+          formType='dialog'
+          schema={new TestSchema()}
+          viewHelperProps={{mode: 'create'}}
+          onSave={jest.fn(() => Promise.resolve())}
+          onClose={onClose}
+          onHelp={jest.fn()}
+          onEdit={jest.fn()}
+          onDataChange={jest.fn()}
+          hasSQL={false}
+          disableSqlHelp={true}
+          disableDialogHelp={true}
+        />
+      );
+    });
+    return ctrl;
+  };
+
+  const pressEscape = async (ctrl) => {
+    await act(async () => {
+      fireEvent.keyDown(ctrl.container.firstChild, {key: 'Escape'});
+    });
+  };
+
+  it('closes the dialog on Escape', async () => {
+    const onClose = jest.fn();
+    const ctrl = await renderDialog(onClose);
+
+    await pressEscape(ctrl);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls the current onClose, not the one from the first render',
+    async () => {
+      const firstOnClose = jest.fn();
+      const secondOnClose = jest.fn();
+      // The same schema throughout: the memo deps are the schema id, the mode
+      // and the reset key, so this is the case where nothing invalidates the
+      // memo and only the callback has changed.
+      const schema = new TestSchema();
+
+      let ctrl;
+      await act(async () => {
+        ctrl = render(dialog(schema, firstOnClose));
+      });
+
+      // The parent re-renders with a new callback, as it does whenever it
+      // defines onClose inline.
+      await act(async () => {
+        ctrl.rerender(dialog(schema, secondOnClose));
+      });
+
+      await pressEscape(ctrl);
+
+      expect(secondOnClose).toHaveBeenCalled();
+      expect(firstOnClose).not.toHaveBeenCalled();
+    });
+});

--- a/web/regression/javascript/SchemaView/SchemaDialogViewKeyboard.spec.js
+++ b/web/regression/javascript/SchemaView/SchemaDialogViewKeyboard.spec.js
@@ -7,11 +7,31 @@
 //
 //////////////////////////////////////////////////////////////
 
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
+import BaseUISchema from 'sources/SchemaView/base_schema.ui';
 import SchemaView from '../../../pgadmin/static/js/SchemaView';
 import { TestSchema } from './TestSchema.ui';
 import { withBrowser } from '../genericFunctions';
+
+// A single required field is all the Ctrl/Cmd+Enter save-and-close tests
+// need; TestSchema's nested tab and row collection require a lot more
+// simulated input just to get to a savable state.
+class MinimalSchema extends BaseUISchema {
+  constructor() {
+    super({field1: null});
+  }
+
+  get baseFields() {
+    return [
+      {
+        id: 'field1', label: 'Field1', type: 'text', group: null,
+        mode: ['properties', 'edit', 'create'], disabled: false, visible: true,
+      },
+    ];
+  }
+}
 
 // Escape closes a dialog rendered as a dockable panel (issue #5691). The
 // handler sits on the dialog wrapper, which must not be memoized along with
@@ -20,6 +40,7 @@ import { withBrowser } from '../genericFunctions';
 // a memoized wrapper would keep calling whichever one it captured first.
 describe('SchemaDialogView keyboard handling', () => {
   const SchemaViewWithBrowser = withBrowser(SchemaView);
+  const user = userEvent.setup();
 
   const dialog = (schema, onClose) => (
     <SchemaViewWithBrowser
@@ -37,15 +58,15 @@ describe('SchemaDialogView keyboard handling', () => {
     />
   );
 
-  const renderDialog = async (onClose) => {
+  const renderDialog = async (onClose, onSave = jest.fn(() => Promise.resolve()), schema = new TestSchema()) => {
     let ctrl;
     await act(async () => {
       ctrl = render(
         <SchemaViewWithBrowser
           formType='dialog'
-          schema={new TestSchema()}
+          schema={schema}
           viewHelperProps={{mode: 'create'}}
-          onSave={jest.fn(() => Promise.resolve())}
+          onSave={onSave}
           onClose={onClose}
           onHelp={jest.fn()}
           onEdit={jest.fn()}
@@ -62,6 +83,12 @@ describe('SchemaDialogView keyboard handling', () => {
   const pressEscape = async (ctrl) => {
     await act(async () => {
       fireEvent.keyDown(ctrl.container.firstChild, {key: 'Escape'});
+    });
+  };
+
+  const pressCtrlEnter = async (ctrl) => {
+    await act(async () => {
+      fireEvent.keyDown(ctrl.container.firstChild, {key: 'Enter', ctrlKey: true});
     });
   };
 
@@ -99,4 +126,25 @@ describe('SchemaDialogView keyboard handling', () => {
       expect(secondOnClose).toHaveBeenCalled();
       expect(firstOnClose).not.toHaveBeenCalled();
     });
+
+  // Ctrl/Cmd+Enter is meant to save and close in one step (issue #7167).
+  // onSaveClick alone is not enough: it only calls onSave, so this covers the
+  // dialog actually closing once that save resolves.
+  it('saves and closes the dialog on Ctrl/Cmd+Enter', async () => {
+    const onClose = jest.fn();
+    const onSave = jest.fn(() => Promise.resolve());
+    const ctrl = await renderDialog(onClose, onSave, new MinimalSchema());
+
+    // Wait for the dialog's auto-focus to settle before typing, as the other
+    // SchemaDialogView specs do.
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 500));
+    });
+    await user.type(ctrl.container.querySelector('[name="field1"]'), 'val1');
+
+    await pressCtrlEnter(ctrl);
+
+    expect(onSave).toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
 });

--- a/web/regression/javascript/browser/keyboard_navigation_spec.js
+++ b/web/regression/javascript/browser/keyboard_navigation_spec.js
@@ -1,0 +1,176 @@
+/////////////////////////////////////////////////////////////
+//
+// pgAdmin 4 - PostgreSQL Tools
+//
+// Copyright (C) 2013 - 2026, The pgAdmin Development Team
+// This software is released under the PostgreSQL Licence
+//
+//////////////////////////////////////////////////////////////
+
+// keyboard.js reaches pgadmin.js by relative path, which skips the
+// sources/pgadmin alias that maps to the fake, so point it there explicitly.
+jest.mock('../../../pgadmin/static/js/pgadmin', () =>
+  jest.requireActual('../fake_pgadmin'));
+
+import pgAdmin from 'sources/pgadmin';
+import '../../../pgadmin/browser/static/js/keyboard';
+
+// Cycling between workspace tabs must stay in the workspace: the object
+// explorer is a tab-set of its own, and the SQL editor, ERD and Schema Diff
+// each render a nested DockLayout whose own tabs carry the same
+// dock-tab-active class (issue #7232).
+describe('keyboardNavigation.bindRightPanel', () => {
+  const shortcutObj = {
+    tabbed_panel_forward: 'ctrl+alt+]',
+    tabbed_panel_backward: 'ctrl+alt+[',
+    close_tab_panel: 'shift+alt+w',
+  };
+
+  const tabBtn = (id, isActive) => {
+    const tab = document.createElement('div');
+    tab.className = isActive ? 'dock-tab dock-tab-active' : 'dock-tab';
+    const btn = document.createElement('div');
+    btn.className = 'dock-tab-btn';
+    btn.id = `rc-dock-tab-btn-${id}`;
+    tab.appendChild(btn);
+    return tab;
+  };
+
+  const panel = (tabs) => {
+    const el = document.createElement('div');
+    el.className = 'dock-panel';
+    tabs.forEach((tab) => el.appendChild(tab));
+    return el;
+  };
+
+  /* A workspace holding the object explorer, three workspace tabs and, inside
+   * the active workspace tab, a tool with its own dock layout. */
+  const buildLayout = ({activeWorkspaceTab = 'id-dashboard'} = {}) => {
+    const root = document.createElement('div');
+    root.id = 'root';
+
+    const topLayout = document.createElement('div');
+    topLayout.className = 'dock-layout';
+    root.appendChild(topLayout);
+
+    topLayout.appendChild(panel([tabBtn('id-object-explorer', true)]));
+
+    const workspaceTabs = ['id-dashboard', 'id-properties', 'id-sql'].map(
+      (id) => tabBtn(id, id === activeWorkspaceTab));
+    const workspacePanel = panel(workspaceTabs);
+    topLayout.appendChild(workspacePanel);
+
+    // The tool's own dock layout, nested inside the workspace panel exactly
+    // as the SQL editor's is.
+    const innerLayout = document.createElement('div');
+    innerLayout.className = 'dock-layout';
+    innerLayout.appendChild(panel([
+      tabBtn('id-dataoutput', true),
+      tabBtn('id-messages', false),
+    ]));
+    workspacePanel.appendChild(innerLayout);
+
+    document.body.appendChild(root);
+    return {root, workspacePanel};
+  };
+
+  let focusTabSpy;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    pgAdmin.Browser.keyboardNavigation.keyboardShortcut = shortcutObj;
+    focusTabSpy = jest.spyOn(
+      pgAdmin.Browser.keyboardNavigation, '_focusTab'
+    ).mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    focusTabSpy.mockRestore();
+    document.body.innerHTML = '';
+  });
+
+  it('cycles the workspace tabs, not a tool\'s nested tabs', () => {
+    buildLayout();
+
+    pgAdmin.Browser.keyboardNavigation.bindRightPanel(
+      new Event('keydown'), {key: shortcutObj.tabbed_panel_forward});
+
+    expect(focusTabSpy).toHaveBeenCalled();
+    const [tabs, activeIdx] = focusTabSpy.mock.calls[0];
+    const ids = tabs.map((tab) => tab.id);
+
+    expect(ids).toEqual([
+      'rc-dock-tab-btn-id-dashboard',
+      'rc-dock-tab-btn-id-properties',
+      'rc-dock-tab-btn-id-sql',
+    ]);
+    // Neither the nested tool tabs nor the object explorer may take part.
+    expect(ids).not.toContain('rc-dock-tab-btn-id-dataoutput');
+    expect(ids).not.toContain('rc-dock-tab-btn-id-object-explorer');
+    expect(tabs[activeIdx].id).toBe('rc-dock-tab-btn-id-dashboard');
+  });
+
+  it('starts from whichever workspace tab is active', () => {
+    buildLayout({activeWorkspaceTab: 'id-sql'});
+
+    pgAdmin.Browser.keyboardNavigation.bindRightPanel(
+      new Event('keydown'), {key: shortcutObj.tabbed_panel_backward});
+
+    const [tabs, activeIdx] = focusTabSpy.mock.calls[0];
+    expect(tabs[activeIdx].id).toBe('rc-dock-tab-btn-id-sql');
+  });
+
+  /* The selection must not depend on where the nested layout happens to sit
+   * in the DOM: rc-dock is free to order panels as it likes, and an inner
+   * layout appearing first would otherwise win the search for the active
+   * tab and cycle a tool's own tabs. */
+  it('ignores nested tool tabs even when they come first in the DOM', () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    const topLayout = document.createElement('div');
+    topLayout.className = 'dock-layout';
+    root.appendChild(topLayout);
+
+    const innerLayout = document.createElement('div');
+    innerLayout.className = 'dock-layout';
+    innerLayout.appendChild(panel([
+      tabBtn('id-dataoutput', true),
+      tabBtn('id-messages', false),
+    ]));
+    topLayout.appendChild(innerLayout);
+
+    topLayout.appendChild(panel([tabBtn('id-object-explorer', true)]));
+    topLayout.appendChild(panel([
+      tabBtn('id-dashboard', false),
+      tabBtn('id-sql', true),
+    ]));
+    document.body.appendChild(root);
+
+    pgAdmin.Browser.keyboardNavigation.bindRightPanel(
+      new Event('keydown'), {key: shortcutObj.tabbed_panel_forward});
+
+    expect(focusTabSpy).toHaveBeenCalled();
+    const [tabs, activeIdx] = focusTabSpy.mock.calls[0];
+    const ids = tabs.map((tab) => tab.id);
+    expect(ids).toEqual([
+      'rc-dock-tab-btn-id-dashboard',
+      'rc-dock-tab-btn-id-sql',
+    ]);
+    expect(tabs[activeIdx].id).toBe('rc-dock-tab-btn-id-sql');
+  });
+
+  it('does nothing when only the object explorer is present', () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    const topLayout = document.createElement('div');
+    topLayout.className = 'dock-layout';
+    topLayout.appendChild(panel([tabBtn('id-object-explorer', true)]));
+    root.appendChild(topLayout);
+    document.body.appendChild(root);
+
+    pgAdmin.Browser.keyboardNavigation.bindRightPanel(
+      new Event('keydown'), {key: shortcutObj.tabbed_panel_forward});
+
+    expect(focusTabSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

A cluster of keyboard-shortcut improvements across the workspace tabs, the SQL
editor, and dialogs.

### Main tab switching (#7232)
The "Tabbed panel forward/backward" shortcut did nothing when keyboard focus
was inside a tool (SQL editor, PSQL terminal, ERD/Schema Diff canvas), because
`bindRightPanel` resolved the target tab from `document.activeElement`, which
pointed at the tool's own nested dock tab rather than a workspace tab. It now
locates the active **workspace** tab via rc-dock's `dock-tab-active` class
(independent of focus) and restricts cycling to the workspace tab-set.

The default was also colliding with the Query Tool's inner-panel navigation
(both were `Alt+Shift+] / [`) and emitted typographic glyphs on macOS. The
default is changed to **Ctrl/Cmd+Alt+] / [** (inner-panel nav keeps
`Alt+Shift+] / [`, unchanged), and the bogus key codes (Meta / ContextMenu —
the latter literally triggered the browser's "display a menu") are corrected to
the real bracket key codes.

### SQL editor (#3834)
Add **Ctrl/Cmd+Shift+D** to duplicate the current line or selection.

### Dialogs (#7167, #5691, #5196)
Object/utility dialogs rendered as dockable panels (Properties, Backup, the
Query Tool sort/filter dialog, etc.) gain:
- **Ctrl/Cmd+Enter** to save & close (#7167), and
- **Escape** to close (#5691).

The Escape handler is scoped to panel dialogs (MUI modals already close on
Escape) and yields to inner controls that handle Escape first (e.g. an open
dropdown). This also makes the unsaved-changes confirmation operable from the
keyboard (#5196) without explicit per-button letter shortcuts.

## Test plan
Verified interactively in a desktop-mode instance:
- [x] Tab switch works with focus in the SQL editor / PSQL / ERD / Schema Diff, cycling only the workspace tabs.
- [x] Ctrl/Cmd+Shift+D duplicates the current line/selection.
- [x] Ctrl/Cmd+Enter saves a dialog; Escape closes Properties/Backup dialogs (and modals still close once, dropdowns close first).

Default shortcuts and the new editor shortcut are documented in
`keyboard_shortcuts.rst`.

Closes #7232
Closes #3834
Closes #7167
Closes #5691
Closes #5196


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shortcuts to duplicate the current line or selection in SQL editors.
  * Added Ctrl/Cmd+Enter to save dialogs and improved Escape-key closing behavior.
  * Updated tab navigation shortcuts across Windows/Linux and Mac.

* **Bug Fixes**
  * Improved keyboard navigation between workspace tabs, including layouts with nested panels.

* **Tests**
  * Added coverage for dialog keyboard handling and workspace tab navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->