### PR TITLE
fix: pin Yarn version from packageManager field in remaining build scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=bind,source=.git,target=/pgadmin4/.git \
     npm install -g corepack && \
     corepack enable && \
     yarn set version berry && \
-    yarn set version 4 && \
+    yarn set version "$(node -p "require('./package.json').packageManager.split('@')[1]")" && \
     yarn install && \
     yarn run bundle && \
     rm -rf yarn.lock \

--- a/Make.bat
+++ b/Make.bat
@@ -221,8 +221,13 @@ REM Main build sequence Ends
 
     ECHO Installing javascript dependencies...
     CD "%BUILDROOT%\web"
+    FOR /f "delims=" %%v IN ('node -p "require('./package.json').packageManager.split('@')[1]"') DO SET "YARN_VERSION=%%v"
+    IF "%YARN_VERSION%"=="" (
+        ECHO ERROR: Could not determine Yarn version from package.json packageManager field.
+        EXIT /B 1
+    )
     CALL yarn set version berry || EXIT /B 1
-    CALL yarn set version 4 || EXIT /B 1
+    CALL yarn set version %YARN_VERSION% || EXIT /B 1
     CALL yarn install || EXIT /B 1
     CALL npm rebuild || EXIT /B 1
 
@@ -276,8 +281,13 @@ REM Main build sequence Ends
 
     CD "%BUILDROOT%\runtime\resources\app\"
 
+    FOR /f "delims=" %%v IN ('node -p "require('./package.json').packageManager.split('@')[1]"') DO SET "YARN_VERSION=%%v"
+    IF "%YARN_VERSION%"=="" (
+        ECHO ERROR: Could not determine Yarn version from package.json packageManager field.
+        EXIT /B 1
+    )
     CALL yarn set version berry || EXIT /B 1
-    CALL yarn set version 4 || EXIT /B 1
+    CALL yarn set version %YARN_VERSION% || EXIT /B 1
     CALL yarn workspaces focus --production || EXIT /B 1
 
     ECHO Removing yarn cache...

--- a/Make.bat
+++ b/Make.bat
@@ -221,6 +221,7 @@ REM Main build sequence Ends
 
     ECHO Installing javascript dependencies...
     CD "%BUILDROOT%\web"
+    SET "YARN_VERSION="
     FOR /f "delims=" %%v IN ('node -p "require('./package.json').packageManager.split('@')[1]"') DO SET "YARN_VERSION=%%v"
     IF "%YARN_VERSION%"=="" (
         ECHO ERROR: Could not determine Yarn version from package.json packageManager field.
@@ -281,6 +282,7 @@ REM Main build sequence Ends
 
     CD "%BUILDROOT%\runtime\resources\app\"
 
+    SET "YARN_VERSION="
     FOR /f "delims=" %%v IN ('node -p "require('./package.json').packageManager.split('@')[1]"') DO SET "YARN_VERSION=%%v"
     IF "%YARN_VERSION%"=="" (
         ECHO ERROR: Could not determine Yarn version from package.json packageManager field.

--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -66,8 +66,13 @@ _build_runtime() {
 
     # Install the runtime node_modules, then replace the package.json
     pushd "${BUNDLE_DIR}/Contents/Resources/app/" > /dev/null || exit
+        YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        if [ -z "${YARN_VERSION}" ]; then
+            echo "ERROR: Could not determine Yarn version from package.json packageManager field."
+            exit 1
+        fi
         yarn set version berry
-        yarn set version 4
+        yarn set version "${YARN_VERSION}"
         yarn workspaces focus --production
 
         # remove the yarn cache
@@ -298,8 +303,13 @@ _complete_bundle() {
 
     # Build node modules
     pushd "${SOURCE_DIR}/web" > /dev/null || exit
+        YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        if [ -z "${YARN_VERSION}" ]; then
+            echo "ERROR: Could not determine Yarn version from package.json packageManager field."
+            exit 1
+        fi
         yarn set version berry
-        yarn set version 4
+        yarn set version "${YARN_VERSION}"
         yarn install 2>&1
 
         # Record the source commit hash before the heavy lint/webpack

--- a/pkg/pip/build.sh
+++ b/pkg/pip/build.sh
@@ -56,8 +56,13 @@ do
     tar cf - "${FILE}" | (cd ../pip-build/pgadmin4; tar xf -)
 done
 
+YARN_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+if [ -z "${YARN_VERSION}" ]; then
+    echo "ERROR: Could not determine Yarn version from package.json packageManager field."
+    exit 1
+fi
 yarn set version berry
-yarn set version 4
+yarn set version "${YARN_VERSION}"
 yarn install
 yarn run bundle
 


### PR DESCRIPTION
## Summary
- #10156 fixed CI build failures caused by Yarn 4.x fetching a newer patch with different builtin compat hashes, which broke `--immutable` lockfile validation, but only patched `pkg/linux/build-functions.sh` and the GitHub Actions workflows.
- `Make.bat`, `pkg/mac/build-functions.sh`, `pkg/pip/build.sh`, and `Dockerfile` still hardcoded `yarn set version 4`, which is what caused the Windows Jenkins snapshot build to fail (job `pgadmin4-windows-x64-snapshot` #1669, `The lockfile would have been modified by this install, which is explicitly forbidden.`).
- This applies the same fix pattern: derive the Yarn version from each workspace's `package.json` `packageManager` field instead of hardcoding a major version.

## Test plan
- [ ] Windows Jenkins snapshot build succeeds
- [ ] macOS build succeeds (both runtime and web node_modules install steps)
- [ ] Docker image build succeeds
- [ ] pip package build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build and packaging processes now use the Yarn version specified in the project’s `package.json` `packageManager` field instead of a fixed Yarn version.
  * Added explicit, early build failures when the Yarn version cannot be determined.
  * Improved consistency across Docker, Windows, macOS, and Python package build steps by aligning Yarn setup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->