### PR TITLE
chore: add support for Python 3.14

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -43,7 +43,7 @@ jobs:
           sonar.test.inclusions=**/tests/**, web/regression
           
           # Python compatibility
-          sonar.python.version=3.7, 3.8, 3.9, 3.10, 3.11
+          sonar.python.version=3.9, 3.10, 3.11, 3.12, 3.13, 3.14
           EOF
           
           APP_RELEASE=`grep "^APP_RELEASE" web/config.py | cut -d"=" -f2 | sed 's/ //g'`

--- a/Make.bat
+++ b/Make.bat
@@ -52,7 +52,7 @@ REM Main build sequence Ends
 
 :SET_ENVIRONMENT
     ECHO Configuring the environment...
-    IF "%PGADMIN_PYTHON_DIR%" == ""   SET "PGADMIN_PYTHON_DIR=C:\Python313"
+    IF "%PGADMIN_PYTHON_DIR%" == ""   SET "PGADMIN_PYTHON_DIR=C:\Python314"
     IF "%PGADMIN_KRB5_DIR%" == ""     SET "PGADMIN_KRB5_DIR=C:\Program Files\MIT\Kerberos"
     IF "%PGADMIN_POSTGRES_DIR%" == "" SET "PGADMIN_POSTGRES_DIR=C:\Program Files\PostgreSQL\17"
     IF "%PGADMIN_INNOTOOL_DIR%" == "" SET "PGADMIN_INNOTOOL_DIR=C:\Program Files (x86)\Inno Setup 6"

--- a/pkg/mac/README.md
+++ b/pkg/mac/README.md
@@ -13,7 +13,7 @@ Either build the sources or get them from macports or similar:
   
 ## Building
 
-1. To bundle a different version of Python from the default of 3.13.1, set the
+1. To bundle a different version of Python from the default of 3.14.7, set the
    *PGADMIN_PYTHON_VERSION* environment variable, e.g:
 
        export PGADMIN_PYTHON_VERSION=3.13.11

--- a/pkg/mac/build.sh
+++ b/pkg/mac/build.sh
@@ -53,8 +53,8 @@ if [ "${PGADMIN_POSTGRES_DIR}" == "" ]; then
 fi
 
 if [ "${PGADMIN_PYTHON_VERSION}" == "" ]; then
-    echo "PGADMIN_PYTHON_VERSION not set. Setting it to the default: 3.13.11"
-    export PGADMIN_PYTHON_VERSION=3.13.11
+    echo "PGADMIN_PYTHON_VERSION not set. Setting it to the default: 3.14.7"
+    export PGADMIN_PYTHON_VERSION=3.14.7
 fi
 
 # Initialize variables

--- a/pkg/pip/setup_pip.py
+++ b/pkg/pip/setup_pip.py
@@ -84,7 +84,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13'
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
     ],
 
     keywords='pgadmin4,postgresql,postgres',

--- a/pkg/win32/README.md
+++ b/pkg/win32/README.md
@@ -204,7 +204,7 @@ examples shown below are the defaults for the build system, so if they match
 your requirements you don't need to set them. For PostgreSQL 16 and below:
 
         SET "PGADMIN_POSTGRES_DIR=C:\build64\pgsql"
-        SET "PGADMIN_PYTHON_DIR=C:\Python313"
+        SET "PGADMIN_PYTHON_DIR=C:\Python314"
         SET "PGADMIN_KRB5_DIR=C:\build64\krb5"
         SET "PGADMIN_INNOTOOL_DIR=C:\Program Files (x86)\Inno Setup 6"
         SET "PGADMIN_SIGNTOOL_DIR=C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64"
@@ -214,7 +214,7 @@ your requirements you don't need to set them. For PostgreSQL 16 and below:
     For PostgreSQL 17 and later:
 
         SET "PGADMIN_POSTGRES_DIR=C:\build64"
-        SET "PGADMIN_PYTHON_DIR=C:\Python313"
+        SET "PGADMIN_PYTHON_DIR=C:\Python314"
         SET "PGADMIN_KRB5_DIR=C:\build64"
         SET "PGADMIN_INNOTOOL_DIR=C:\Program Files (x86)\Inno Setup 6"
         SET "PGADMIN_SIGNTOOL_DIR=C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64"


### PR DESCRIPTION
Python 3.14 has been out for a while now and pgAdmin runs happily on it, so this adds it to the set of versions we claim to support and moves the desktop builds onto it.

Specifically:

- `pkg/pip/setup_pip.py` gains the `Programming Language :: Python :: 3.14` trove classifier. There is no `python_requires` in that setup, so nothing else needed relaxing, and the minimum supported version is unchanged at 3.9.
- The macOS bundle now defaults to Python 3.14.7 rather than 3.13.11. Whilst there, `pkg/mac/README.md` claimed the default was 3.13.1, which had not matched `pkg/mac/build.sh` for some time, so the two are now consistent.
- The Windows build looks for an interpreter in `C:\Python314` by default, with `pkg/win32/README.md` updated to match; the rest of the Windows build derives the version from the interpreter itself, so nothing else needed touching.
- The SonarQube scanner's Python compatibility list had drifted rather badly, still naming 3.7 and 3.8 and stopping at 3.11, so it has been brought into line with the versions we actually support.

The container image needs nothing, since it moved to `python:3-alpine` and discovers the interpreter at runtime, and the `python_version` markers in `requirements.txt` are all `> '3.9'` boundaries that 3.14 already satisfies.

## Testing

Verified on macOS with a clean Python 3.14.7 virtual environment built from the python.org framework build:

- `pip install -r requirements.txt` and `pip install -r web/regression/requirements.txt` both complete cleanly, with `psycopg-c`, `jsonformatter` and `Flask-Principal` building from source without complaint.
- `python regression/runtests.py --exclude feature_tests` against PostgreSQL 17 gives 1998 passed, 131 failed, 361 skipped. The failures are all backup, restore, maintenance and import/export job tests, and they reproduce identically under Python 3.12.7 and at earlier commits on the same machine, so they are a local environment issue rather than anything to do with 3.14.
- `pycodestyle` is clean, and the new classifier was checked against the official trove list.

One thing deliberately left out: the `run-python-tests-*.yml` workflows still pin `python-version: '3.10'`. Adding 3.14 there would mean a matrix, and roughly triple those jobs against live PostgreSQL and EPAS instances, so it seemed better to raise that separately rather than bundle an infrastructure decision into this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python 3.14 support to package compatibility and distribution metadata.
  * Updated Windows and macOS packaging defaults to use Python 3.14.

* **Documentation**
  * Updated installation and build documentation to reference Python 3.14.
  * Refreshed bundled Python version details for macOS distributions.

* **Compatibility**
  * Updated supported Python versions for quality and compatibility scanning, including Python 3.12–3.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->