### PR TITLE
Add Gateway API HTTPRoute support to the Helm chart

### DIFF
--- a/pkg/helm/templates/httproute.yaml
+++ b/pkg/helm/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.httpRoute.enabled }}
+{{- if not .Values.httpRoute.parentRefs }}
+{{- fail "httpRoute.parentRefs must be set when httpRoute.enabled is true" }}
+{{- end }}
+apiVersion: {{ .Values.httpRoute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ template "pgadmin4.fullname" . }}
+  {{- with .Values.commonLabels }}
+  labels: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.httpRoute.annotations .Values.commonAnnotations }}
+  annotations: {{ merge .Values.httpRoute.annotations .Values.commonAnnotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs: {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- $hostnames := .Values.httpRoute.hostnames }}
+  {{- if and (not $hostnames) .Values.ingress.hostname }}
+  {{- $hostnames = list (tpl .Values.ingress.hostname .) }}
+  {{- end }}
+  {{- with $hostnames }}
+  hostnames: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .Values.httpRoute.rules }}
+  {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+  {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ template "pgadmin4.fullname" . }}
+          port: {{ .Values.service.port }}
+  {{- end }}
+{{- end }}

--- a/pkg/helm/values.yaml
+++ b/pkg/helm/values.yaml
@@ -106,6 +106,25 @@ ingress:
   annotations: {}
   # If set, enables TLS configuration in the Ingress resource.
   tlsSecret: ""
+httpRoute:
+  # Enable a Gateway API HTTPRoute as an alternative to the Ingress above.
+  enabled: false
+  # apiVersion for the HTTPRoute resource. Override if your Gateway API
+  # implementation still serves the resource under v1beta1.
+  apiVersion: gateway.networking.k8s.io/v1
+  # parentRefs is required when httpRoute.enabled is true. It references the
+  # Gateway (and optionally a listener) that should route to pgAdmin.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # hostnames for the route. When empty, falls back to ingress.hostname.
+  hostnames: []
+  #  - pgadmin4.example.com
+  annotations: {}
+  # Custom routing rules. When empty, a single rule forwards all traffic
+  # ("/" PathPrefix) to the pgAdmin service.
+  rules: []
 startupProbe:
   enabled: false
   httpGet:


### PR DESCRIPTION
Adds an opt-in Gateway API `HTTPRoute` template to the pgAdmin Helm chart as an alternative to the existing Ingress, addressing #9942. Disabled by default (`httpRoute.enabled: false`) so existing installs are unaffected.

The template mirrors the existing `ingress.yaml` conventions: `pgadmin4.fullname` backend, `commonLabels`/`commonAnnotations` propagation, and a hostname that falls back to `ingress.hostname` when `httpRoute.hostnames` is unset. `parentRefs` is required (a `fail` guard fires when it is empty), `apiVersion` defaults to `gateway.networking.k8s.io/v1`, and the default rule forwards `/` (PathPrefix) to the pgAdmin service. Custom `hostnames` and `rules` can be supplied for full control.

Validation (local `helm` v3.18):
- Default values render **no** HTTPRoute (`kind: HTTPRoute` count = 0).
- `httpRoute.enabled=true` with `parentRefs` + `hostnames` renders a valid HTTPRoute (backendRef → service port 80, PathPrefix `/`).
- `httpRoute.enabled=true` without `parentRefs` fails fast with a clear message.
- Empty `httpRoute.hostnames` correctly falls back to `ingress.hostname`.
- Custom `httpRoute.rules` override renders as supplied.
- `helm lint` clean both with the feature disabled and enabled.

related: #9942

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kubernetes HTTPRoute resources with Gateway API integration
  * HTTPRoute can be conditionally enabled with configurable parent references, hostnames, and custom routing rules
  * Routes all traffic to the pgAdmin4 service by default when no custom rules are specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->