### PR TITLE
Helm Chart: Add existingClaim to persistence

### DIFF
--- a/pkg/helm/README.md
+++ b/pkg/helm/README.md
@@ -35,6 +35,7 @@ The chart should dump its version and appVersion in the Chart.yaml file every re
 | `preferences.data` | Preferences to load | `{}` |
 | `resources.*` | Allocated requests and limits resources | `{"requests": {...}, "limits": {...}}` |
 | `persistence.enabled` | PVC resource creation | `true` |
+| `persistence.existingClaim` | Provide existing PVC instead of creating one | `""` |
 | `service.type` | Service type | `"ClusterIP"` |
 | `service.loadBalancerIP` | Load balancer IP (Only if service.type is LoadBalancer) | `""` |
 | `ingress.enabled` | Ingress resource creation | `false` |

--- a/pkg/helm/templates/deployment.yaml
+++ b/pkg/helm/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
-            claimName: {{ template "pgadmin4.fullname" . }}
+            claimName: {{ .Values.persistence.existingClaim | default (include "pgadmin4.fullname" .) }}
       {{- end }}
       {{- if .Values.config_local.enabled }}
         - name: config-local

--- a/pkg/helm/templates/pvc.yaml
+++ b/pkg/helm/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/pkg/helm/values.yaml
+++ b/pkg/helm/values.yaml
@@ -88,6 +88,7 @@ persistence:
   size: 1Gi
   storageClass: ""
   accessModes: ["ReadWriteOnce"]
+  existingClaim: ""
 
 service:
   type: ClusterIP
@@ -179,4 +180,3 @@ containerSecurityContext:
     type: RuntimeDefault
   windowsOptions:
     hostProcess: false
-


### PR DESCRIPTION
Hello!

This change aims to make it possible for users to provide their own PVC instead of the Chart to create one or not use persistence at all.

> [!IMPORTANT] 
> I also noticed that the current version of the Helm chart (`9.17.0`) fails by default, because there is no `9.17.0` pgadmin4 Docker image, only `9.17`. I fixed this by hand in my setup, but should be fixed by actually uploading the correct tag the Helm chart is requesting

Thank you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using an existing persistent volume claim through the `persistence.existingClaim` Helm setting.
  * Charts now create a new claim only when persistence is enabled and no existing claim is specified.
* **Documentation**
  * Documented the new persistence setting and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->