### PR TITLE
Fix for #10187 -PG 19 extension changes breaks pgAdmin extension UI

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/extensions/templates/extensions/sql/properties.sql
+++ b/web/pgadmin/browser/server_groups/servers/databases/extensions/templates/extensions/sql/properties.sql
@@ -7,7 +7,7 @@ SELECT
 FROM
     pg_catalog.pg_extension x
     LEFT JOIN pg_catalog.pg_namespace n ON x.extnamespace=n.oid
-    JOIN pg_catalog.pg_available_extensions() e(name, default_version, comment) ON x.extname=e.name
+    JOIN pg_catalog.pg_available_extensions() e ON x.extname=e.name
 {%- if eid %}
  WHERE x.oid = {{eid}}::oid
 {% elif ename %}

--- a/web/pgadmin/tools/search_objects/templates/search_objects/sql/pg/default/search.sql
+++ b/web/pgadmin/tools/search_objects/templates/search_objects/sql/pg/default/search.sql
@@ -473,7 +473,7 @@ FROM (
     {{ show_node_prefs['extension'] }} AS show_node, NULL AS other_info
     FROM pg_catalog.pg_extension x
     JOIN pg_catalog.pg_namespace n on x.extnamespace=n.oid
-    join pg_catalog.pg_available_extensions() e(name, default_version, comment) ON x.extname=e.name
+    join pg_catalog.pg_available_extensions() e ON x.extname=e.name
 {% endif %}
 {% if all_obj %}
     UNION

--- a/web/pgadmin/tools/search_objects/templates/search_objects/sql/ppas/default/search.sql
+++ b/web/pgadmin/tools/search_objects/templates/search_objects/sql/ppas/default/search.sql
@@ -508,7 +508,7 @@ FROM (
     {{ show_node_prefs['extension'] }} AS show_node, NULL AS other_info
     FROM pg_catalog.pg_extension x
     JOIN pg_catalog.pg_namespace n on x.extnamespace=n.oid
-    join pg_catalog.pg_available_extensions() e(name, default_version, comment) ON x.extname=e.name
+    join pg_catalog.pg_available_extensions() e ON x.extname=e.name
 {% endif %}
 {% if all_obj %}
     UNION


### PR DESCRIPTION
Fixes #10187 
Extension UI gives error with PG 19
column reference "comment" is ambiguous LINE 5: e.comment

Issue caused because in pg19 :

SELECT * FROM pg_catalog.pg_available_extensions();

now outputs an additional column `location`
after default_version and comment is now 4th column.

Removed the aliasing cause the aliasing was redundant since pg_available_extensions() already names them as expected using out parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension metadata queries for better compatibility with current PostgreSQL function output.
  * Extension properties and search results continue to display extension information consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->