### PR TITLE
fix: detect a selected-but-unusable OS keyring and fall back gracefully

### DIFF
--- a/web/pgadmin/evaluate_config.py
+++ b/web/pgadmin/evaluate_config.py
@@ -138,8 +138,26 @@ def evaluate_and_patch_config(config: dict) -> dict:
         config.setdefault('KEYRING_NAME', '')
     else:
         k_name = keyring.get_keyring().name
-        # Setup USE_OS_SECRET_STORAGE false as no keyring backend available
-        if k_name == 'fail Keyring':
+        # A keyring backend may be selected (e.g. SecretService on Linux)
+        # yet be completely unusable at runtime - for example in a headless
+        # or RDP session where there is no running D-Bus / GNOME Keyring.
+        # In that case every keyring call raises and the crypt key is never
+        # set, surfacing as a bare CryptKeyMissing on every operation.
+        # Probe the backend with a harmless read of an entry that never
+        # exists; if the backend is healthy this returns None without
+        # prompting, and if it is unusable it raises. When it is not usable,
+        # disable OS secret storage so pgAdmin falls back to the
+        # master-password / in-app crypt key mechanism.
+        keyring_usable = k_name != 'fail Keyring'
+        if keyring_usable:
+            try:
+                keyring.get_password(
+                    'pgAdmin4', 'entry_to_check_keyring_access')
+            except Exception:
+                keyring_usable = False
+
+        if not keyring_usable:
+            # Setup USE_OS_SECRET_STORAGE false as no usable keyring backend
             config['USE_OS_SECRET_STORAGE'] = False
             config['KEYRING_NAME'] = ''
         else:


### PR DESCRIPTION
### Summary
Fixes #10107 — in Desktop mode on Debian 13 (Trixie) under an RDP session (no D-Bus / GNOME Keyring available), pgAdmin fails with a bare `CryptKeyMissing` on every server-registration or connect attempt, instead of falling back to the master-password mechanism.

### Root Cause
`evaluate_and_patch_config()` only disables `USE_OS_SECRET_STORAGE` when `keyring.get_keyring().name == 'fail Keyring'` — i.e. when the `keyring` library couldn't find *any* backend at all. On Debian 13 over RDP, a real backend (e.g. `SecretService`) **is** selected (so the name check passes), but it's non-functional because there's no D-Bus/GNOME Keyring session running in that environment. Every actual keyring read/write then fails silently at a different layer, the crypt key never gets set, and `Connection.connect()` unconditionally raises `CryptKeyMissing` whenever the key is absent — with no recovery path.

### Fix
After a keyring backend is selected, probe it with a harmless read of a never-existing entry (`keyring.get_password('pgAdmin4', 'entry_to_check_keyring_access')`). A healthy backend returns `None` without prompting (OS keyrings only prompt for *existing* entries). An unusable backend raises an exception on this probe — in that case, disable `USE_OS_SECRET_STORAGE` so the app falls back to the master-password / in-app crypt key mechanism instead of failing outright.

### Test Steps
*(Requires a Debian 13 desktop-mode environment without a working D-Bus/keyring session — e.g. an RDP session, or simulate by disabling/blocking the keyring daemon.)*
1. On an affected system, launch pgAdmin in Desktop mode and try to register a new server with "Save Password" checked.
2. **Before the fix:** operation fails with `pgadmin.utils.exception.CryptKeyMissing`.
3. **After the fix:** registration succeeds; pgAdmin instead prompts for/uses the master password mechanism, with no `CryptKeyMissing` error.
4. Regression: on a normal desktop environment where the OS keyring **does** work (e.g. macOS Keychain, or a working Linux session), confirm `USE_OS_SECRET_STORAGE` stays enabled and passwords are still stored via the OS keyring as before (no unnecessary fallback).
5. Confirm Server mode (Debian 13, browser access) is unaffected, per the original report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unavailable or unusable OS keyring providers.
  * Automatically disables OS secret storage and clears the keyring setting when the configured provider cannot be used.
  * Preserves the selected keyring configuration when availability is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->