### PR TITLE
fix: don't hard-fail on an undecryptable saved password

### DIFF
--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -271,6 +271,13 @@ class Connection(BaseConnection):
                     'decrypted. The user will be prompted for the password. '
                     'Error: {0}'.format(str(e))
                 )
+                # Clear the cached ciphertext so it isn't silently reused
+                # on the next connect() attempt, which would just hit
+                # this same decode failure again, and (since a stale but
+                # still-truthy encpass would otherwise remain cached)
+                # skip the passexec fallback below.
+                self.password = None
+                manager.password = None
                 return False, '', None
         return False, '', password
 

--- a/web/pgadmin/utils/driver/psycopg3/connection.py
+++ b/web/pgadmin/utils/driver/psycopg3/connection.py
@@ -258,12 +258,20 @@ class Connection(BaseConnection):
                 if isinstance(password, bytes):
                     password = password.decode()
             except Exception as e:
-                manager.stop_ssh_tunnel()
-                current_app.logger.exception(e)
-                return True, \
-                    _(
-                        "Failed to decrypt the saved password.\nError: {0}"
-                    ).format(str(e)), password
+                # The saved password could not be decrypted. This happens
+                # when the stored ciphertext was encrypted with a different
+                # key (e.g. OIDC/OAuth2 logins where the derived encryption
+                # key changed between sessions), leaving un-decodable bytes
+                # (typically a "'utf-8' codec can't decode byte 0x.." error).
+                # Instead of failing every connection attempt permanently,
+                # discard the bad saved password and continue so the user is
+                # prompted for the password again.
+                current_app.logger.warning(
+                    'Ignoring the saved password as it could not be '
+                    'decrypted. The user will be prompted for the password. '
+                    'Error: {0}'.format(str(e))
+                )
+                return False, '', None
         return False, '', password
 
     def connect(self, **kwargs):


### PR DESCRIPTION
### Summary
Fixes #10140 — some OIDC/OAuth2 users intermittently get a hard `Failed to decrypt the saved password` error on every connection attempt, and the account stays broken even after being deleted and recreated via OIDC.

### Root Cause
`Connection._decode_password()` calls `decrypt()` (AES-CFB8, unauthenticated) on the stored password ciphertext and lets any `UnicodeDecodeError` from a failed decrypt propagate as a hard error. For OIDC/OAuth2 logins, the crypt key used to encrypt a saved password can differ between sessions; if it does, the ciphertext saved under a previous key can **never** be decoded correctly under the current key, and every connection attempt hits this same decode failure — surfacing the scary, unrecoverable-looking "Failed to decrypt the saved password" error. Deleting and recreating the pgAdmin user doesn't help because the problem is in the stored ciphertext for the server record, not the user record.

### Fix
Catch the decode failure in `_decode_password()`, log a warning, and return an empty/no-password result instead of propagating the exception — i.e. treat an undecryptable saved password the same as "no saved password was ever set." `connect()` then falls through to its normal password-prompt path, so the user is prompted for and can re-enter the correct password, making the account recoverable instead of permanently stuck. OIDC/OAuth2 crypt-key derivation itself is untouched by this change.

### Test Steps
*(Exact repro requires an OIDC/OAuth2 setup where the crypt key can rotate between sessions; a close approximation can be done by directly corrupting a stored password's ciphertext in the config DB for a test server.)*
1. Set up a server with a saved password (Save Password enabled).
2. Simulate a crypt-key change or corrupt the stored `password` ciphertext for that server record so it no longer decrypts under the current key.
3. Attempt to connect to that server.
4. **Before the fix:** connection attempt fails immediately with "Failed to decrypt the saved password", with no path to recovery.
5. **After the fix:** the bad saved password is silently discarded; pgAdmin instead prompts for the password normally, and entering the correct password connects successfully.
6. Regression: confirm a server with a valid, correctly-encrypted saved password still connects automatically without any prompt (no over-broad fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling when a saved password cannot be decrypted.
  * Invalid or unusable saved passwords are now safely ignored and cleared.
  * Instead of failing immediately, the connection process now prompts you to enter your password again.
  * Improved execution reliability for operations that require single-statement processing, including retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->