### PR TITLE
fix: Schema Diff filter chip toggle broadcasting stale empty selection

### DIFF
--- a/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffButtonComponent.jsx
+++ b/web/pgadmin/tools/schema_diff/static/js/components/SchemaDiffButtonComponent.jsx
@@ -112,21 +112,22 @@ export function SchemaDiffButtonComponent({ sourceData, targetData, selectedRowI
   }, [filters]);
 
   const selectFilterOption = (option) => {
-    let newOptions = [];
-    setSelectedFilters((prev) => {
-      let newSelectdOptions = [...prev];
-      let removeIndex = newSelectdOptions.indexOf(option);
-      if (prev.includes(option)) {
-        newSelectdOptions.splice(removeIndex, 1);
-      } else {
-        newSelectdOptions.push(option);
-      }
-      newOptions = [...newSelectdOptions];
-      return newSelectdOptions;
-    });
+    // Derive the new selection synchronously from the current state.
+    // The new array must be computed here (not inside a setState updater)
+    // because React invokes functional updaters lazily during render, so a
+    // value assigned inside the updater is not yet available when the event
+    // below fires. Reading it there previously broadcast an empty filter
+    // list, which blanked the results tree on every chip toggle. #10102
+    let newSelectedOptions = [...selectedFilters];
+    let removeIndex = newSelectedOptions.indexOf(option);
+    if (removeIndex !== -1) {
+      newSelectedOptions.splice(removeIndex, 1);
+    } else {
+      newSelectedOptions.push(option);
+    }
 
-    let filterParam = newOptions;
-    eventBus.fireEvent(SCHEMA_DIFF_EVENT.TRIGGER_CHANGE_FILTER, { filterParams: filterParam });
+    setSelectedFilters(newSelectedOptions);
+    eventBus.fireEvent(SCHEMA_DIFF_EVENT.TRIGGER_CHANGE_FILTER, { filterParams: newSelectedOptions });
   };
 
   const selectCompareOption = (option) => {


### PR DESCRIPTION
### Summary
Fixes #10102 — in Tools → Schema Diff, toggling a result-status filter chip off and back on shows "No difference found" even when real differences exist, until the whole comparison is re-run.

### Root Cause
`selectFilterOption()` computed the new chip selection (`newOptions`) **inside** the functional form of `setSelectedFilters(prev => {...})`, then immediately used that same `newOptions` variable to dispatch `TRIGGER_CHANGE_FILTER` synchronously in the same tick. React's functional state updater runs lazily during the next render — so at the point the event was dispatched, `newOptions` was still its initial empty array. Every chip toggle therefore broadcast an **empty** filter, `prepareRows()` had nothing to render, and the tree went blank. The initial "Compare" click worked fine only because it reads `selectedFilters` state directly rather than going through this buggy path.

### Fix
Compute the new filter selection synchronously from the current `selectedFilters` state (not from inside the `setSelectedFilters` updater callback), and use that same synchronously-computed array both to update state and to dispatch the change event — so the event and the state always agree.

### Test Steps
1. Tools → Schema Diff → pick a source/target database or schema pair with real differences (some objects "Source Only", "Target Only", and "Different").
2. Click Compare — confirm the results tree shows non-zero counts.
3. Open the Filter dropdown, click a status chip to deselect it (e.g. "Identical").
4. Click the same chip again to re-enable it.
5. **Expected:** the results tree restores exactly the rows that match the now-active filters, with correct counts at every level — no "No difference found" flash, no need to re-run Compare.
6. Repeat with multiple chips toggled in different orders to confirm no combination re-breaks it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema diff filter selection so applied filters are consistently reflected immediately.
  * Corrected filter change notifications to report the current selection accurately when toggling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->