### PR TITLE
fix: pin Yarn version from packageManager field in build scripts

### DIFF
--- a/.github/workflows/check-javascript-style.yml
+++ b/.github/workflows/check-javascript-style.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upgrade yarn
         run: |
           yarn set version berry
-          yarn set version 4
+          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
 
       - name: Install Node modules
         run: |

--- a/.github/workflows/run-feature-tests-epas.yml
+++ b/.github/workflows/run-feature-tests-epas.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Upgrade yarn
         run: |
           yarn set version berry
-          yarn set version 4
+          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
 
       - name: Build the JS bundle
         run: |

--- a/.github/workflows/run-feature-tests-pg.yml
+++ b/.github/workflows/run-feature-tests-pg.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Upgrade yarn
         run: |
           yarn set version berry
-          yarn set version 4
+          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
 
       - name: Build the JS bundle
         run: |

--- a/.github/workflows/run-javascript-tests.yml
+++ b/.github/workflows/run-javascript-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Upgrade yarn
         run: |
           yarn set version berry
-          yarn set version 4
+          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
 
       - name: Install Node modules
         run: |

--- a/pkg/linux/build-functions.sh
+++ b/pkg/linux/build-functions.sh
@@ -210,6 +210,10 @@ _build_runtime() {
     # Install the runtime node_modules
     pushd "${BUNDLEDIR}/resources/app" > /dev/null || exit
         YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        if [ -z "${YARN_VERSION}" ]; then
+            echo "ERROR: Could not determine Yarn version from package.json packageManager field."
+            exit 1
+        fi
         yarn set version "${YARN_VERSION}"
         yarn workspaces focus --production
 
@@ -258,6 +262,10 @@ _copy_code() {
 
     pushd "${SOURCEDIR}/web" > /dev/null || exit
         YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        if [ -z "${YARN_VERSION}" ]; then
+            echo "ERROR: Could not determine Yarn version from package.json packageManager field."
+            exit 1
+        fi
         yarn set version "${YARN_VERSION}"
         yarn install
         yarn run bundle

--- a/pkg/linux/build-functions.sh
+++ b/pkg/linux/build-functions.sh
@@ -209,8 +209,8 @@ _build_runtime() {
 
     # Install the runtime node_modules
     pushd "${BUNDLEDIR}/resources/app" > /dev/null || exit
-        yarn set version berry
-        yarn set version 4
+        YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        yarn set version "${YARN_VERSION}"
         yarn workspaces focus --production
 
         # remove the yarn cache
@@ -257,8 +257,8 @@ _copy_code() {
     find "${SERVERROOT}/usr/${APP_NAME}/venv/" -name "_tkinter*" -print0 | xargs -0 rm -rf
 
     pushd "${SOURCEDIR}/web" > /dev/null || exit
-        yarn set version berry
-        yarn set version 4
+        YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        yarn set version "${YARN_VERSION}"
         yarn install
         yarn run bundle
     popd > /dev/null || exit

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -10,7 +10,7 @@
     "start": "electron .",
     "linter": "yarn run eslint -c .eslintrc.js ."
   },
-  "packageManager": "yarn@4.9.2",
+  "packageManager": "yarn@4.15.0",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "electron": "^42.3.3",


### PR DESCRIPTION
## Summary

- Replace hardcoded `yarn set version 4` in `pkg/linux/build-functions.sh` with a dynamic lookup from each workspace's `packageManager` field in `package.json`
- Sync `runtime/package.json` Yarn version to `4.15.0` to match `web/package.json`

## Root Cause

CI DEB build (#1708) failed with `YN0028` — `yarn install` ran with `--immutable` but the lockfile would have been modified. The build script ran `yarn set version 4` which fetched the latest Yarn 4.x release; that newer Yarn recomputes builtin compat patch hashes differently from the version used to generate the committed lockfile.

## Fix

```bash
YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
yarn set version "${YARN_VERSION}"
```

Both the web and runtime build blocks now use the version declared in their respective `package.json`. The build script never needs updating when Yarn is bumped — the single source of truth is `packageManager`.

## Test plan

- [ ] Trigger DEB snapshot build on CI and confirm `yarn install` passes
- [ ] Confirm RPM/other Linux builds unaffected (same `build-functions.sh`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s expected Yarn version to **4.15.0** via the runtime package configuration.
  * Desktop runtime and web/server bundling now automatically use the Yarn version declared in the project configuration, with validation to prevent empty version selection.

* **CI**
  * CI “Upgrade yarn” steps now derive the Yarn version from the web package configuration instead of using hard-coded Yarn versions, keeping JavaScript checks and test runs consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->