### PR TITLE
feat: add preference for default View Data row limit

### DIFF
--- a/web/pgadmin/tools/sqleditor/command.py
+++ b/web/pgadmin/tools/sqleditor/command.py
@@ -363,6 +363,14 @@ class GridCommand(BaseCommand, SQLFilter, FetchedRowTracker):
 
         if self.cmd_type in (VIEW_FIRST_100_ROWS, VIEW_LAST_100_ROWS):
             self.limit = 100
+        elif self.cmd_type == VIEW_ALL_ROWS:
+            # Apply the user-configurable default row limit (if any) for the
+            # "All Rows" option. A value of 0 (the default) means no limit,
+            # preserving the existing behaviour of fetching all rows.
+            default_row_limit = Preferences.module('sqleditor').preference(
+                'view_data_default_row_limit').get()
+            if default_row_limit and default_row_limit > 0:
+                self.limit = default_row_limit
 
         self.thread_native_id = None
         self.server_cursor = kwargs['server_cursor'] if\

--- a/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
+++ b/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
@@ -120,6 +120,21 @@ def register_query_tool_preferences(self):
                          "First/Last 100 Rows options, data is always sorted.")
     )
 
+    self.view_data_default_row_limit = self.preference.register(
+        'Options', 'view_data_default_row_limit',
+        gettext("Default row limit for View Data"), 'integer', 0,
+        min_val=0,
+        category_label=PREF_LABEL_OPTIONS,
+        help_str=gettext(
+            "Specify the maximum number of rows to fetch when using the "
+            "View/Edit Data - All Rows option. This appends a LIMIT clause "
+            "to the generated query, which can significantly improve "
+            "performance on very large tables. Set to 0 (the default) to "
+            "fetch all rows with no limit (the existing behavior). This "
+            "does not affect the First/Last 100 Rows options."
+        )
+    )
+
     self.show_prompt_save_data_changes = self.preference.register(
         'Options', 'prompt_save_data_changes',
         gettext("Prompt to save unsaved data changes?"), 'boolean', True,


### PR DESCRIPTION
### Summary
Closes #10104 — adds a preference to cap the row count fetched by the plain "View Data" action, so it's usable on large tables without always doing a full `SELECT *`.

### Root Cause
Not a bug — a missing option. The Object Explorer's unqualified "View Data" shortcut always runs with no `LIMIT`, unlike "First 100 Rows" / "Last 100 Rows", which hardcode `limit=100`. On a large table, "View Data" always tries to fetch every row, and there was no way to change that default short of manually running a query with a `LIMIT`.

### Fix
Add a new preference `view_data_default_row_limit` (integer, default `0` = unlimited, preserving current behavior) under the sqleditor module's Options category. In `GridCommand.__init__`, when `cmd_type == VIEW_ALL_ROWS`, read this preference and set `self.limit` to it if positive. The existing `objectquery.sql` template already renders a `LIMIT` clause only when `limit > 0`, so no template changes are needed. "First/Last 100 Rows" are untouched — they keep their own hardcoded limit.

### Test Steps
1. Open Preferences → SQL Editor / Options (or wherever the sqleditor preferences group renders) and confirm a new "Default View Data row limit" (or similarly labeled) integer preference exists, defaulting to `0`.
2. With the preference left at `0`, right-click a table → View/Edit Data → View Data. Confirm behavior is unchanged (no `LIMIT` applied) from before this change.
3. Set the preference to e.g. `50`, then View Data on a table with more than 50 rows. Confirm exactly 50 rows load.
4. Confirm "First 100 Rows" and "Last 100 Rows" still fetch exactly 100 rows regardless of this preference's value.
5. Set the preference back to `0` and confirm "View Data" returns to unlimited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable row limit for the “View/Edit Data – All Rows” option.
  * A limit greater than zero now restricts the number of displayed rows.
  * The default setting of zero preserves the existing unlimited behavior.
  * The First 100 Rows and Last 100 Rows options remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->