### PR TITLE
fix: follow Flask-Security-Too 5.8.2's corrected is_locked() semantics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,10 @@ Flask-Mail==0.*
 Flask-Migrate==4.*
 Flask-Paranoid==0.*
 Flask-Security-Too==5.6.*; python_version <= '3.9'
-Flask-Security-Too==5.8.*; python_version > '3.9'
+# 5.8.2 corrected the inverted UserMixin.is_locked() test in LoginForm;
+# User.is_locked() in web/pgadmin/model/__init__.py follows the fixed
+# semantics, so anything earlier in the 5.8 series would refuse all logins.
+Flask-Security-Too>=5.8.2,<5.9; python_version > '3.9'
 Flask-SocketIO==5.6.*
 Flask-SQLAlchemy==3.1.*
 Flask-WTF==1.2.*; python_version <= '3.9'

--- a/web/pgadmin/model/__init__.py
+++ b/web/pgadmin/model/__init__.py
@@ -222,17 +222,20 @@ class User(db.Model, UserMixin):
 
     def is_locked(self, form_error=None):
         # Flask-Security's LoginForm.validate() calls this after password
-        # verification and treats the return value inverted: True means
-        # "not locked, proceed"; False means "locked, fail validation".
-        # The default UserMixin.is_locked unconditionally returns True,
-        # which is what allows the /login bypass on a locked account.
+        # verification and fails validation when it returns True, so True
+        # means "locked, refuse the login". Flask-Security-Too up to and
+        # including 5.8.1 had that test inverted (fixed upstream in 5.8.2 by
+        # pallets-eco/flask-security#1267), which is why requirements.txt
+        # floors the dependency at 5.8.2: on an older release the value
+        # below would be read backwards and every unlocked user would be
+        # refused a session.
         if self.locked:
             if form_error is not None:
                 form_error.append(gettext(
                     'Your account is locked. Please contact the '
                     'Administrator.'))
-            return False
-        return True
+            return True
+        return False
 
 
 class Setting(db.Model, UserScopedMixin):

--- a/web/pgadmin/tools/user_management/tests/test_locked_user.py
+++ b/web/pgadmin/tools/user_management/tests/test_locked_user.py
@@ -26,8 +26,10 @@ class TestLockedUser(BaseTestGenerator):
 
       - `is_active` -> False when the account is deactivated OR locked
         (Flask-Login's `login_user()` then refuses the session).
-      - `is_locked(errors)` -> False when locked, True otherwise; populates
+      - `is_locked(errors)` -> True when locked, False otherwise; populates
         the supplied error list when locked so the form surfaces a message.
+        Flask-Security-Too <= 5.8.1 read this the other way round, which is
+        why requirements.txt floors the dependency at 5.8.2.
     """
 
     # Pure model-contract test - no Postgres server interaction needed.
@@ -39,16 +41,16 @@ class TestLockedUser(BaseTestGenerator):
     scenarios = [
         ('active and not locked: login allowed',
          dict(active=True, locked=False,
-              expect_is_active=True, expect_is_locked=True)),
+              expect_is_active=True, expect_is_locked=False)),
         ('active and locked: login blocked',
          dict(active=True, locked=True,
-              expect_is_active=False, expect_is_locked=False)),
+              expect_is_active=False, expect_is_locked=True)),
         ('inactive and not locked: login blocked',
          dict(active=False, locked=False,
-              expect_is_active=False, expect_is_locked=True)),
+              expect_is_active=False, expect_is_locked=False)),
         ('inactive and locked: login blocked',
          dict(active=False, locked=True,
-              expect_is_active=False, expect_is_locked=False)),
+              expect_is_active=False, expect_is_locked=True)),
     ]
 
     def runTest(self):


### PR DESCRIPTION
Logins are currently broken against Flask-Security-Too 5.8.2, which was released on 12 August 2026 and is picked up automatically by our loose `Flask-Security-Too==5.8.*` pin. Every PR opened since then fails `run-python-tests-server-mode` with `302 != 200` on login and `'AnonymousUser' object has no attribute 'id'` thereafter, and this is not merely a test artifact: on 5.8.2 nobody can log in at all.

The cause is an upstream bug fix. Flask-Security-Too up to and including 5.8.1 had the `is_locked()` test inverted in its login forms, so `LoginForm.validate()` read a `True` return as "not locked, carry on", and the base `UserMixin.is_locked()` unconditionally returned `True`. That was corrected in 5.8.2 (`pallets-eco/flask-security#1267`), which flipped the callers to `if self.user.is_locked(...)` and changed the base implementation to return `False`. Our `User.is_locked()` was written against the old, inverted convention, as its comment described, so under 5.8.2 an *unlocked* user is now read as locked, validation fails, and the login POST redirects to the login page.

This changes `User.is_locked()` to return `True` when the account is locked, matching the corrected contract, and floors the dependency at `>=5.8.2,<5.9`. The floor is doing real work rather than being belt and braces: the two conventions are mutually exclusive, so the same code cannot satisfy both, and without a floor a fresh environment could still resolve 5.8.0 or 5.8.1 and lock everyone out in the opposite direction. The `5.6.*` pin for Python 3.9 is untouched, as `is_locked()` was only introduced in 5.8.0 and is never called there; lockout on that branch is enforced through `is_active`, which is unchanged.

### Testing

Verified locally against PostgreSQL 18 with 5.8.2 shadowed into the environment, in all four directions:

| Scenario | Result |
| --- | --- |
| Fix + 5.8.2 (`test_sg_data_isolation`, SERVER_MODE=True) | 3 passed |
| Old code + 5.8.2 (negative control) | 3 failed, reproducing the CI output exactly |
| Fix + 5.8.0 | 3 failed, which is what the version floor now prevents |
| Fix + 5.8.2 (`tools.user_management`, full package) | 7 passed |

`pycodestyle` is clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected locked-account detection so locked users are consistently identified and prevented from logging in.
  * Preserved existing locked-account error messaging.
  * Updated supported security package versions to ensure the corrected behavior is applied.

* **Tests**
  * Updated regression coverage for locked and inactive account scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->