### PR TITLE
fix: remove unused sqlalchemy exists import in server_access.py

### DIFF
--- a/web/pgadmin/utils/server_access.py
+++ b/web/pgadmin/utils/server_access.py
@@ -14,7 +14,7 @@ helpers enforce that users can only access servers they own or that
 have been explicitly shared with them via SharedServer entries.
 """
 
-from sqlalchemy import or_, case, exists, func, literal
+from sqlalchemy import or_, case, func, literal
 from flask_security import current_user
 
 from pgadmin.model import db, Server, ServerGroup


### PR DESCRIPTION
### Summary
Follow-up to #10077 (merged) — review flagged that the `exists` symbol imported from `sqlalchemy` on line 17 is never called. Verified: the only other `exists` occurrence in the file is `.exists()` at line 165, which is a method call on a `Query` instance, unrelated to this import.

### Fix
Drop `exists` from the import list. No behavior change.

### Testing
`python3 -m pycodestyle --config=.pycodestyle web/pgadmin/utils/server_access.py` clean, `ast.parse` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up an unused internal import.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->