### PR TITLE
feat: add system-wide default for Geometry Viewer custom tile provider

### DIFF
--- a/docs/en_US/preferences.rst
+++ b/docs/en_US/preferences.rst
@@ -662,6 +662,12 @@ provider used as a base layer when viewing geometry data.
 When a custom tile provider is configured, it is selected as the default
 base layer of the Geometry Viewer.
 
+An administrator may set a system-wide default for these fields via the
+``DEFAULT_GEOMETRY_VIEWER_PROVIDER`` setting in :ref:`config_py`. It applies
+to any user who has not saved their own values for the fields above; a
+user's own preferences, once saved, always take precedence over the
+system-wide default.
+
 .. image:: images/preferences_graph_visualiser.png
     :alt: Preferences sqleditor graph visualiser section
     :align: center

--- a/web/config.py
+++ b/web/config.py
@@ -547,6 +547,26 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 DATA_RESULT_ROWS_PER_PAGE = 1000
 
 ##########################################################################
+# System-wide default for the Geometry Viewer's custom tile provider
+# (Query Tool > Data Output > Geometry Viewer). Applies to any user who
+# has not saved their own "Custom tile provider ..." preference; a
+# per-user preference, once set, always takes precedence over this
+# default. Leave "url" empty to keep using the built-in tile layers by
+# default (the pre-existing behaviour).
+#
+# "crs" must be one of "EPSG:3857" (Web Mercator), "EPSG:4326", or
+# "EPSG:3395" - the only coordinate reference systems the Geometry
+# Viewer's tile layer selector supports.
+##########################################################################
+DEFAULT_GEOMETRY_VIEWER_PROVIDER = {
+    "url": "",
+    "name": "Custom",
+    "crs": "EPSG:3857",
+    "attribution": "",
+    "max_zoom": 18
+}
+
+##########################################################################
 # Allow users to display Gravatar image for their username in Server mode
 ##########################################################################
 SHOW_GRAVATAR_IMAGE = True

--- a/web/pgadmin/tools/sqleditor/tests/test_geometry_viewer_provider_defaults.py
+++ b/web/pgadmin/tools/sqleditor/tests/test_geometry_viewer_provider_defaults.py
@@ -31,67 +31,46 @@ class GeometryViewerProviderDefaultsTestCase(BaseTestGenerator):
         'max_zoom': 12,
     }
 
