### PR TITLE
fix(cli): register module preferences before set-prefs validation

### DIFF
--- a/web/pgadmin/preferences/__init__.py
+++ b/web/pgadmin/preferences/__init__.py
@@ -313,13 +313,9 @@ def save_pref(data):
     if data['value'] in ['true','false']:
         data['value'] = True if data['value'] == 'true' else False
 
-    res, _ = Preferences.save_cli(
+    return Preferences.save_cli(
         data['mid'], data['category_id'], data['id'], data['user_id'],
         data['value'])
-
-    if not res:
-        return False
-    return True
 
 
 @blueprint.route("/update", methods=["PUT"], endpoint="update_pref")

--- a/web/setup.py
+++ b/web/setup.py
@@ -730,6 +730,18 @@ class ManagePreferences:
         invalid_prefs = []
         invalid_value_prefs = []
         valid_prefs = []
+        # Module preference objects are registered lazily via
+        # register_before_app_start() callbacks; pgAdmin4.py runs them at
+        # web-app startup, but the CLI never does. save_cli() now validates
+        # against the registered preference type, so we have to trigger
+        # registration ourselves. PGADMIN_RUNTIME must be set first because
+        # some register_preferences() methods (e.g. browser) check it; we
+        # use False so the full server-mode preference set (including
+        # keyboard shortcuts) is exposed to the CLI. run_before_app_start()
+        # enters both an app context and a test_request_context internally,
+        # which registration callbacks that touch current_user require.
+        app.PGADMIN_RUNTIME = False
+        app.run_before_app_start()
         with app.app_context():
             from pgadmin.preferences import save_pref
             for opt in pref_options:
@@ -750,13 +762,14 @@ class ManagePreferences:
                         'name': final_opt[2],
                         'user_id': user_id,
                         'value': val}
-                    if save_pref(_row):
+                    ok, msg = save_pref(_row)
+                    if ok:
                         valid_prefs.append(_row)
 
                         if not json:
                             table.add_row(jsonlib.dumps(_row))
                     else:
-                        invalid_value_prefs.append(f)
+                        invalid_value_prefs.append((f, msg))
                 else:
                     invalid_prefs.append(f)
 
@@ -765,10 +778,8 @@ class ManagePreferences:
                     (', ').join(
                         invalid_prefs)))
 
-            if len(invalid_value_prefs) >= 1:
-                print("Invalid value provided for preference(s) "
-                      "[red]{0}[/red].".format(
-                          (', ').join(invalid_value_prefs)))
+            for name, msg in invalid_value_prefs:
+                print("Could not set [red]{0}[/red]: {1}".format(name, msg))
 
             if not json and console:
                 print(table)


### PR DESCRIPTION
## Summary

- PR #10047 made `Preferences.save_cli()` validate values against the in-memory preference object before writing, but `setup.py set-prefs` only enters `app.app_context()` and never calls `app.run_before_app_start()`. `Preferences.modules` therefore stays empty, every `save_cli` lookup returns `(False, "Module 'X' is no longer in use.")`, and the CLI reports a generic "Invalid value provided" for every preference — regardless of the actual value.
- Trigger registration explicitly: `app.PGADMIN_RUNTIME = False` + `app.run_before_app_start()` before the save loop. `run_before_app_start()` enters both an app context and a `test_request_context()` internally, which satisfies registration callbacks that touch `current_user`. `PGADMIN_RUNTIME` is set to `False` so the full server-mode preference set (incl. keyboard shortcuts) is exposed to the CLI.
- Surface the typed error message from `save_cli` per failed preference (`"Could not set <pref>: Invalid value for integer option."`) instead of the aggregate generic message — useful when batching multiple `key=value` pairs of mixed types in one command or via `--input-file`. `save_pref` now returns the `(ok, msg)` tuple straight from `save_cli`; its only caller is `setup.py`.

## Test plan

- [x] `python setup.py set-prefs <user> "browser:display:show_user_defined_templates=true"` → saved
- [x] `python setup.py set-prefs <user> "browser:display:browser_tree_state_save_interval=notanint"` → "Could not set …: Invalid value for integer option."
- [x] `python setup.py set-prefs <user> "browser:display:no_such_pref=foo"` → "Preference(s) … not found."
- [x] `python setup.py set-prefs <user> "browser:display:browser_tree_state_save_interval=5"` → saved
- [x] `pycodestyle` clean on both files
- [ ] GUI preferences dialog still saves correctly (unaffected — `Preferences.save()` path unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when setting preferences, now displaying specific error details for each preference rather than generic messages.
  * Improved preference registration handling for command-line interface operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->