### PR TITLE
Add backendRefs group and kind to httproute.yaml

### DIFF
--- a/pkg/helm/templates/httproute.yaml
+++ b/pkg/helm/templates/httproute.yaml
@@ -30,7 +30,10 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {{ template "pgadmin4.fullname" . }}
+        - group: ''	
+          kind: Service
+          name: {{ template "pgadmin4.fullname" . }}
           port: {{ .Values.service.port }}
+          weight: 1
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When an HTTPRoute is created with an unset group, kind and weight, the fields are defaulted.

This causes tools like ArgoCD to detect a diff.

This PR sets the fields explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default HTTP route backend references to include the required Gateway API details, improving routing compatibility while preserving the configured service and port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->