+    # What every field falls back to when the admin-supplied value for it
+    # is missing, the wrong type, or out of range.
+    _ALL_FALLBACK = {
+        'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+        'attribution': '', 'max_zoom': 18,
+    }
+
+    _partial_override_expected = dict(_ALL_FALLBACK)
+    _partial_override_expected['url'] = \
+        'https://x.example.com/{z}/{x}/{y}.png'
+
     scenarios = [
         ('Fully valid override is used as-is',
          dict(provider=_FULL_VALID, expected=_FULL_VALID)),
 
         ('Partial override falls back for missing keys',
-         dict(
-             provider={'url': 'https://x.example.com/{z}/{x}/{y}.png'},
-             expected={
-                 'url': 'https://x.example.com/{z}/{x}/{y}.png',
-                 'name': 'Custom', 'crs': 'EPSG:3857',
-                 'attribution': '', 'max_zoom': 18,
-             })),
+         dict(provider={'url': 'https://x.example.com/{z}/{x}/{y}.png'},
+              expected=_partial_override_expected)),
 
         ('Non-dict override falls back entirely',
-         dict(provider='oops, not a dict',
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+         dict(provider='oops, not a dict', expected=_ALL_FALLBACK)),
 
         ('Unsupported CRS falls back to EPSG:3857',
-         dict(provider={'crs': 'EPSG:9999'},
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+         dict(provider={'crs': 'EPSG:9999'}, expected=_ALL_FALLBACK)),
 
         ('Out-of-range max_zoom falls back to 18',
-         dict(provider={'max_zoom': 999},
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+         dict(provider={'max_zoom': 999}, expected=_ALL_FALLBACK)),
 
         ('Non-integer max_zoom falls back to 18',
-         dict(provider={'max_zoom': '18'},
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+         dict(provider={'max_zoom': '18'}, expected=_ALL_FALLBACK)),
 
         ('Boolean max_zoom falls back to 18',
-         dict(provider={'max_zoom': True},
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+         dict(provider={'max_zoom': True}, expected=_ALL_FALLBACK)),
 
         ('Non-string name/url/attribution fall back individually',
          dict(provider={'name': 123, 'url': 456, 'attribution': 789},
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+              expected=_ALL_FALLBACK)),
 
         ('Empty dict falls back entirely',
-         dict(provider={},
-              expected={
-                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
-                  'attribution': '', 'max_zoom': 18,
-              })),
+         dict(provider={}, expected=_ALL_FALLBACK)),
     ]
 
     def runTest(self):

--- a/web/pgadmin/tools/sqleditor/tests/test_geometry_viewer_provider_defaults.py
+++ b/web/pgadmin/tools/sqleditor/tests/test_geometry_viewer_provider_defaults.py
@@ -1,0 +1,102 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+from unittest.mock import patch
+
+from pgadmin.utils.route import BaseTestGenerator
+from pgadmin.tools.sqleditor.utils import query_tool_preferences as qtp
+
+
+class GeometryViewerProviderDefaultsTestCase(BaseTestGenerator):
+    """
+    Verify resolve_geometry_viewer_provider_defaults() safely resolves
+    config.DEFAULT_GEOMETRY_VIEWER_PROVIDER, since config_local.py /
+    config_distro.py / PGADMIN_CONFIG_* replace that variable wholesale
+    rather than merging individual keys - a partial, wrong-typed, or
+    out-of-range administrator override must fall back to the original
+    hardcoded defaults instead of crashing preference registration.
+    """
+
+    _FULL_VALID = {
+        'url': 'https://internal.example.com/tiles/{z}/{x}/{y}.png',
+        'name': 'Internal',
+        'crs': 'EPSG:4326',
+        'attribution': 'Internal Corp',
+        'max_zoom': 12,
+    }
+
+    scenarios = [
+        ('Fully valid override is used as-is',
+         dict(provider=_FULL_VALID, expected=_FULL_VALID)),
+
+        ('Partial override falls back for missing keys',
+         dict(
+             provider={'url': 'https://x.example.com/{z}/{x}/{y}.png'},
+             expected={
+                 'url': 'https://x.example.com/{z}/{x}/{y}.png',
+                 'name': 'Custom', 'crs': 'EPSG:3857',
+                 'attribution': '', 'max_zoom': 18,
+             })),
+
+        ('Non-dict override falls back entirely',
+         dict(provider='oops, not a dict',
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+
+        ('Unsupported CRS falls back to EPSG:3857',
+         dict(provider={'crs': 'EPSG:9999'},
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+
+        ('Out-of-range max_zoom falls back to 18',
+         dict(provider={'max_zoom': 999},
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+
+        ('Non-integer max_zoom falls back to 18',
+         dict(provider={'max_zoom': '18'},
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+
+        ('Boolean max_zoom falls back to 18',
+         dict(provider={'max_zoom': True},
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+
+        ('Non-string name/url/attribution fall back individually',
+         dict(provider={'name': 123, 'url': 456, 'attribution': 789},
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+
+        ('Empty dict falls back entirely',
+         dict(provider={},
+              expected={
+                  'url': '', 'name': 'Custom', 'crs': 'EPSG:3857',
+                  'attribution': '', 'max_zoom': 18,
+              })),
+    ]
+
+    def runTest(self):
+        with patch.object(qtp.config, 'DEFAULT_GEOMETRY_VIEWER_PROVIDER',
+                          self.provider):
+            result = qtp.resolve_geometry_viewer_provider_defaults()
+
+        self.assertEqual(result, self.expected)

--- a/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
+++ b/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
@@ -8,16 +8,58 @@
 ##########################################################################
 
 """Register preferences for query tool"""
+import config
 from flask_babel import gettext
 from pgadmin.utils.constants import PREF_LABEL_DISPLAY, \
     PREF_LABEL_KEYBOARD_SHORTCUTS, PREF_LABEL_EXPLAIN, PREF_LABEL_OPTIONS, \
     PREF_LABEL_CSV_TXT, PREF_LABEL_RESULTS_GRID, \
     PREF_LABEL_GRAPH_VISUALISER, PREF_LABEL_GEOMETRY_VIEWER
 from pgadmin.utils import SHORTCUT_FIELDS as shortcut_fields
-from config import DATA_RESULT_ROWS_PER_PAGE, DEFAULT_GEOMETRY_VIEWER_PROVIDER
+from config import DATA_RESULT_ROWS_PER_PAGE
+
+GEOMETRY_VIEWER_CRS_CHOICES = ('EPSG:3857', 'EPSG:4326', 'EPSG:3395')
+
+
+def resolve_geometry_viewer_provider_defaults():
+    """Resolve config.DEFAULT_GEOMETRY_VIEWER_PROVIDER into safe defaults
+    for the geometry_viewer preferences.
+
+    config_local.py/config_distro.py/PGADMIN_CONFIG_* replace this single
+    config.py variable wholesale rather than merging individual keys, so
+    an administrator overriding only some fields, or setting the wrong
+    type entirely (e.g. a string instead of a dict), must not crash
+    preference registration for the rest, and an out-of-range/unsupported
+    value must not silently reach the frontend unvalidated.
+    """
+    provider = config.DEFAULT_GEOMETRY_VIEWER_PROVIDER
+    if not isinstance(provider, dict):
+        provider = {}
+
+    def _str_default(key, fallback):
+        value = provider.get(key, fallback)
+        return value if isinstance(value, str) else fallback
+
+    crs = provider.get('crs', 'EPSG:3857')
+    if crs not in GEOMETRY_VIEWER_CRS_CHOICES:
+        crs = 'EPSG:3857'
+
+    max_zoom = provider.get('max_zoom', 18)
+    if not isinstance(max_zoom, int) or isinstance(max_zoom, bool) or \
+            not 0 <= max_zoom <= 25:
+        max_zoom = 18
+
+    return {
+        'url': _str_default('url', ''),
+        'name': _str_default('name', 'Custom'),
+        'crs': crs,
+        'attribution': _str_default('attribution', ''),
+        'max_zoom': max_zoom,
+    }
 
 
 def register_query_tool_preferences(self):
+    geometry_viewer_defaults = resolve_geometry_viewer_provider_defaults()
+
     self.explain_verbose = self.preference.register(
         'Explain', 'explain_verbose',
         gettext("Verbose output?"), 'boolean', False,
@@ -842,7 +884,7 @@ def register_query_tool_preferences(self):
     self.custom_tile_url = self.preference.register(
         'geometry_viewer', 'custom_tile_url',
         gettext("Custom tile provider URL"), 'text',
-        DEFAULT_GEOMETRY_VIEWER_PROVIDER['url'],
+        geometry_viewer_defaults['url'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         control_props={
             'placeholder': 'https://{s}.tile.example.com/{z}/{x}/{y}.png',
@@ -863,7 +905,7 @@ def register_query_tool_preferences(self):
     self.custom_tile_name = self.preference.register(
         'geometry_viewer', 'custom_tile_name',
         gettext("Custom tile provider name"), 'text',
-        DEFAULT_GEOMETRY_VIEWER_PROVIDER['name'],
+        geometry_viewer_defaults['name'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         help_str=gettext('Display name of the custom tile provider in the '
                          'layer selector of the Geometry Viewer.'),
@@ -873,7 +915,7 @@ def register_query_tool_preferences(self):
     self.custom_tile_crs = self.preference.register(
         'geometry_viewer', 'custom_tile_crs',
         gettext("Custom tile provider CRS"), 'options',
-        DEFAULT_GEOMETRY_VIEWER_PROVIDER['crs'],
+        geometry_viewer_defaults['crs'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         options=[{'label': gettext('EPSG:3857 (Web Mercator)'),
                   'value': 'EPSG:3857'},
@@ -892,7 +934,7 @@ def register_query_tool_preferences(self):
     self.custom_tile_attribution = self.preference.register(
         'geometry_viewer', 'custom_tile_attribution',
         gettext("Custom tile provider attribution"), 'text',
-        DEFAULT_GEOMETRY_VIEWER_PROVIDER['attribution'],
+        geometry_viewer_defaults['attribution'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         help_str=gettext('Attribution text shown on the map for the custom '
                          'tile provider. May contain HTML links.'),
@@ -902,7 +944,7 @@ def register_query_tool_preferences(self):
     self.custom_tile_max_zoom = self.preference.register(
         'geometry_viewer', 'custom_tile_max_zoom',
         gettext("Custom tile provider max zoom"), 'integer',
-        DEFAULT_GEOMETRY_VIEWER_PROVIDER['max_zoom'],
+        geometry_viewer_defaults['max_zoom'],
         min_val=0, max_val=25,
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         help_str=gettext('Maximum zoom level of the custom tile provider.')

--- a/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
+++ b/web/pgadmin/tools/sqleditor/utils/query_tool_preferences.py
@@ -14,7 +14,7 @@ from pgadmin.utils.constants import PREF_LABEL_DISPLAY, \
     PREF_LABEL_CSV_TXT, PREF_LABEL_RESULTS_GRID, \
     PREF_LABEL_GRAPH_VISUALISER, PREF_LABEL_GEOMETRY_VIEWER
 from pgadmin.utils import SHORTCUT_FIELDS as shortcut_fields
-from config import DATA_RESULT_ROWS_PER_PAGE
+from config import DATA_RESULT_ROWS_PER_PAGE, DEFAULT_GEOMETRY_VIEWER_PROVIDER
 
 
 def register_query_tool_preferences(self):
@@ -841,7 +841,8 @@ def register_query_tool_preferences(self):
 
     self.custom_tile_url = self.preference.register(
         'geometry_viewer', 'custom_tile_url',
-        gettext("Custom tile provider URL"), 'text', '',
+        gettext("Custom tile provider URL"), 'text',
+        DEFAULT_GEOMETRY_VIEWER_PROVIDER['url'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         control_props={
             'placeholder': 'https://{s}.tile.example.com/{z}/{x}/{y}.png',
@@ -853,13 +854,16 @@ def register_query_tool_preferences(self):
                          '.png. The template must contain the {x}, {y} and '
                          '{z} placeholders, and may contain {s} for '
                          'subdomains (a, b, c). Leave empty to disable the '
-                         'custom tile provider.'),
+                         'custom tile provider. Defaults to the '
+                         'administrator-configured '
+                         'DEFAULT_GEOMETRY_VIEWER_PROVIDER, if any.'),
         allow_blanks=True
     )
 
     self.custom_tile_name = self.preference.register(
         'geometry_viewer', 'custom_tile_name',
-        gettext("Custom tile provider name"), 'text', 'Custom',
+        gettext("Custom tile provider name"), 'text',
+        DEFAULT_GEOMETRY_VIEWER_PROVIDER['name'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         help_str=gettext('Display name of the custom tile provider in the '
                          'layer selector of the Geometry Viewer.'),
@@ -868,7 +872,8 @@ def register_query_tool_preferences(self):
 
     self.custom_tile_crs = self.preference.register(
         'geometry_viewer', 'custom_tile_crs',
-        gettext("Custom tile provider CRS"), 'options', 'EPSG:3857',
+        gettext("Custom tile provider CRS"), 'options',
+        DEFAULT_GEOMETRY_VIEWER_PROVIDER['crs'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         options=[{'label': gettext('EPSG:3857 (Web Mercator)'),
                   'value': 'EPSG:3857'},
@@ -886,7 +891,8 @@ def register_query_tool_preferences(self):
 
     self.custom_tile_attribution = self.preference.register(
         'geometry_viewer', 'custom_tile_attribution',
-        gettext("Custom tile provider attribution"), 'text', '',
+        gettext("Custom tile provider attribution"), 'text',
+        DEFAULT_GEOMETRY_VIEWER_PROVIDER['attribution'],
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         help_str=gettext('Attribution text shown on the map for the custom '
                          'tile provider. May contain HTML links.'),
@@ -895,7 +901,8 @@ def register_query_tool_preferences(self):
 
     self.custom_tile_max_zoom = self.preference.register(
         'geometry_viewer', 'custom_tile_max_zoom',
-        gettext("Custom tile provider max zoom"), 'integer', 18,
+        gettext("Custom tile provider max zoom"), 'integer',
+        DEFAULT_GEOMETRY_VIEWER_PROVIDER['max_zoom'],
         min_val=0, max_val=25,
         category_label=PREF_LABEL_GEOMETRY_VIEWER,
         help_str=gettext('Maximum zoom level of the custom tile provider.')


### PR DESCRIPTION
### Summary
Follow-up to #10142. Geometry Viewer's custom tile provider was only configurable per-user (Preferences), with no way for an administrator to set an organization-wide default (e.g. an internal tile server) that applies to every user out of the box.

### Design
`config.DEFAULT_GEOMETRY_VIEWER_PROVIDER` is a plain dict, and the five `custom_tile_*` preference defaults (`url`, `name`, `crs`, `attribution`, `max_zoom`) are sourced from it instead of hardcoded literals. `Preference.get()` only reads a per-user DB row if the user has explicitly saved one, otherwise it falls back to this default — so this is override semantics: a user's own saved preference always wins, there is only ever one active provider (no second/competing entry), and no naming-conflict surface is introduced.

An administrator sets it in `config_local.py`/`config_distro.py` (or `PGADMIN_CONFIG_DEFAULT_GEOMETRY_VIEWER_PROVIDER` as a Python-dict-literal string, same mechanism already used for `DEFAULT_BINARY_PATHS`).

### Safety
`config_local.py`/`config_distro.py`/`PGADMIN_CONFIG_*` replace this config variable **wholesale**, not merged key-by-key. A naive `DEFAULT_GEOMETRY_VIEWER_PROVIDER['name']` would `KeyError`-crash preference registration (and thus app startup) on any partial admin override, or `AttributeError` if the admin sets the wrong type entirely (e.g. a string instead of a dict).

`resolve_geometry_viewer_provider_defaults()` guards against this: falls back per-field on missing/wrong-type values, validates `crs` against the 3 supported choices, and validates `max_zoom` is a non-bool int in `[0, 25]` — degrading to the original hardcoded defaults instead of crashing.

### Security
No new attacker-reachable surface: `DEFAULT_GEOMETRY_VIEWER_PROVIDER` is filesystem/deployment-level admin config, same trust boundary as `DEFAULT_BINARY_PATHS`/`OAUTH2_CONFIG`. The existing DOMPurify sanitization on `name`/`attribution` and the `http(s)://` + `{x}/{y}/{z}` URL validation in `GeometryViewerUtils.js` (from #10142) apply uniformly to config-sourced and per-user values alike — same code path, no bypass. Per-user preference isolation (`user_id`-keyed) is untouched.

### Testing
- `test_geometry_viewer_provider_defaults.py` — 9 scenarios (fully valid, partial override, non-dict, invalid CRS, out-of-range/non-int/bool max_zoom, non-string fields, empty dict), run via `regression/runtests.py --pkg tools.sqleditor` — all pass.
- `pycodestyle --config=.pycodestyle` clean (the exact `make check-pep8` invocation).
- Docs built via Sphinx (`make docs` equivalent) — 0 new warnings, new `preferences.rst` paragraph renders correctly, `config_py` ref resolves.

### Known minor nit (not fixed here, low risk)
The 3 supported CRS values are listed twice — once in `GEOMETRY_VIEWER_CRS_CHOICES` (validation) and once in the preference's `options=[...]` list (UI labels, from #10142). If a 4th CRS is ever added, both need updating in sync. Pre-existing pattern, not introduced by this PR; flagging for awareness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system-wide default settings for Geometry Viewer custom tile provider fields.
  * Administrators can configure default URL, name, CRS, attribution, and max zoom.
  * Existing saved user preferences continue to override the system defaults.

* **Documentation**
  * Documented how the system default applies and when user preferences take precedence.

* **Tests**
  * Added test coverage for default resolution, including partial overrides and validation of invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->