### PR TITLE
fix: dedupe concurrent getNodeAjaxOptions requests (#10155)

### DIFF
--- a/web/pgadmin/browser/static/js/node_ajax.js
+++ b/web/pgadmin/browser/static/js/node_ajax.js
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////
 
 import _ from 'lodash';
-import getApiInstance from '../../../static/js/api_instance';
+import getApiInstance, {getInflight} from '../../../static/js/api_instance';
 import {generate_url} from 'sources/browser/generate_url';
 import pgAdmin from 'sources/pgadmin';
 
@@ -77,13 +77,6 @@ export function generateNodeUrl(treeNodeInfo, actionType, itemNodeData, withId, 
 }
 
 
-/* Tracks AJAX requests that are currently in flight, keyed by the resolved
- * URL + query params. This lets concurrent callers asking for the same options
- * (e.g. every row's Data Type dropdown mounting at once) share a single HTTP
- * request instead of each firing their own before the cache is populated.
- */
-const _inflightAjaxRequests = new Map();
-
 /* Get the nodes list as options required by select controls
  * The options are cached for performance reasons.
  */
@@ -123,25 +116,16 @@ export function getNodeAjaxOptions(url, nodeObj, treeNodeInfo, itemNodeData, par
       if (_.isUndefined(data) || _.isNull(data)) {
         // Share a single in-flight request among all concurrent callers asking
         // for the same URL + params, so we don't fire duplicate GETs before the
-        // first response lands and populates the cache.
-        let inflightKey = fullUrl + '#' + JSON.stringify(otherParams.urlParams || {});
-        let request = _inflightAjaxRequests.get(inflightKey);
-        if (!request) {
-          request = api.get(fullUrl, {
-            params: otherParams.urlParams,
-          }).then((res)=>{
-            let resData = res.data;
-            if(res.data.data) {
-              resData = res.data.data;
-            }
-            otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, resData);
-            return resData;
-          }).finally(()=>{
-            _inflightAjaxRequests.delete(inflightKey);
-          });
-          _inflightAjaxRequests.set(inflightKey, request);
-        }
-        request.then((resData)=>{
+        // first response lands and populates the cache. Each caller still runs
+        // its own caching + transform on the shared response.
+        getInflight(api, fullUrl, {
+          params: otherParams.urlParams,
+        }).then((res)=>{
+          let resData = res.data;
+          if(res.data.data) {
+            resData = res.data.data;
+          }
+          otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, resData);
           resolve(transform(resData));
         }).catch((err)=>{
           reject(err instanceof Error ? err : Error('Something went wrong'));

--- a/web/pgadmin/browser/static/js/node_ajax.js
+++ b/web/pgadmin/browser/static/js/node_ajax.js
@@ -77,6 +77,13 @@ export function generateNodeUrl(treeNodeInfo, actionType, itemNodeData, withId, 
 }
 
 
+/* Tracks AJAX requests that are currently in flight, keyed by the resolved
+ * URL + query params. This lets concurrent callers asking for the same options
+ * (e.g. every row's Data Type dropdown mounting at once) share a single HTTP
+ * request instead of each firing their own before the cache is populated.
+ */
+const _inflightAjaxRequests = new Map();
+
 /* Get the nodes list as options required by select controls
  * The options are cached for performance reasons.
  */
@@ -114,15 +121,28 @@ export function getNodeAjaxOptions(url, nodeObj, treeNodeInfo, itemNodeData, par
       let data = cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel);
 
       if (_.isUndefined(data) || _.isNull(data)) {
-        api.get(fullUrl, {
-          params: otherParams.urlParams,
-        }).then((res)=>{
-          data = res.data;
-          if(res.data.data) {
-            data = res.data.data;
-          }
-          otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, data);
-          resolve(transform(data));
+        // Share a single in-flight request among all concurrent callers asking
+        // for the same URL + params, so we don't fire duplicate GETs before the
+        // first response lands and populates the cache.
+        let inflightKey = fullUrl + '#' + JSON.stringify(otherParams.urlParams || {});
+        let request = _inflightAjaxRequests.get(inflightKey);
+        if (!request) {
+          request = api.get(fullUrl, {
+            params: otherParams.urlParams,
+          }).then((res)=>{
+            let resData = res.data;
+            if(res.data.data) {
+              resData = res.data.data;
+            }
+            otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, resData);
+            return resData;
+          }).finally(()=>{
+            _inflightAjaxRequests.delete(inflightKey);
+          });
+          _inflightAjaxRequests.set(inflightKey, request);
+        }
+        request.then((resData)=>{
+          resolve(transform(resData));
         }).catch((err)=>{
           reject(err instanceof Error ? err : Error('Something went wrong'));
         });

--- a/web/pgadmin/static/js/api_instance.js
+++ b/web/pgadmin/static/js/api_instance.js
@@ -23,6 +23,44 @@ export default function getApiInstance(headers={}) {
   });
 }
 
+/* Tracks GET requests that are currently in flight, keyed by the resolved URL +
+ * params. This lets concurrent callers asking for the exact same resource
+ * (e.g. every column row's Data Type dropdown mounting at once on a wide table)
+ * share a single HTTP request instead of each firing their own identical GET.
+ */
+const _inflightGetRequests = new Map();
+
+/* Builds a key that is independent of object key insertion order, so that
+ * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key. */
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  return '{' + Object.keys(value).sort().map(
+    (key) => JSON.stringify(key) + ':' + stableStringify(value[key])
+  ).join(',') + '}';
+}
+
+/* Like api.get(url, config), but shares a single in-flight request among all
+ * concurrent callers requesting the same url + params. The shared entry is
+ * removed once the request settles (success or failure), so it never leaks and
+ * later calls fetch fresh data. Each caller attaches its own then/catch, so
+ * response handling (transform, caching, etc.) stays per-caller. */
+export function getInflight(api, url, config={}) {
+  const key = url + '#' + stableStringify(config.params ?? {});
+  let request = _inflightGetRequests.get(key);
+  if (!request) {
+    request = api.get(url, config).finally(() => {
+      _inflightGetRequests.delete(key);
+    });
+    _inflightGetRequests.set(key, request);
+  }
+  return request;
+}
+
 export function parseApiError(error, withData=false) {
   if (error.response) {
     // The request was made and the server responded with a status code

--- a/web/pgadmin/static/js/api_instance.js
+++ b/web/pgadmin/static/js/api_instance.js
@@ -31,10 +31,19 @@ export default function getApiInstance(headers={}) {
 const _inflightGetRequests = new Map();
 
 /* Builds a key that is independent of object key insertion order, so that
- * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key. */
+ * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key.
+ * Params are expected to be plain JSON-like query values (primitives, plain
+ * objects, arrays); exotic inputs like Date/Map/cyclic objects are not valid
+ * GET query params and are out of scope here.
+ * Primitives are type-tagged so that values that share a JSON form but differ
+ * in type never collide, e.g. the number 1 vs the string "1", or an array hole
+ * ([undefined]) vs the empty array ([]). */
 function stableStringify(value) {
+  if (value === undefined) {
+    return 'undefined';
+  }
   if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value);
+    return typeof value + ':' + JSON.stringify(value);
   }
   if (Array.isArray(value)) {
     return '[' + value.map(stableStringify).join(',') + ']';
@@ -50,7 +59,15 @@ function stableStringify(value) {
  * later calls fetch fresh data. Each caller attaches its own then/catch, so
  * response handling (transform, caching, etc.) stays per-caller. */
 export function getInflight(api, url, config={}) {
-  const key = url + '#' + stableStringify(config.params ?? {});
+  // Key on url + params + any per-request headers, so callers that differ only
+  // in headers (e.g. a different Authorization) never share a response. The
+  // instance-level headers set by getApiInstance() are the session-global CSRF
+  // token and Content-type, identical across concurrent callers, so they don't
+  // need to be in the key; anything caller-specific should be passed here via
+  // config.headers.
+  const key = url
+    + '#' + stableStringify(config.params ?? {})
+    + '#' + stableStringify(config.headers ?? {});
   let request = _inflightGetRequests.get(key);
   if (!request) {
     request = api.get(url, config).finally(() => {


### PR DESCRIPTION
## Summary

Fixes #10155.

`getNodeAjaxOptions()` in `web/pgadmin/browser/static/js/node_ajax.js` — the shared helper behind every AJAX-backed dropdown — cached responses **only after they resolved**. So when many components requested the same URL before the first response landed (e.g. every column row's Data Type dropdown mounting at once on a wide table's Columns tab), each one saw an empty cache and fired its own identical `GET`. A 150-column table produced ~150 concurrent duplicate `get_types` requests.

## Fix

Added in-flight request sharing:

- A module-level `Map` tracks requests currently in progress, keyed by the resolved full URL + query params.
- On a cache miss, a caller reuses an existing in-flight request if one matches; otherwise it starts one and stores it.
- The first request to resolve populates the cache exactly as before.
- The map entry is removed on settle (`.finally()`), success or failure, so it doesn't leak.

Result: one shared `get_types` request for all concurrent callers instead of one per row. Cached behavior and response-shape handling are unchanged.

## Notes

Could not run the JS linter locally — the repo's `.eslintrc.js` (legacy format) is incompatible with the installed ESLint v9 (flat-config only), a pre-existing toolchain issue unrelated to this change. The file was verified to parse as valid ES module syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate concurrent GET requests when multiple parts of the application request the same resource with identical parameters.
  * Shared a single in-progress request among concurrent callers and ensured it is properly cleared after the request completes or fails, without changing existing cache-hit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->