### PR TITLE
docs: describe what AI features transmit to LLM providers

### DIFF
--- a/docs/en_US/ai_tools.rst
+++ b/docs/en_US/ai_tools.rst
@@ -82,6 +82,38 @@ Select your preferred LLM provider from the dropdown:
 After configuring your provider, click *Save* to apply the changes.
 
 
+.. _ai_data_handling:
+
+Data Handling and Provider Selection
+************************************
+
+When a cloud LLM provider is configured, pgAdmin transmits information about
+your database to that provider's API. Depending on the feature in use, this may
+include schema definitions such as table, column, index and constraint names
+and data types; server and database configuration settings read from
+``pg_settings``; query text; and EXPLAIN plan output. The *AI Assistant* in the
+Query Tool is also able to run queries against your database, within a read-only
+transaction and limited to 1000 rows, so row data may be included where the
+assistant determines it is needed to answer a question.
+
+None of this is transmitted unless you invoke an AI feature, and none of it is
+transmitted at all when no provider has been configured, which is the default;
+when AI features have been disabled by the administrator through the
+``LLM_ENABLED`` setting; or when a locally hosted provider such as Ollama or
+Docker Model Runner is configured.
+
+Each provider processes this data under its own terms of service, privacy policy
+and legal jurisdiction, and operates its infrastructure in locations of its own
+choosing. If you work in an environment subject to data residency requirements,
+procurement policies, or sector-specific rules governing the handling of
+database metadata, review both the provider's terms and your own organisation's
+policies before enabling a cloud provider.
+
+The providers listed in pgAdmin reflect the APIs that pgAdmin is able to
+communicate with. Their inclusion is not a recommendation, and no provider is
+enabled by default.
+
+
 Security Reports
 ****************
 

--- a/docs/en_US/query_tool.rst
+++ b/docs/en_US/query_tool.rst
@@ -243,7 +243,9 @@ iteratively. For example, you can ask for a query and then follow up with
 
 **Note:** The AI Assistant uses database schema inspection tools to understand
 your database structure. It supports SELECT, INSERT, UPDATE, DELETE, and DDL
-statements. All generated queries should be reviewed before execution.
+statements. All generated queries should be reviewed before execution. See
+:ref:`ai_data_handling` for details of the information that is transmitted to
+your configured LLM provider.
 
 The Data Output Panel
 *********************


### PR DESCRIPTION
The AI documentation covers how to configure each provider in some detail, but it says nothing about what actually leaves the server once one is configured, which is the first thing anyone working under data residency requirements, procurement policy or sector-specific rules is going to want to know. This adds a provider-neutral *Data Handling and Provider Selection* section to `ai_tools.rst` to close that gap, and cross-references it from the AI Assistant notes in the Query Tool documentation.

The section covers three things: what may be transmitted, when nothing is transmitted, and whose terms apply.

On the first, I verified each claim against the code rather than describing what I assumed it did, so it names schema definitions, server and database configuration settings read from `pg_settings` (`llm/reports/queries.py`), query text, EXPLAIN plan output (`llm/prompts/explain.py`), and row data via the Query Tool assistant's `execute_sql_query` tool, which is worth mentioning explicitly because people reasonably assume only metadata is sent. That tool runs inside a read-only transaction and caps results at 1000 rows (`llm/tools/database.py`), and saying so bounds the exposure rather than leaving the reader to imagine the worst.

On the second, note that the accurate statement is that no *provider* is configured by default: `LLM_ENABLED` itself defaults to `True` (`config.py`), whilst `DEFAULT_LLM_PROVIDER` is empty, so it is the absent provider rather than a disabled master switch that means nothing is sent out of the box. Locally hosted providers such as Ollama and Docker Model Runner transmit nothing externally either.

On the third, I have deliberately kept the wording generic, pointing the reader at data residency requirements, procurement policies and sector-specific rules, and at the provider's own terms and their organisation's policies, without naming any particular jurisdiction or restriction. Anything more specific dates badly, is inevitably parochial in a document read worldwide, and commits us to maintaining a footnote that earns nothing: a reader affected by such a rule already knows to go and check it, and the generic phrasing tells them to. The closing sentence makes explicit that the provider list reflects the APIs pgAdmin is able to speak to rather than a recommendation.

`make docs` builds clean, with the only warning being the pre-existing missing `code_snippets` reference in `contributions.rst`. The new section renders as a sibling of *Configuring AI Reports* and *Security Reports*, and the `:ref:` from `query_tool.rst` resolves.

Documentation only, so no release notes entry, in line with our deferred changelog practice. I have written this one myself, so it wants review from another committer rather than me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about data shared with configured cloud AI providers, including query context and potential read-only result data.
  * Clarified when data is not transmitted and noted provider terminology, jurisdiction considerations, and default provider settings.
  * Documented that AI-generated queries may include DDL statements.
  * Added a link to the AI data-handling guidance from the query tool documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->