### PR TITLE
fix: honor selected EOL sequence when copying query text to clipboard #10158

### DIFF
--- a/web/pgadmin/static/js/components/ReactCodeMirror/CustomEditorView.js
+++ b/web/pgadmin/static/js/components/ReactCodeMirror/CustomEditorView.js
@@ -306,7 +306,7 @@ export default class CustomEditorView extends EditorView {
   static getSelectionFromState(state) {
     // function to get selection from EditorState
     const lineSep = state.facet(eol);
-    return state.selection.ranges.map((range)=>state.sliceDoc(range.from, range.to)).join(lineSep) ?? '';
+    return state.selection.ranges.map((range)=>state.doc.sliceString(range.from, range.to, lineSep)).join(lineSep) ?? '';
   }
 
   replaceSelection(newValue) {


### PR DESCRIPTION
### Summary

Fixes #10158 — a regression of the EOL feature added in #7393.

The Query Tool status bar lets you choose **LF** or **CRLF** as the end-of-line sequence used when copying query text to the clipboard. Since #8691 this setting had no effect: copied text always used LF regardless of the choice.

### Root cause

`CustomEditorView.getSelectionFromState()` joined the selection *ranges* with the chosen EOL, but sliced each range using `state.sliceDoc(from, to)` — which always uses the document's own line break (`\n`). For a normal single-range selection (the common case) there is nothing to join, so every internal line break stayed `\n` and the LF/CRLF choice was ignored.

This was introduced in #8691, where the copy path was reworked to fix multi-cursor copying and switched from `doc.sliceString(..., lineSep)` (applies the separator to line breaks) to `sliceDoc(...)` (does not).

### Fix

Slice each range with `state.doc.sliceString(range.from, range.to, lineSep)` so the chosen EOL is applied to line breaks *within* the selection as well. The `.join(lineSep)` still applies it *between* multiple cursor ranges, so the #8691 multi-cursor fix is preserved.

```diff
- return state.selection.ranges.map((range)=>state.sliceDoc(range.from, range.to)).join(lineSep) ?? '';
+ return state.selection.ranges.map((range)=>state.doc.sliceString(range.from, range.to, lineSep)).join(lineSep) ?? '';
```

### Test steps

1. Open a Query Tool and enter multiple lines of SQL.
2. In the bottom-right status bar, set the EOL toggle to **CRLF**.
3. Select all (Ctrl/Cmd+A) and copy (Ctrl/Cmd+C).
4. Inspect the **raw clipboard bytes** (the destination editor may normalize on paste, so check the clipboard directly):
   - macOS: `pbpaste | xxd | head`
   - or count: `echo "CR: $(pbpaste | tr -cd '\r' | wc -c)  LF: $(pbpaste | tr -cd '\n' | wc -c)"`
5. **Expected:** every line break is `0d 0a` (CRLF) — CR and LF counts are equal and non-zero.
6. Switch the toggle to **LF**, copy again, and re-check.
7. **Expected:** line breaks are bare `0a` (LF) — CR count is `0`.

> Note: pasting into another editor may convert the endings to match that editor's own EOL setting, which can mask the result — that's why the raw clipboard is the source of truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selected-text extraction in the code editor to preserve the document’s configured line-ending format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->