### PR TITLE
Pin sonarqube-scan-action to a full commit SHA (v8.2.1)

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -52,7 +52,7 @@ jobs:
           sed -i "s/%VERSION%/${APP_LONG_VERSION}/g" sonar-project.properties
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONARQUBE_HOST }}


### PR DESCRIPTION
Hi, and thank you for pgAdmin.

Small CI supply-chain hardening, one line. `sonarqube-scan.yml` runs the scanner from a **mutable branch ref**, in the step that holds the SonarQube credentials:

```yaml
uses: sonarsource/sonarqube-scan-action@master
env:
  SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
  SONAR_HOST_URL: ${{ secrets.SONARQUBE_HOST }}
```

Whatever `master` happens to point at executes with those secrets in scope; a branch can move after review, a full commit SHA cannot. This PR pins to the commit behind the current release, keeping the version visible:

```yaml
uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
```

Verified: `gh api repos/sonarsource/sonarqube-scan-action/git/ref/tags/v8.2.1` → `2291811…`. It's the only workflow ref in the repo on a branch rather than a tag, so behavior today is unchanged. (If you'd rather discuss on pgadmin-hackers first, happy to take it there — filing here since small workflow PRs have been merged from GitHub recently.)

For transparency: I used AI assistance to spot and draft this; I verified the workflow content and the release SHA myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the SonarQube scanning action to a specific version for more consistent and reliable code-quality scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->