### PR TITLE
fix: report the correct error message on trigger node.sql failure

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/databases/schemas/tables/triggers/__init__.py
@@ -327,7 +327,7 @@ class TriggerView(PGChildNodeView, SchemaDiffObjectCompare):
             )
             status, res = self.conn.execute_2darray(sql)
             if not status:
-                return internal_server_error(errormsg=rset)
+                return internal_server_error(errormsg=res)
 
             if len(res['rows']) == 0:
                 return gone(gettext(


### PR DESCRIPTION
### Summary
Follow-up to #10177 (merged) — review of that PR flagged an adjacent, pre-existing bug in the same function it touched.

### Bug
In `TriggerFunctionView` (or equivalent trigger-function-info flow), after resolving the trigger function's `node.sql` data:

```python
status, res = self.conn.execute_2darray(sql)
if not status:
    return internal_server_error(errormsg=rset)
```

`rset` is the result dict from the *earlier*, already-successful `get_function_oid.sql` query — not the error from the query that actually failed. Any failure on this second query (permissions, catalog access error) surfaces a stale/misleading payload instead of the real cause, making it undiagnosable.

### Fix
`errormsg=res` — the actual error string from the failed query, consistent with every other error-handling call site in this file (`errormsg=res` pattern used ~10 other times).

### Testing
`ast.parse` clean, `pycodestyle` clean. No behavior change on the success path; only the error message on this one failure path changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when loading database trigger details.
  - Error responses now display the correct query failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->