### PR TITLE
fix: skip row virtualization for small data grids

### DIFF
--- a/web/pgadmin/static/js/SchemaView/DataGridView/grid.jsx
+++ b/web/pgadmin/static/js/SchemaView/DataGridView/grid.jsx
@@ -125,12 +125,14 @@ export default function DataGridView({
   const VIRTUALISE_CELL_BUDGET = 700; // Number of cells to render
   const DEFAULT_VIRTUALISE_THRESHOLD = 100; // Number of rows to render
   const visibleColCount = table.getVisibleLeafColumns().length;
+  const rawThreshold = field.virtualiseThreshold;
   const virtualiseThreshold =
-    field.virtualiseThreshold ??
-    (visibleColCount > 0
-      ? Math.min(400, Math.max(25,
-        Math.round(VIRTUALISE_CELL_BUDGET / visibleColCount)))
-      : DEFAULT_VIRTUALISE_THRESHOLD);
+    (typeof rawThreshold === 'number' && rawThreshold > 0)
+      ? rawThreshold
+      : (visibleColCount > 0
+        ? Math.min(400, Math.max(25,
+          Math.round(VIRTUALISE_CELL_BUDGET / visibleColCount)))
+        : DEFAULT_VIRTUALISE_THRESHOLD);
   const virtualise = rows.length > virtualiseThreshold;
 
   const virtualizer = useVirtualizer({

--- a/web/pgadmin/static/js/SchemaView/DataGridView/grid.jsx
+++ b/web/pgadmin/static/js/SchemaView/DataGridView/grid.jsx
@@ -122,6 +122,17 @@ export default function DataGridView({
     )
   ).includes(true);
 
+  const VIRTUALISE_CELL_BUDGET = 700; // Number of cells to render
+  const DEFAULT_VIRTUALISE_THRESHOLD = 100; // Number of rows to render
+  const visibleColCount = table.getVisibleLeafColumns().length;
+  const virtualiseThreshold =
+    field.virtualiseThreshold ??
+    (visibleColCount > 0
+      ? Math.min(400, Math.max(25,
+        Math.round(VIRTUALISE_CELL_BUDGET / visibleColCount)))
+      : DEFAULT_VIRTUALISE_THRESHOLD);
+  const virtualise = rows.length > virtualiseThreshold;
+
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableEleRef.current,
@@ -152,32 +163,51 @@ export default function DataGridView({
               ref={tableEleRef} table={table} data-test="data-grid-view"
               tableClassName='DataGridView-table'>
               <PgReactTableHeader table={table} />
-              <PgReactTableBody style={{
-                height: virtualizer.getTotalSize() + 'px'
-              }}>
-                {
-                  virtualizer.getVirtualItems().map((virtualRow) => {
-                    const row = rows[virtualRow.index];
-                    return (
+              {virtualise ?
+                <PgReactTableBody style={{
+                  height: virtualizer.getTotalSize() + 'px'
+                }}>
+                  {
+                    virtualizer.getVirtualItems().map((virtualRow) => {
+                      const row = rows[virtualRow.index];
+                      return (
+                        <PgReactTableRow
+                          key={row.id}
+                          data-index={virtualRow.index}
+                          ref={node => virtualizer.measureElement(node)}
+                          style={{
+                            // This should always be a `style` as it changes on
+                            // scroll.
+                            transform: `translateY(${virtualRow.start}px)`,
+                          }}
+                        >
+                          <GridRow
+                            rowId={virtualRow.index} isResizing={isResizing}
+                            row={row}
+                          />
+                        </PgReactTableRow>
+                      );
+                    })
+                  }
+                </PgReactTableBody>
+                :
+                <PgReactTableBody>
+                  {
+                    rows.map((row, index) => (
                       <PgReactTableRow
                         key={row.id}
-                        data-index={virtualRow.index}
-                        ref={node => virtualizer.measureElement(node)}
-                        style={{
-                          // This should always be a `style` as it changes on
-                          // scroll.
-                          transform: `translateY(${virtualRow.start}px)`,
-                        }}
+                        data-index={index}
+                        className='pgrt-row--static'
                       >
                         <GridRow
-                          rowId={virtualRow.index} isResizing={isResizing}
+                          rowId={index} isResizing={isResizing}
                           row={row}
                         />
                       </PgReactTableRow>
-                    );
-                  })
-                }
-              </PgReactTableBody>
+                    ))
+                  }
+                </PgReactTableBody>
+              }
             </PgReactTable>
           </DndProvider>
         </Box>

--- a/web/pgadmin/static/js/components/PgReactTableStyled.jsx
+++ b/web/pgadmin/static/js/components/PgReactTableStyled.jsx
@@ -91,6 +91,9 @@ const StyledDiv = styled('div')(({theme})=>({
         flexDirection: 'column',
         position: 'absolute',
         width: '100%',
+        '&.pgrt-row--static': {
+          position: 'relative',
+        },
 
         '& .pgrt-row-content': {
           display: 'flex',


### PR DESCRIPTION
## Description

Switching back to a dialog tab that contains an editable data grid (e.g. Table Properties → Columns) was noticeably slow — the grid appeared to "reload" its rows on every tab switch. This PR skips row virtualization for small grids so hide/show becomes a pure CSS toggle, eliminating the jank while preserving virtualization for large grids.

## Root Cause

`DataGridView` unconditionally virtualized rows. In `SchemaView` dialogs, inactive tabs stay mounted but hidden via the HTML `hidden` attribute (`display:none`) in `components/TabPanel.jsx:27`, so a hidden tab's scroll viewport measures 0 and the virtual window collapses.

On switching back, the viewport height goes 0 → real, the virtualizer's `ResizeObserver` fires, and every rendered row is re-measured through a synchronous `getBoundingClientRect()` via a fresh `measureElement` ref callback (`SchemaView/DataGridView/grid.jsx:143`, `:177`). This forced-layout settle loop is visible lag on grids with complex cell editors, and at small row counts virtualization provides no benefit — it is pure overhead.

## Fix

- `SchemaView/DataGridView/grid.jsx:125-134` — compute an adaptive `virtualiseThreshold` (overridable via `field.virtualiseThreshold`), scaled by visible column count as `min(400, max(25, round(700 / cols)))`, defaulting to 100 when column count is unknown; virtualize only when `rows.length > virtualiseThreshold`.
- `SchemaView/DataGridView/grid.jsx:166-210` — branch the table body: large grids keep the virtualizer (`measureElement` + absolute positioning + `translateY`); small grids render every row in normal document flow with `className='pgrt-row--static'`, no `measureElement`.
- `components/PgReactTableStyled.jsx:94-96` — add `&.pgrt-row--static { position: relative }` so opted-out rows escape the virtualizer's absolute layout and stack in normal flow, making tab hide/show a pure CSS toggle.

## Test Plan

- [x] `npx eslint -c .eslintrc.js` on both changed files — clean, no errors
- [ ] Manual: open Table Properties on a table with 30+ columns → Columns tab; switch to Constraints and back several times → rows repaint instantly, no re-load/jank
- [ ] Manual: confirm large grids (rows above threshold) still scroll and virtualize correctly
- [ ] Manual: verify small-grid rows render, edit, add/remove, and reorder correctly in normal flow

Fixes : #10143 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved data grid rendering by dynamically selecting virtualization based on dataset size and visible columns.
  * Added support for configuring virtualization thresholds.
  * Smaller datasets now render with simpler static row styling for improved reliability and responsiveness.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->