### PR TITLE
feat: toggle Object Explorer by re-clicking Default workspace icon

### DIFF
--- a/web/pgadmin/misc/workspaces/static/js/WorkspaceProvider.jsx
+++ b/web/pgadmin/misc/workspaces/static/js/WorkspaceProvider.jsx
@@ -7,11 +7,12 @@
 //
 //////////////////////////////////////////////////////////////
 
-import React, { useContext, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { BROWSER_PANELS, WORKSPACES } from '../../../../browser/static/js/constants';
 import { usePgAdmin } from '../../../../static/js/PgAdminProvider';
 import usePreferences from '../../../../preferences/static/js/store';
+import { LAYOUT_EVENTS } from '../../../../static/js/helpers/Layout';
 import { config } from './config';
 
 const WorkspaceContext = React.createContext();
@@ -21,6 +22,9 @@ export const useWorkspace = ()=>useContext(WorkspaceContext);
 export function WorkspaceProvider({children}) {
   const pgAdmin = usePgAdmin();
   const [currentWorkspace, setCurrentWorkspace] = useState(WORKSPACES.DEFAULT);
+  // Reflects whether Object Explorer is visible in Default workspace.
+  // Kept in sync with the dock layout (MAIN maximized => sidebar closed).
+  const [isDefaultSidebarOpen, setIsDefaultSidebarOpen] = useState(true);
   const lastSelectedTreeItem = useRef();
   const isClassic = (usePreferences()?.getPreferencesForModule('misc')?.layout ?? 'classic') == 'classic';
   const openInResWorkspace = usePreferences()?.getPreferencesForModule('misc')?.open_in_res_workspace && !isClassic;
@@ -69,9 +73,66 @@ export function WorkspaceProvider({children}) {
     return {docker: docker, focus: ()=>changeWorkspace(workspace)};
   };
 
+  const syncDefaultSidebarFromLayout = useCallback(()=>{
+    const docker = pgAdmin.Browser.docker.default_workspace;
+    if (!docker?.layoutObj || typeof docker.isPanelMaximized !== 'function') {
+      return;
+    }
+    if (!docker.find?.(BROWSER_PANELS.MAIN)) {
+      return;
+    }
+    // MAIN maximized => Object Explorer hidden => sidebar closed.
+    setIsDefaultSidebarOpen(!docker.isPanelMaximized(BROWSER_PANELS.MAIN));
+  }, [pgAdmin]);
+
+  // Keep React state aligned with the dock layout (reload, reset, maximize, etc.).
+  useEffect(()=>{
+    if (isClassic) {
+      return;
+    }
+
+    const docker = pgAdmin.Browser.docker.default_workspace;
+    if (!docker?.eventBus) {
+      return;
+    }
+
+    syncDefaultSidebarFromLayout();
+    const deregInit = docker.eventBus.registerListener(LAYOUT_EVENTS.INIT, syncDefaultSidebarFromLayout);
+    const deregMaximize = docker.eventBus.registerListener(LAYOUT_EVENTS.MAXIMIZE, syncDefaultSidebarFromLayout);
+    const deregChange = docker.eventBus.registerListener(LAYOUT_EVENTS.CHANGE, syncDefaultSidebarFromLayout);
+
+    return ()=>{
+      deregInit();
+      deregMaximize();
+      deregChange();
+    };
+  }, [isClassic, pgAdmin, syncDefaultSidebarFromLayout]);
+
+  const restoreDefaultSidebar = ()=>{
+    if (!isDefaultSidebarOpen) {
+      // Object Explorer was collapsed via maximize — toggle restores it.
+      // Only update React state when the layout toggle actually succeeds.
+      if (!pgAdmin.Browser.docker.default_workspace?.toggleMaximize?.(BROWSER_PANELS.MAIN)) {
+        return;
+      }
+      syncDefaultSidebarFromLayout();
+    }
+  };
+
+  const toggleDefaultSidebar = ()=>{
+    if (!pgAdmin.Browser.docker.default_workspace?.toggleMaximize?.(BROWSER_PANELS.MAIN)) {
+      return;
+    }
+    syncDefaultSidebarFromLayout();
+  };
+
   const changeWorkspace = (newVal)=>{
     // Set the currentWorkspace flag.
     if (currentWorkspace == newVal) return;
+    // Restore Object Explorer if it was collapsed when leaving Default workspace.
+    if (currentWorkspace == WORKSPACES.DEFAULT && !isDefaultSidebarOpen) {
+      restoreDefaultSidebar();
+    }
     pgAdmin.Browser.docker.currentWorkspace = newVal;
     if (newVal == WORKSPACES.DEFAULT) {
       setTimeout(() => {
@@ -117,12 +178,14 @@ export function WorkspaceProvider({children}) {
   const value = useMemo(()=>({
     config: config,
     currentWorkspace: currentWorkspace,
+    isDefaultSidebarOpen,
     enabled: !isClassic,
     changeWorkspace,
+    toggleDefaultSidebar,
     hasOpenTabs,
     getLayoutObj,
     onWorkspaceDisabled
-  }), [currentWorkspace, isClassic]);
+  }), [currentWorkspace, isClassic, isDefaultSidebarOpen]);
 
   return <WorkspaceContext.Provider value={value}>
     {children}

--- a/web/pgadmin/misc/workspaces/static/js/WorkspaceToolbar.jsx
+++ b/web/pgadmin/misc/workspaces/static/js/WorkspaceToolbar.jsx
@@ -46,8 +46,9 @@ const StyledWorkspaceButton = styled(PgIconButton)(({theme}) => ({
 }));
 
 function WorkspaceButton({menuItem, value, options, ...props}) {
-  const {currentWorkspace, hasOpenTabs, getLayoutObj, onWorkspaceDisabled, changeWorkspace} = useWorkspace();
-  const active = value == currentWorkspace;
+  const {currentWorkspace, isDefaultSidebarOpen, hasOpenTabs, getLayoutObj, onWorkspaceDisabled, changeWorkspace, toggleDefaultSidebar} = useWorkspace();
+  // Default workspace icon is "active" only when that workspace is selected and Object Explorer is visible.
+  const active = value == currentWorkspace && (value !== WORKSPACES.DEFAULT || isDefaultSidebarOpen);
   const [disabled, setDisabled] = useState();
 
   useEffect(()=>{
@@ -84,6 +85,12 @@ function WorkspaceButton({menuItem, value, options, ...props}) {
         } else {
           // Check permission and call.
           withCheckPermission(options, () => {
+            // Re-clicking the active Default workspace icon toggles Object Explorer
+            // visibility (VS Code-style sidebar toggle). See #9631.
+            if (value === currentWorkspace && value === WORKSPACES.DEFAULT) {
+              toggleDefaultSidebar();
+              return;
+            }
             changeWorkspace(value);
           })();
         }

--- a/web/pgadmin/static/js/BrowserComponent.jsx
+++ b/web/pgadmin/static/js/BrowserComponent.jsx
@@ -10,7 +10,7 @@
 import {useEffect, useMemo, useState } from 'react';
 import AppMenuBar from './AppMenuBar';
 import ObjectBreadcrumbs from './components/ObjectBreadcrumbs';
-import Layout, { LAYOUT_EVENTS, LayoutDocker, getDefaultGroup } from './helpers/Layout';
+import Layout, { LayoutDocker, getDefaultGroup } from './helpers/Layout';
 import gettext from 'sources/gettext';
 import ObjectExplorer from './tree/ObjectExplorer';
 import Properties from '../../misc/properties/Properties';
@@ -139,7 +139,6 @@ function Layouts({browser}) {
             key={item.docker}
             getLayoutInstance={(obj)=>{
               pgAdmin.Browser.docker[item.docker] = obj;
-              obj.eventBus.fireEvent(LAYOUT_EVENTS.INIT);
             }}
             defaultLayout={item.layout}
             layoutId={`Workspace/Layout-${item.workspace}`}

--- a/web/pgadmin/static/js/helpers/Layout/index.jsx
+++ b/web/pgadmin/static/js/helpers/Layout/index.jsx
@@ -284,6 +284,22 @@ export class LayoutDocker {
     return panelData?.parent?.activeId == panelData?.id;
   }
 
+  isPanelMaximized(panelId) {
+    const panelData = this.find(panelId);
+    return panelData?.parent?.mode === 'maximize';
+  }
+
+  // Toggle maximize for a panel. Maximizing the main panel hides sibling
+  // panels (e.g. Object Explorer) — used for VS Code-style sidebar toggle.
+  toggleMaximize(panelId) {
+    const panelData = this.find(panelId);
+    if (!panelData || !this.layoutObj) {
+      return false;
+    }
+    this.layoutObj.dockMove(panelData, null, 'maximize');
+    return true;
+  }
+
   openTab(panelData, refTabId, direction='middle', forceRerender=false) {
     let panel = this.layoutObj.find(panelData.id);
     if(panel) {
@@ -445,6 +461,8 @@ export class LayoutDocker {
 
     focusOn && this.focus(focusOn);
     this.saveLayout();
+    // Notify listeners (e.g. workspace sidebar sync) that layout was restored.
+    this.eventBus.fireEvent(LAYOUT_EVENTS.INIT);
   }
 
   static getPanel({icon, title, closable, tooltip, renamable, manualClose, bgcolor, fgcolor, server_id, ...attrs}) {
@@ -712,6 +730,9 @@ export default function Layout({groups, noContextGroups, getLayoutInstance, layo
                 layoutDockerObj.layoutObj = obj;
                 getLayoutInstance?.(layoutDockerObj);
                 layoutDockerObj.loadLayout(savedLayout);
+                // Fire after loadLayout so listeners see the restored layout
+                // (e.g. maximized main panel / collapsed Object Explorer).
+                layoutDockerObj.eventBus.fireEvent(LAYOUT_EVENTS.INIT);
               }
             }}
             loadTab={loadTab}


### PR DESCRIPTION
## Summary
- Fixes #9631 by allowing the Default workspace icon to toggle Object Explorer visibility when that workspace is already selected (VS Code-style activity bar behavior).
- Keeps the toolbar active state in sync with the dock layout (including after reload and reset layout).
- Re-clicking other workspace icons continues to switch workspaces as before; Query Tool / PSQL / Schema Diff workspaces have no left Object Explorer panel to collapse.

## How it works
- Re-clicking the Default workspace icon maximizes/restores the main panel via rc-dock, which hides or shows the Object Explorer sibling panel.
- Sidebar open state is derived from whether the main panel is maximized, and is refreshed on layout `INIT` / `MAXIMIZE` / `CHANGE`.

## Test plan
- [ ] Use **Workspace** layout (not Classic)
- [ ] Click the Default / Object Explorer icon → Object Explorer collapses
- [ ] Click it again → Object Explorer restores
- [ ] Collapse Object Explorer, switch to Query Tool, switch back → Object Explorer is visible again
- [ ] Collapse Object Explorer, reload pgAdmin → icon/layout state stay consistent
- [ ] Collapse Object Explorer, use Reset Layout → Object Explorer is visible and icon state is consistent


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to toggle the Object Explorer sidebar by selecting the active Default workspace.
  * Sidebar visibility now stays synchronized with workspace maximization and layout changes.
  * Switching between workspaces restores the appropriate sidebar state.

* **Bug Fixes**
  * Improved workspace layout restoration so panels and sidebar visibility reflect the saved layout correctly.
  * Prevented unnecessary layout initialization during workspace creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->