### PR TITLE
Add AI contribution commit trailer guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,12 +79,12 @@ For more detail, see the [pull request submission guide](docs/en_US/submitting_p
 Contributors are responsible for understanding, testing, and standing behind everything they submit, whether or not AI tools were used. Please do not open large numbers of auto-generated issues or pull requests without first discussing that work with the maintainers.
 
 - If you used AI tools in preparing your PR, please commit with the `Co-Authored-By`, `Generated-by`, or similar commit trailer.
-  ```
+  ```text
   Co-Authored-By: <AI tool name and version>
   Generated-by: <AI tool name and version>
   ```
   Example:
-  ```
+  ```text
   #1234: Fix issue in web interface
 
   Co-Authored-By: Claude Sonnet 4.6 <claude@anthropic.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,18 @@ For more detail, see the [pull request submission guide](docs/en_US/submitting_p
 
 Contributors are responsible for understanding, testing, and standing behind everything they submit, whether or not AI tools were used. Please do not open large numbers of auto-generated issues or pull requests without first discussing that work with the maintainers.
 
+- If you used AI tools in preparing your PR, please commit with the `Co-Authored-By`, `Generated-by`, or similar commit trailer.
+  ```
+  Co-Authored-By: <AI tool name and version>
+  Generated-by: <AI tool name and version>
+  ```
+  Example:
+  ```
+  #1234: Fix issue in web interface
+
+  Co-Authored-By: Claude Sonnet 4.6 <claude@anthropic.com>
+  ```
+
 ## Development Setup
 
 In the following documentation and examples, `$PGADMIN4_SRC` is used to denote the top-level directory of your copy of the pgAdmin source tree (either from a tarball or a git checkout).


### PR DESCRIPTION
## Summary
Adds guidance to `CONTRIBUTING.md` requesting contributors to include commit trailers (e.g., `Co-Authored-By`, `Generated-by`) when AI tools are used in preparing PRs.

## Background & Rationale
- **Inspiration:** Inspired by Apache Kafka's AI contribution guidelines.
- Makes tracking AI-assisted contributions quantitative, giving clarity on AI usage across pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidance for disclosing AI-assisted work.
  * Included supported commit trailer examples and a sample commit format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->