### PR TITLE
fix(mac): prune dangling symlinks before codesign so Gatekeeper accepts the bundle

### DIFF
--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -427,6 +427,36 @@ _strip_architecture() {
     done < <(find "${BUNDLE_DIR}" -type f)
 }
 
+_prune_dangling_symlinks() {
+    # Gatekeeper walks every symlink in the bundle and rejects the whole app
+    # with "invalid destination for symbolic link in bundle" if any link does
+    # not resolve to a real file inside the app. Notarisation does NOT catch
+    # this, so a broken link slips through stapling and only surfaces as a
+    # Gatekeeper failure on the end user's machine.
+    #
+    # The embedded Python.framework ships such links: an arm64-only build still
+    # carries a bin/python*-intel64 launcher symlink (whose target we delete in
+    # _strip_architecture), and the bundled Tcl/Tk frameworks carry
+    # PrivateHeaders links pointing at a Versions/Current that has none. Rather
+    # than hunt individual offenders, prune EVERY dangling symlink so a future
+    # stray link cannot reintroduce the bug.
+    #
+    # NB: this MUST run after _strip_architecture (which orphans links by
+    # deleting their targets) and before _codesign_binaries / _codesign_bundle.
+
+    echo "Pruning dangling symlinks before signing..."
+    # -type l selects symlinks; "! -exec test -e {} \;" keeps only those whose
+    # target does not exist (test -e follows the link). BSD find on macOS.
+    find "${BUNDLE_DIR}" -type l ! -exec test -e {} \; -print -delete
+
+    # Belt and braces: fail the build if anything still dangles, so this can
+    # never silently slip past notarisation into a shipped bundle again.
+    if find "${BUNDLE_DIR}" -type l ! -exec test -e {} \; -print | grep -q .; then
+        echo "ERROR: bundle still contains dangling symlinks (Gatekeeper will reject)" >&2
+        exit 1
+    fi
+}
+
 _generate_sbom() {
    echo "Generating SBOM..."
    syft "${BUNDLE_DIR}/Contents/" -o cyclonedx-json > "${BUNDLE_DIR}/Contents/sbom.json"

--- a/pkg/mac/build.sh
+++ b/pkg/mac/build.sh
@@ -93,6 +93,7 @@ _create_python_env
 _build_docs
 _complete_bundle
 _strip_architecture
+_prune_dangling_symlinks
 _generate_sbom
 _codesign_binaries
 _codesign_bundle


### PR DESCRIPTION
### Problem

A signed, notarised and stapled `pgAdmin 4.app` is **rejected by Gatekeeper** even though signing and notarisation are completely valid:

```
$ spctl -a -vvv -t install "pgAdmin 4.app"
pgAdmin 4.app: rejected (invalid destination for symbolic link in bundle)
```

Gatekeeper walks every symlink in the bundle and rejects the whole app if any link does not resolve to a real file inside it. Notarisation does **not** catch this, so a broken link slips through stapling and only surfaces as a Gatekeeper failure on the end user's machine.

The embedded `Python.framework` (pulled in via `relocatable-python`) ships three such dangling links:

| Symlink (under `Versions/3.13`) | Why it dangles |
|---|---|
| `bin/python3-intel64` | arm64-only build; the Intel launcher target is removed by `_strip_architecture`, leaving the link |
| `Frameworks/Tcl.framework/PrivateHeaders` | points at `Versions/Current/PrivateHeaders`, which does not exist |
| `Frameworks/Tk.framework/PrivateHeaders` | same as Tcl |

### Fix

Add a `_prune_dangling_symlinks` step to the macOS build pipeline that removes **every** dangling symlink in the bundle, rather than hunting individual offenders by name, so a future stray link cannot reintroduce the problem. It runs **after** `_strip_architecture` (which orphans the intel link by deleting its target) and **before** the codesign steps, and it then re-scans and fails the build if anything still dangles, so this can never silently slip past notarisation again.

### Verification

- `bash -n` passes on both scripts.
- The `find -type l ! -exec test -e {} \;` prune idiom was exercised on a scratch tree: it deletes dangling links, preserves valid symlinks and real files, and the post-check guard passes.

Full end-to-end confirmation (`spctl -a` accepting a freshly signed/notarised/stapled build) requires the codesign credentials and a real Mac, and should be done as part of the next macOS package build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the macOS build pipeline with automated detection and removal of invalid symbolic links during the pre-signing phase. The build process now includes protective checks that prevent completion if problematic symbolic links remain after cleanup, ensuring distributed applications meet system security requirements and successfully pass Gatekeeper validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->