### PR TITLE
Fix runtime menu refresh crash when application menus are not yet received (#9762)

### DIFF
--- a/docs/en_US/release_notes_9_16.rst
+++ b/docs/en_US/release_notes_9_16.rst
@@ -42,6 +42,7 @@ Bug fixes
   | `Issue #6308 <https://github.com/pgadmin-org/pgadmin4/issues/6308>`_ -  Fix the infinite loading spinner after an idle database connection is silently dropped, by detecting stale connections and offering a reconnect dialog.
   | `Issue #9595 <https://github.com/pgadmin-org/pgadmin4/issues/9595>`_ -  Fix missing ALTER ... SET DEFAULT statements for inherited columns in the generated table SQL/EDIT script.
   | `Issue #9677 <https://github.com/pgadmin-org/pgadmin4/issues/9677>`_ -  Fix the Unlogged table toggle in table properties not generating any ALTER TABLE ... SET LOGGED/UNLOGGED statement.
+  | `Issue #9762 <https://github.com/pgadmin-org/pgadmin4/issues/9762>`_ -  Fix the "Cannot read properties of undefined (reading 'map')" crash in the desktop runtime when a menu refresh is triggered before the application menus have been received.
   | `Issue #9828 <https://github.com/pgadmin-org/pgadmin4/issues/9828>`_ -  Fix tool calls failing against OpenAI-compatible providers that emit empty/null name, arguments, or id fields in streaming continuation deltas.
   | `Issue #9875 <https://github.com/pgadmin-org/pgadmin4/issues/9875>`_ -  Fixed an issue where EXPLAIN and EXPLAIN ANALYZE failed to execute when blank lines separated clauses in the SQL query.
   | `Issue #9810 <https://github.com/pgadmin-org/pgadmin4/issues/9810>`_ -  Use the ServerManager's passfile for the credential gate in connect() so the check matches the passfile actually used for the connection, and warn on conflicting passfile/passexec settings.

--- a/runtime/src/js/menu.js
+++ b/runtime/src/js/menu.js
@@ -190,6 +190,12 @@ function buildAndSetMenus(menus, pgAdminMainScreen, configStore, callbacks={}) {
 }
 
 export function refreshMenus(pgAdminMainScreen, configStore, callbacks={}) {
+  // cachedMenus is only populated once the renderer sends its menu definition
+  // via the 'setMenus' IPC. A refresh can be triggered before that happens
+  // (e.g. an auto-update event, or the window being closed while the UI is
+  // still loading). In that case there are no menus to rebuild, so bail out
+  // to avoid dereferencing an undefined menu list.
+  if (!cachedMenus) return;
   buildAndSetMenus(cachedMenus, pgAdminMainScreen, configStore, callbacks);
 }
 


### PR DESCRIPTION
## Summary

- The desktop (Electron) runtime crashed with `TypeError: Cannot read properties of undefined (reading 'map')` in `menu.js`, surfacing as an *"A JavaScript error occurred in the main process"* dialog.
- Root cause: `refreshMenus()` rebuilds the application menu from the module-level `cachedMenus`, which is only populated once the renderer sends its menu definition via the `setMenus` IPC. If a menu refresh is triggered **before** that happens — e.g. an auto-update event on macOS, or the user closing the window (which fires `updateConfigAndMenus('error-close', ...)`) while the UI is still loading/blank — `cachedMenus` is `undefined` and `bindMenuClicks()` dereferences it.
- Fix: guard `refreshMenus()` so it bails out early when there are no cached menus to rebuild. This matches the existing early-return style in the same file.

This explains the reporters' symptom of the error box appearing when clicking the window's X while the UI was stuck on a blank/loading screen, and the macOS variant triggered via the auto-updater.

## Test plan

- [x] `node --check` passes on the modified `menu.js`.
- [ ] Manual: launch the desktop runtime and close the main window before the UI finishes loading — no uncaught-exception dialog appears.
- [ ] Manual (macOS): trigger an auto-update check before menus are set — no crash.

Closes #9762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a desktop application crash that occurred when menu refresh was triggered before application menus finished loading. This error would interrupt the startup process. The fix adds a safety check to prevent the crash and ensures a stable and reliable application startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->