### PR TITLE
chore: stop Dependabot proposing major jest-dom bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,3 +108,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # @testing-library/jest-dom 7 requires Node >= 22, whilst Node 20 is the
+    # minimum we support and what most of the buildfarm runs. Revisit once the
+    # buildfarm moves to Node 22. See #10271 and #10210.
+    ignore:
+      - dependency-name: "@testing-library/jest-dom"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Follow-up to #10271, which I closed rather than merged.

`@testing-library/jest-dom` 7 declares `"engines": {"node": ">=22"}`, whilst Node 20 remains our minimum and is what most of the buildfarm runs. In practice the bump does pass our JS tests on Node 20, and `run-javascript-tests` pins `node-version: '20.x'`, so this is a deliberate choice not to depend on an officially unsupported combination rather than a reaction to a failure.

The `^6.9.1` constraint in `web/package.json` already prevents 7.x from being installed. What Dependabot proposes is widening that constraint, so the ignore rule is what actually stops the PR reappearing, in the same way as the paramiko exclusion added in #10257.

When the buildfarm moves to Node 22 this rule should come out and the upgrade can go in properly, along with a bump of `node-version` in the JS workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to defer major updates that require a newer Node.js version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->