### PR TITLE
fix: render disconnect tree label via className, not embedded HTML

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/static/js/database.js
+++ b/web/pgadmin/browser/server_groups/servers/databases/static/js/database.js
@@ -523,8 +523,7 @@ define('pgadmin.node.database', [
           i = item,
           label = data.label;
         let disconnect = function() {
-          d.label = `<span class='text-muted'>[Disconnecting...]</span> ${label}`;
-          t.setLabel(i,{label:d.label});
+          t.setLabel(i, {label: `[Disconnecting...] ${label}`, className: 'text-muted'});
           t.close(i);
           let data = d;
           getApiInstance().delete(

--- a/web/pgadmin/browser/server_groups/servers/static/js/server.js
+++ b/web/pgadmin/browser/server_groups/servers/static/js/server.js
@@ -822,8 +822,7 @@ define('pgadmin.node.server', [
         label = data.label;
 
       let disconnect = function() {
-        d.label = `<span class='text-muted'>[Disconnecting...]</span> ${label}`;
-        t.setLabel(i,{label:d.label});
+        t.setLabel(i, {label: `[Disconnecting...] ${label}`, className: 'text-muted'});
         t.close(i);
         getApiInstance().delete(
           obj.generate_url(i, 'connect', d, true),

--- a/web/pgadmin/static/js/components/PgTree/FileTreeX/index.tsx
+++ b/web/pgadmin/static/js/components/PgTree/FileTreeX/index.tsx
@@ -455,10 +455,15 @@ export class FileTreeX extends React.Component<IFileTreeXProps> {
       const label$ = ref.querySelector('span.file-name') as HTMLDivElement;
 
       if (label$) {
+        let className = '';
         if (typeof(label) == 'object' && label.label) {
+          className = label.className ?? '';
           label = label.label;
         }
+        // Render the label as plain text (never as an HTML string) and apply
+        // any requested styling via a CSS class instead of embedding markup.
         label$.textContent = label;
+        label$.className = 'file-name' + (className ? ' ' + className : '');
       }
 
     }


### PR DESCRIPTION
### Summary
Fixes #10106 — when disconnecting a server (or database), the Object Explorer tree node briefly shows the literal text `<span class='text-muted'>[Disconnecting...]</span>` instead of a greyed-out "[Disconnecting...]" label.

### Root Cause
The disconnect handlers in `server.js` / `database.js` built the transitional tree-node label as an **HTML string** and passed it straight to the tree's `setLabel()`. `FileTreeX`'s `setLabel()` writes the label via `label.textContent`, which — correctly — escapes any markup rather than rendering it, so the raw tag text is displayed verbatim instead of being interpreted as HTML.

### Fix
Have the disconnect handlers pass plain text (`[Disconnecting...] ${label}`) plus a `className: 'text-muted'` instead of an HTML string. `setLabel()` now applies that className to the label `<span>` (and resets it to the default `file-name` class otherwise), so the muted styling comes from CSS rather than injected markup.

### Test Steps
1. In the Object Explorer, expand Servers and connect to any server.
2. Right-click the connected server → Disconnect Server (or use the toolbar disconnect action).
3. Watch the tree node label during the transition.
4. **Expected:** label reads a greyed-out `[Disconnecting...] <server name>` — not the literal `<span class='text-muted'>...</span>` markup text.
5. Repeat for a connected database node's disconnect path if applicable.
6. Confirm the label correctly returns to normal (non-muted) styling once disconnected / on reconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server and database disconnection status labels with consistent muted styling.
  * Prevented label content from being interpreted as HTML, improving display safety.
  * Ensured tree labels update correctly when custom styling is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->