### PR TITLE
Fix: Response not iterable on trigger expansion

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py
@@ -322,7 +322,8 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
             sql = render_template("/".join(
                 [self.trigger_function_template_path, self._NODE_SQL]),
                 scid=trigger_function_schema_oid,
-                fnid=rset['rows'][0]['tfuncoid']
+                fnid=rset['rows'][0]['tfuncoid'],
+                conn=self.conn
             )
             status, res = self.conn.execute_2darray(sql)
             if not status:

--- a/web/pgadmin/browser/utils.py
+++ b/web/pgadmin/browser/utils.py
@@ -343,6 +343,12 @@ class NodeView(View, metaclass=type(MethodView)):
         """Build a list of treeview nodes from the child nodes."""
         children = self.get_children_nodes(*args, **kwargs)
 
+        # get_children_nodes may return a Flask Response (e.g. an error
+        # response) instead of a list of nodes. In that case return it as-is
+        # rather than trying to iterate/sort it.
+        if isinstance(children, flask.Response):
+            return children
+
         # Return sorted nodes based on label
         return make_json_response(
             data=sorted(
@@ -453,10 +459,18 @@ class PGChildNodeView(NodeView):
                 )
             )
 
+        children = self.get_children_nodes(manager, **kwargs)
+
+        # get_children_nodes may return a Flask Response (e.g. an error
+        # response) instead of a list of nodes. In that case return it as-is
+        # rather than trying to iterate/sort it.
+        if isinstance(children, flask.Response):
+            return children
+
         # Return sorted nodes based on label
         return make_json_response(
             data=sorted(
-                self.get_children_nodes(manager, **kwargs),
+                children,
                 key=lambda c: c['label']
             )
         )


### PR DESCRIPTION
### Summary
Fixes #10117 — expanding a Trigger node under a Table to view its trigger function throws `'Response' object is not iterable`, crashing the tree instead of showing the function (or a clean error).

### Root Cause
Two separate bugs on the same code path, `TriggerView.get_children_nodes()`:

1. **The reported crash:** `get_children_nodes()` can legitimately return a Flask `Response` instead of a list — e.g. `gone("Could not find the specified trigger function")` when the trigger's function has no matching row in the trigger-function node query (see #2). `NodeView.children()` / `PGChildNodeView.children()` unconditionally called `sorted(...)` on whatever `get_children_nodes()` returned, so a `Response` blew up with `'Response' object is not iterable` instead of being passed through.
2. **A masked regression found while testing the fix for #1:** the `render_template()` call that builds the trigger-function `node.sql` query never passed `conn=` into the template context, even though the template quotes `fnid` via `{{ fnid|qtLiteral(conn) }}`. This call site predates `qtLiteral` requiring a connection; after `qtLiteral` was hardened (in `658bb585d`) to `raise ValueError` instead of silently degrading when `conn` is missing, this call started raising on **every** trigger expansion (not just the internal-language case), which is what actually surfaced while verifying fix #1 — before that, it looked like every trigger's function node was broken with a `qtLiteral requires a connection` 500 error, masking the narrower, real #10117 repro underneath.

### Fix
1. In `NodeView.children()` and `PGChildNodeView.children()` (`web/pgadmin/browser/utils.py`), check `isinstance(children, flask.Response)` before sorting/iterating, and return the Response as-is when it is one.
2. In `TriggerView.get_children_nodes()` (`web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py`), pass `conn=self.conn` into the `node.sql` render call, matching every other `render_template` call site in the file.

### Test Steps
1. Run the following against a test database — it creates a table with two triggers, one using a genuine PostgreSQL built-in **internal**-language trigger function, and one using a normal `plpgsql` trigger function:
   ```sql
   CREATE TABLE trigger_bug_test (id int PRIMARY KEY, val text);

   -- Built into every PostgreSQL server since 9.0, LANGUAGE internal.
   CREATE FUNCTION my_redundant_trigger() RETURNS trigger LANGUAGE internal
     AS 'suppress_redundant_updates_trigger';
   CREATE TRIGGER trg_suppress_redundant BEFORE UPDATE ON trigger_bug_test
     FOR EACH ROW EXECUTE FUNCTION my_redundant_trigger();

   -- A normal, ordinary plpgsql trigger function.
   CREATE FUNCTION trg_normal_plpgsql_fn() RETURNS trigger LANGUAGE plpgsql AS $$
   BEGIN
       NEW.val := coalesce(NEW.val, '') || '_touched';
       RETURN NEW;
   END;
   $$;
   CREATE TRIGGER trg_normal_plpgsql BEFORE INSERT ON trigger_bug_test
     FOR EACH ROW EXECUTE FUNCTION trg_normal_plpgsql_fn();
   ```
2. In the Object Explorer, expand `trigger_bug_test > Triggers > trg_suppress_redundant`.
   - **Before the fix:** `'Response' object is not iterable`.
   - **After the fix:** a clean "Could not find the specified trigger function" message — expected, since pgAdmin can't browse internal-language function source; no crash.
3. Expand `trigger_bug_test > Triggers > trg_normal_plpgsql`.
   - **Before the `conn=self.conn` fix:** `qtLiteral requires a connection` 500 error.
   - **After the fix:** expands normally and shows the `trg_normal_plpgsql_fn()` function node.
4. Regression: expand a trigger on any other existing table in the test database and confirm its function node still displays correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading browser tree nodes, ensuring error responses are displayed correctly instead of causing additional processing failures.
  * Improved trigger-function detail loading for database trigger nodes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->