### PR TITLE
fix: scan all Mach-O binaries for bundle linkage, not just .so/.dylib

### DIFF
--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -515,7 +515,10 @@ _verify_bundle_linkage() {
         echo "ERROR: ${f} links against build-host libraries:" >&2
         echo "${deps}" | sed 's/^/    /' >&2
         found="yes"
-    done < <(find "${BUNDLE_DIR}" \( -name '*.so' -o -name '*.dylib' \) -type f)
+    done < <(find "${BUNDLE_DIR}" -type f -perm +111 -exec file "{}" \; | \
+        grep -v "(for architecture" | \
+        grep -E "Mach-O executable|Mach-O 64-bit executable|Mach-O 64-bit bundle|Mach-O 64-bit dynamically linked shared library" | \
+        awk -F":" '{print $1}' | uniq)
 
     if [ -n "${found}" ]; then
         echo "ERROR: the bundle links against libraries outside it; those paths" >&2

--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -515,7 +515,7 @@ _verify_bundle_linkage() {
         echo "ERROR: ${f} links against build-host libraries:" >&2
         echo "${deps}" | sed 's/^/    /' >&2
         found="yes"
-    done < <(find "${BUNDLE_DIR}" -type f -perm +111 -exec file "{}" \; | \
+    done < <(find "${BUNDLE_DIR}" -type f -exec file "{}" \; | \
         grep -v "(for architecture" | \
         grep -E "Mach-O executable|Mach-O 64-bit executable|Mach-O 64-bit bundle|Mach-O 64-bit dynamically linked shared library" | \
         awk -F":" '{print $1}' | uniq)


### PR DESCRIPTION
### Summary
Follow-up to #10135 (merged). CodeRabbit flagged that `_verify_bundle_linkage`'s scan only matched files by `.so`/`.dylib` name suffix, so a shipped executable (`Contents/MacOS/*`) or a `Python.framework` payload carrying a host-linked dependency but no matching suffix would slip through the check unnoticed — the exact class of bug #10135 was added to catch in the first place.

### Fix
Detect Mach-O executables/libraries by content (via `file`), the same pattern the codesign step in this file already uses, instead of filtering by extension:

```diff
-    done < <(find "${BUNDLE_DIR}" \( -name '*.so' -o -name '*.dylib' \) -type f)
+    done < <(find "${BUNDLE_DIR}" -type f -perm +111 -exec file "{}" \; | \
+        grep -v "(for architecture" | \
+        grep -E "Mach-O executable|Mach-O 64-bit executable|Mach-O 64-bit bundle|Mach-O 64-bit dynamically linked shared library" | \
+        awk -F":" '{print $1}' | uniq)
```

### Testing
macOS build script only, no runtime code paths affected. `bash -n pkg/mac/build-functions.sh` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS bundle verification by expanding the set of inspected binaries to include Mach-O applications, bundles, and shared libraries, based on actual file types.
  * Enhanced detection of unintended build-environment library references during release validation by running dependency install-name checks against the newly identified set of relevant binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->