### PR TITLE
fix(pkg): remove trailing quote from Windows ProductVersion

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -322,7 +322,7 @@ REM Main build sequence Ends
     %TMPDIR%\rcedit-x64.exe "%BUILDROOT%\runtime\pgAdmin4.exe" --set-icon "%WD%\pkg\win32\Resources\pgAdmin4.ico"
     %TMPDIR%\rcedit-x64.exe "%BUILDROOT%\runtime\pgAdmin4.exe" --set-version-string "FileDescription" "%APP_NAME%"
     %TMPDIR%\rcedit-x64.exe "%BUILDROOT%\runtime\pgAdmin4.exe" --set-version-string "ProductName" "%APP_NAME%"
-    %TMPDIR%\rcedit-x64.exe "%BUILDROOT%\runtime\pgAdmin4.exe" --set-product-version "%APP_VERSION%""
+    %TMPDIR%\rcedit-x64.exe "%BUILDROOT%\runtime\pgAdmin4.exe" --set-product-version "%APP_VERSION%"
 
     IF NOT "%PGADMIN_WINDOWS_CSC%" == "" (
         ECHO Attempting to sign the pgAdmin4.exe...


### PR DESCRIPTION
## Summary
- Fixes a typo in `Make.bat` where rcedit was invoked with `"%APP_VERSION%""`, which stamped `ProductVersion` as e.g. `9.17"` on Windows installer builds.
- Closes https://github.com/pgadmin-org/pgadmin4/issues/10235

## Test plan
- [ ] Rebuild the Windows installer package
- [ ] Confirm `(Get-Item '...\runtime\pgAdmin4.exe').VersionInfo.ProductVersion` reports a clean version (e.g. `9.17`) with no trailing `"`
- [ ] Confirm File Explorer → Properties → Details shows the same clean Product version


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the product version command used during application packaging.
  * Ensured version information is recorded correctly without an extra quotation mark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->