### PR TITLE
fix: Adjust relationship between ServerGroup and Server/SharedServer

### DIFF
--- a/web/pgadmin/model/__init__.py
+++ b/web/pgadmin/model/__init__.py
@@ -252,6 +252,20 @@ class ServerGroup(db.Model, UserScopedMixin):
     name = db.Column(db.String(128), nullable=False)
     __table_args__ = (db.UniqueConstraint('user_id', 'name'),)
 
+    servers = db.relationship(
+        'Server',
+        back_populates='servergroup',
+        lazy='select',
+        cascade=CASCADE_STR
+    )
+
+    sharedservers = db.relationship(
+        'SharedServer',
+        back_populates='servergroup',
+        lazy='select',
+        cascade=CASCADE_STR
+    )
+
     @property
     def serialize(self):
         """Return object data in easily serializable format"""
@@ -271,11 +285,19 @@ class Server(db.Model, UserScopedMixin):
         db.ForeignKey(USER_ID),
         nullable=False
     )
+
     servergroup_id = db.Column(
         db.Integer,
         db.ForeignKey('servergroup.id'),
         nullable=False
     )
+
+    servergroup = db.relationship(
+        'ServerGroup',
+        back_populates='servers',
+        lazy='joined'
+    )
+
     name = db.Column(db.String(128), nullable=False)
     host = db.Column(db.String(128), nullable=True)
     port = db.Column(
@@ -293,11 +315,7 @@ class Server(db.Model, UserScopedMixin):
     role = db.Column(db.String(64), nullable=True)
     comment = db.Column(db.String(1024), nullable=True)
     discovery_id = db.Column(db.String(128), nullable=True)
-    servers = db.relationship(
-        'ServerGroup',
-        backref=db.backref('server', cascade=CASCADE_STR),
-        lazy='joined'
-    )
+
     db_res = db.Column(db.Text(), nullable=True)
     db_res_type = db.Column(db.String(32), default='databases')
     passexec_cmd = db.Column(db.Text(), nullable=True)
@@ -511,25 +529,36 @@ class SharedServer(db.Model, UserScopedMixin):
         db.UniqueConstraint('osid', 'user_id',
                             name='uq_sharedserver_osid_user'),
     )
+
     id = db.Column(db.Integer, primary_key=True)
     osid = db.Column(
         db.Integer,
         db.ForeignKey(SERVER_ID),
         nullable=False
     )
+
     user_id = db.Column(
         db.Integer,
         db.ForeignKey(USER_ID)
     )
+
     server_owner = db.Column(
         db.String(128),
         db.ForeignKey('user.username')
     )
+
     servergroup_id = db.Column(
         db.Integer,
         db.ForeignKey('servergroup.id'),
         nullable=False
     )
+
+    servergroup = db.relationship(
+        'ServerGroup',
+        back_populates='sharedservers',
+        lazy='joined'
+    )
+
     name = db.Column(db.String(128), nullable=False)
     host = db.Column(db.String(128), nullable=True)
     port = db.Column(
@@ -546,11 +575,6 @@ class SharedServer(db.Model, UserScopedMixin):
     role = db.Column(db.String(64), nullable=True)
     comment = db.Column(db.String(1024), nullable=True)
     discovery_id = db.Column(db.String(128), nullable=True)
-    servers = db.relationship(
-        'ServerGroup',
-        backref=db.backref('sharedserver', cascade=CASCADE_STR),
-        lazy='joined'
-    )
     bgcolor = db.Column(db.String(10), nullable=True)
     fgcolor = db.Column(db.String(10), nullable=True)
     service = db.Column(db.Text(), nullable=True)

--- a/web/pgadmin/tools/schema_diff/__init__.py
+++ b/web/pgadmin/tools/schema_diff/__init__.py
@@ -307,10 +307,10 @@ def servers():
                 "connected": connected
             }
 
-            if server.servers.name in res:
-                res[server.servers.name].append(server_info)
+            if server.servergroup.name in res:
+                res[server.servergroup.name].append(server_info)
             else:
-                res[server.servers.name] = [server_info]
+                res[server.servergroup.name] = [server_info]
 
     except Exception as e:
         app.logger.exception(e)

--- a/web/pgadmin/tools/sqleditor/__init__.py
+++ b/web/pgadmin/tools/sqleditor/__init__.py
@@ -2420,7 +2420,7 @@ def get_new_connection_data(sgid=None, sid=None):
             manager = driver.connection_manager(server.id)
             conn = manager.connection()
             connected = conn.connected()
-            server_group_data[server.servers.name].append({
+            server_group_data[server.servergroup.name].append({
                 'label': server.name,
                 "value": server.id,
                 'image': server_icon_and_background(connected, manager,


### PR DESCRIPTION
- Adjusting relationship
  - ServerGroup has many Servers
  - ServerGroup has many SharedServers
  - Server has one ServerGroup not servers
  - SharedServer has one ServerGroup not servers
  - Using back_populates instead of backref for better control

- Adjusted references to ServerGroup in server (was server.serves): server.servergroup.name instead server.servers.name
- Not find references to ServerGroup in SharedServer (sharedServer.servers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured database model relationships to improve server organization and grouping management.
  * Updated server grouping references in schema comparison and SQL editor tools for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->