### PR TITLE
chore: exclude major paramiko bumps and group minor/patch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
       - "Dependencies"
     commit-message:
       prefix: "Python dependency"
+    # paramiko 5.0 removed DSSKey, which sshtunnel 0.4.0 still references in
+    # SSHTunnelForwarder.get_keys(); a major bump therefore breaks every SSH
+    # tunnelled connection at construction time. sshtunnel has had no release
+    # since 2019, so this stays put until it is fixed or replaced. See #9927.
+    ignore:
+      - dependency-name: "paramiko"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/tools"
@@ -27,6 +34,9 @@ updates:
     commit-message:
       prefix: "Python dependency"
 
+  # Note that web/regression/requirements.txt begins with
+  # "-r ../../requirements.txt", so this entry also sees everything pinned in
+  # the root file and the paramiko exclusion has to be repeated here.
   - package-ecosystem: "pip"
     directory: "/web/regression"
     schedule:
@@ -35,6 +45,9 @@ updates:
       - "Dependencies"
     commit-message:
       prefix: "Python dependency"
+    ignore:
+      - dependency-name: "paramiko"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/runtime"


### PR DESCRIPTION
Follow-up to #9927, which I closed rather than merged.

paramiko 5.0 removed `DSSKey` altogether: there is no `paramiko/dsskey.py` in the wheel and the name is gone from `paramiko/__init__.py`. `sshtunnel` 0.4.0, which is how pgAdmin reaches paramiko at all, still refers to `paramiko.DSSKey` unconditionally in `SSHTunnelForwarder.get_keys()`, and `_consolidate_auth()` calls that from the constructor. So a major bump breaks every SSH tunnelled connection at the point the forwarder is created, not merely DSA key support:

```
$ python -c "import sshtunnel; sshtunnel.SSHTunnelForwarder(('ssh.example.invalid', 22),
    ssh_username='someone', ssh_password='x', remote_bind_address=('127.0.0.1', 5432))"
AttributeError: module 'paramiko' has no attribute 'DSSKey'
```

Nothing in CI exercises SSH tunnels, so the bump looked green and would have gone in on a quiet day. sshtunnel has had no release since 0.4.0 in 2019, so there is nothing newer to move to; the pin stays at `paramiko==3.5.1` and this simply stops Dependabot proposing the jump again.

The exclusion appears under both the `/` and `/web/regression` pip entries because `web/regression/requirements.txt` opens with `-r ../../requirements.txt`, so the latter entry sees the root pins as well. That same include is why we periodically get two identical PRs for one root pin (#10203/#10209, #10205/#10208, #10082/#10084 were all such pairs); deduplicating that properly means restructuring how the test requirements include the runtime ones, which felt like more than this change should carry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to defer major `paramiko` upgrades where compatibility concerns exist.
  * Added documentation explaining the dependency update restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->