### PR TITLE
chore: stop Dependabot re-proposing pickr 1.10 and Babel 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,9 +108,30 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # @testing-library/jest-dom 7 requires Node >= 22, whilst Node 20 is the
-    # minimum we support and what most of the buildfarm runs. Revisit once the
-    # buildfarm moves to Node 22. See #10271 and #10210.
     ignore:
+      # @testing-library/jest-dom 7 requires Node >= 22, whilst Node 20 is the
+      # minimum we support and what most of the buildfarm runs. Revisit once
+      # the buildfarm moves to Node 22. See #10271 and #10210.
       - dependency-name: "@testing-library/jest-dom"
         update-types: ["version-update:semver-major"]
+
+      # Babel 8 requires Node ^22.18.0 || >=24.11.0, and every 8.x package
+      # peer-depends on @babel/core ^8.0.0 whilst we are on 7.x. Taking any of
+      # them individually leaves an unsatisfiable peer requirement and a mixed
+      # 7/8 tree, so Babel 8 needs a coordinated migration across all ten
+      # @babel/* packages once we are on Node 22. See #10283, #10284, #10285.
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]
+
+      # pickr 1.10 switched to a dual CJS/ESM build whose CommonJS entry point
+      # exports a namespace object rather than the class, so Babel's interop
+      # leaves _pickr.default as an object and every dialog with a colour field
+      # dies on mount. That took master's feature tests down for three days
+      # (#10264, reverted in #10278). Note 1.9 -> 1.10 is a *minor* bump, so it
+      # otherwise rejoins the grouped PR and comes back around; minor updates
+      # are excluded here as well as majors until withColorPicker.js is adapted
+      # to the new export shape.
+      - dependency-name: "@simonwep/pickr"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Two more Dependabot exclusions, both for bumps we have already established we cannot take. This is prompted by four PRs that arrived this morning.

### pickr, again

#10282 is the first grouped `/web` PR, carrying 21 packages, and buried in the middle of it is:

```
-    "@simonwep/pickr": "~1.9.1",
+    "@simonwep/pickr": "~1.10.1",
```

That is the bump reverted in #10278 after it took master's feature tests down for three days: 1.10 switched to a dual CJS/ESM build whose CommonJS entry point exports a namespace object rather than the class, so Babel's interop leaves `_pickr.default` as an object and every dialog with a colour field dies on mount.

The reason it came straight back is that 1.9 to 1.10 is a **minor** bump, so it rejoins the minor-and-patch group. Reverting the merge does nothing to stop that. Hence excluding minor updates as well as majors for this package until `withColorPicker.js` is adapted to the new export shape.

Encouragingly, #10282's feature tests failed on all five PG versions, so the gate that missed this the first time does now catch it, but a 21-package group is exactly where a known-bad bump should not be relying on someone reading the diff carefully.

### Babel 8

#10283, #10284 and #10285 propose `@babel/preset-env` 8.0.2, `@babel/eslint-parser` 8.0.1 and `@babel/plugin-syntax-jsx` 8.0.1. Two independent problems:

1. All three declare `engines: {"node": "^22.18.0 || >=24.11.0"}`, whilst Node 20 remains our minimum and is what most of the buildfarm runs.
2. All three peer-depend on `@babel/core ^8.0.0`, and `web/package.json` pins `@babel/core` at `^7.29.6`. Merging any of them individually leaves an unsatisfiable peer requirement and a mixed Babel 7/8 tree; Dependabot is proposing to move three of our ten `@babel/*` packages.

Babel 8 is worth having eventually, but as a coordinated migration once we are on Node 22, not three packages at a time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to avoid incompatible major updates for Babel packages.
  * Restricted Pickr updates to patch-level releases.
  * Added documentation explaining compatibility constraints for excluded updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->