### PR TITLE
fix: ALT+F5 not falling back to statement under cursor

### DIFF
--- a/web/pgadmin/tools/sqleditor/static/js/components/sections/Query.jsx
+++ b/web/pgadmin/tools/sqleditor/static/js/components/sections/Query.jsx
@@ -143,13 +143,23 @@ export default function Query({onTextSelect, setQtStatePartial}) {
     if(queryToolCtx.params.is_query_tool) {
       let external = null;
       let query = editor.current?.getSelection();
+      /* getSelection() flattens all selection ranges joined by the line
+       * separator (to support running non-continuous highlighted blocks).
+       * When nothing is actually highlighted this can still yield a
+       * whitespace-only string (e.g. several empty cursors joined by
+       * newlines), which is truthy and would suppress the cursor /
+       * whole-editor fallbacks below - making ALT+F5 (Execute query) do
+       * nothing. Treat a whitespace-only selection as no selection. #10109 */
+      if(!query?.trim()) {
+        query = '';
+      }
       if(!_.isEmpty(macroSQL)) {
         const regex = /\$SELECTION\$/gi;
         query =  macroSQL.replace(regex, query);
         external = true;
       } else if(executeCursor || explainObject) {
         /* Execute query at cursor position or explain query at cursor position */
-        query = query || editor.current?.getQueryAt(editor.current?.state.selection.head).value || '';
+        query = query || editor.current?.getQueryAt(editor.current?.state.selection.main.head).value || '';
       } else {
         /* Normal execution */
         query = query || editor.current?.getValue() || '';
@@ -443,7 +453,12 @@ export default function Query({onTextSelect, setQtStatePartial}) {
 
   const checkUnderlineQueryCursorWarning = () => {
     let query = editor.current?.getSelection();
-    query = query || editor.current?.getQueryAt(editor.current?.state.selection.head).value || '';
+    /* Ignore a whitespace-only selection so the warning previews the query
+     * under the cursor, matching triggerExecution. #10109 */
+    if(!query?.trim()) {
+      query = '';
+    }
+    query = query || editor.current?.getQueryAt(editor.current?.state.selection.main.head).value || '';
     query && queryToolCtx.modal.showModal(gettext('Execute query'), (closeModal) =>{
       return (<ConfirmExecuteQueryContent
         closeModal={closeModal}


### PR DESCRIPTION
### Summary
Fixes #10109 — `ALT+F5` ("Execute query at cursor") does nothing when the cursor is on/near a statement that isn't highlighted, in a Query Tool tab with multiple statements separated by blank lines.

### Root Cause
`triggerExecution()` computes `query = getSelection()` and only falls back to `getQueryAt(cursor)` when `query` is falsy. Since the fix for #7293/#8691 (support running non-continuous highlighted blocks), `getSelection()` flattens *all* selection ranges and joins them — so even with no real text highlighted, multiple empty cursor ranges can produce a **truthy but whitespace-only** string (e.g. `"\n"`). That truthy value skips the `getQueryAt` fallback entirely, so `ALT+F5` ends up trying to execute whitespace and silently does nothing. The same stale check exists in `checkUnderlineQueryCursorWarning()`. There is also a latent, previously-masked bug: `state.selection.head` is referenced where `EditorSelection` has no such property — the correct field is `state.selection.main.head`.

### Fix
Treat a whitespace-only `getSelection()` result as empty (`if (!query?.trim()) query = '';`) before the fallback check, in both `triggerExecution()` and `checkUnderlineQueryCursorWarning()`, so statement-at-cursor detection applies again whenever there's no genuine highlighted text. A real highlighted selection always contains non-whitespace, so the #7293/#9570 fix for running highlighted (including non-continuous) blocks is unaffected. Also corrects the `state.selection.head` → `state.selection.main.head` reference.

### Test Steps
1. Open the Query Tool and type:
   ```sql
   select 1

   select 2
   ```
2. Click to place the cursor on/near `select 2` (no text highlighted).
3. Press `ALT+F5`.
4. **Expected:** only `select 2` executes and returns its result — not both statements, not nothing.
5. Move the cursor to `select 1` and repeat — confirm `select 1` executes.
6. Regression: highlight `select 1` (a real selection) and press `F5`/`ALT+F5` — confirm the highlighted statement still executes correctly (this must not regress #9570/#7293).
7. Regression: highlight two non-continuous blocks (per #7293's original fix) and confirm both still execute together as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query execution when editor selections contain only whitespace.
  * Prevented empty selection-based execution and cursor warning previews from running unnecessarily.
  * Improved cursor-based query detection for more reliable execution and warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->