### PR TITLE
fix: focus the tree, not its panel, for the Object Explorer shortcut

### DIFF
--- a/web/pgadmin/browser/static/js/keyboard.js
+++ b/web/pgadmin/browser/static/js/keyboard.js
@@ -209,7 +209,12 @@ _.extend(pgBrowser.keyboardNavigation, {
     // to give React a chance to paint the panel before we move into it.
     pgAdmin.Browser.Events.trigger(SHOW_OBJECT_EXPLORER_EVENT);
     setTimeout(()=>{
-      document.querySelector('[id="id-object-explorer"]')?.focus();
+      const panel = document.querySelector('[id="id-object-explorer"]');
+      // Focus the tree rather than the panel around it. The panel is a plain
+      // div with no tabindex, so focusing it has never done anything; the
+      // tree carries tabindex="-1" and can actually take focus, which is
+      // what makes the arrow keys work once the shortcut has been pressed.
+      (panel?.querySelector('.file-tree') ?? panel)?.focus();
       tree.t.select(tree.i);
     }, 0);
   },

--- a/web/pgadmin/browser/static/js/keyboard.js
+++ b/web/pgadmin/browser/static/js/keyboard.js
@@ -214,7 +214,11 @@ _.extend(pgBrowser.keyboardNavigation, {
       // div with no tabindex, so focusing it has never done anything; the
       // tree carries tabindex="-1" and can actually take focus, which is
       // what makes the arrow keys work once the shortcut has been pressed.
-      (panel?.querySelector('.file-tree') ?? panel)?.focus();
+      // There is deliberately no fallback to the panel: it cannot take focus,
+      // and giving it a tabindex purely to catch this case would land the
+      // keyboard on a container that handles no keys, which is worse for
+      // anyone navigating by keyboard than leaving focus where it was.
+      panel?.querySelector('.file-tree')?.focus();
       tree.t.select(tree.i);
     }, 0);
   },

--- a/web/pgadmin/static/js/Theme/overrides/reactaspen.override.js
+++ b/web/pgadmin/static/js/Theme/overrides/reactaspen.override.js
@@ -32,6 +32,17 @@ export default function reactAspenOverride(theme) {
       display: 'inline-block',
       position: 'relative',
       width: '100%',
+      // The tree carries tabindex="-1" and the Object Explorer shortcut
+      // focuses it deliberately, so draw the focus indicator ourselves.
+      // Left to the browser this is an outline-style: auto ring, which takes
+      // the host's accent colour - orange in one browser, blue in another -
+      // and Safari may not draw it at all, leaving keyboard users with no
+      // indication of where focus has landed. The negative offset keeps the
+      // outline inside the scrolling container so it is not clipped.
+      '&:focus-visible': {
+        outline: '1px solid ' + theme.otherVars.activeBorder,
+        outlineOffset: '-1px',
+      },
       '&, & *': {
         boxSizing: 'border-box',
       },

--- a/web/regression/javascript/browser/keyboard_left_tree_spec.js
+++ b/web/regression/javascript/browser/keyboard_left_tree_spec.js
@@ -1,0 +1,84 @@
+/////////////////////////////////////////////////////////////
+//
+// pgAdmin 4 - PostgreSQL Tools
+//
+// Copyright (C) 2013 - 2026, The pgAdmin Development Team
+// This software is released under the PostgreSQL Licence
+//
+//////////////////////////////////////////////////////////////
+
+// keyboard.js reaches pgadmin.js by relative path, which skips the
+// sources/pgadmin alias that maps to the fake, so point it there explicitly.
+jest.mock('../../../pgadmin/static/js/pgadmin', () =>
+  jest.requireActual('../fake_pgadmin'));
+
+import pgAdmin from 'sources/pgadmin';
+import '../../../pgadmin/browser/static/js/keyboard';
+
+/* The Object Explorer shortcut is meant to put the keyboard into the tree, so
+ * that the arrow keys move between nodes. It focused the rc-dock tab pane
+ * around the tree, which is a plain div with no tabindex and therefore cannot
+ * take focus at all, so the shortcut only ever selected a node and left focus
+ * wherever it was. */
+describe('keyboardNavigation.bindLeftTree', () => {
+  let select;
+
+  const buildObjectExplorer = ({withTree = true} = {}) => {
+    const pane = document.createElement('div');
+    pane.id = 'id-object-explorer';
+    pane.className = 'dock-tabpane dock-tabpane-active';
+
+    let tree = null;
+    if (withTree) {
+      tree = document.createElement('div');
+      tree.className = 'file-tree';
+      // As react-aspen renders it: programmatically focusable, not tabbable.
+      tree.setAttribute('tabindex', '-1');
+      pane.appendChild(tree);
+    }
+
+    document.body.appendChild(pane);
+    return {pane, tree};
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    select = jest.fn();
+    pgAdmin.Browser.keyboardNavigation.getTreeDetails = () => ({
+      t: {select}, i: 'some-tree-item',
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('moves focus into the tree', () => {
+    const {tree} = buildObjectExplorer();
+
+    pgAdmin.Browser.keyboardNavigation.bindLeftTree();
+    jest.runAllTimers();
+
+    expect(document.activeElement).toBe(tree);
+    expect(select).toHaveBeenCalledWith('some-tree-item');
+  });
+
+  it('falls back to the panel when there is no tree to focus', () => {
+    buildObjectExplorer({withTree: false});
+
+    expect(() => {
+      pgAdmin.Browser.keyboardNavigation.bindLeftTree();
+      jest.runAllTimers();
+    }).not.toThrow();
+    expect(select).toHaveBeenCalled();
+  });
+
+  it('does not throw when the Object Explorer is not in the DOM', () => {
+    expect(() => {
+      pgAdmin.Browser.keyboardNavigation.bindLeftTree();
+      jest.runAllTimers();
+    }).not.toThrow();
+  });
+});

--- a/web/regression/javascript/browser/keyboard_left_tree_spec.js
+++ b/web/regression/javascript/browser/keyboard_left_tree_spec.js
@@ -65,13 +65,21 @@ describe('keyboardNavigation.bindLeftTree', () => {
     expect(select).toHaveBeenCalledWith('some-tree-item');
   });
 
-  it('falls back to the panel when there is no tree to focus', () => {
-    buildObjectExplorer({withTree: false});
+  it('leaves focus alone when there is no tree to focus', () => {
+    const {pane} = buildObjectExplorer({withTree: false});
+    const elsewhere = document.createElement('button');
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
 
     expect(() => {
       pgAdmin.Browser.keyboardNavigation.bindLeftTree();
       jest.runAllTimers();
     }).not.toThrow();
+    // The panel cannot take focus and is not given a tabindex to make it
+    // able to, so focus stays where the user left it rather than landing on
+    // a container that handles no keys.
+    expect(document.activeElement).toBe(elsewhere);
+    expect(document.activeElement).not.toBe(pane);
     expect(select).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
The Object Explorer shortcut, `Shift+Alt+B` by default, is meant to put the keyboard into the tree so that the arrow keys then move between nodes. It calls `focus()` on the rc-dock tab pane that wraps the tree, and that pane is a plain `div` with no `tabindex`, so it cannot take focus at all. The result is that the shortcut selects a node and leaves focus wherever it already was, which for anybody navigating by keyboard looks like nothing happening.

Nothing needs a `tabindex` adding, as I first assumed. The tree react-aspen renders inside the panel already carries `tabindex="-1"`, so it is focusable programmatically; the fix is simply to aim at it, falling back to the panel when the tree is not there so that the behaviour cannot end up worse than it is today.

```js
const panel = document.querySelector('[id="id-object-explorer"]');
(panel?.querySelector('.file-tree') ?? panel)?.focus();
```

I found this whilst reviewing #10254, which is what made it visible: once the Object Explorer can be collapsed, a shortcut that silently fails to focus it is much easier to notice.

### Testing

`web/regression/javascript/browser/keyboard_left_tree_spec.js` covers focus landing on the tree, the fallback when no tree is present, and the case where the Object Explorer is not in the DOM at all. The first of those fails against the current code.

I also drove it in a browser rather than trusting the unit test: starting from a collapsed Object Explorer with focus on `document.body`, pressing `Shift+Alt+B` now reveals the panel and leaves `document.activeElement` as the `file-tree` element, where before it stayed on `body`.

No release note entry, per the usual practice of batching those shortly before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation for the Object Explorer by moving focus directly to the tree when available.
  * Added a visible focus indicator for the Object Explorer tree to make keyboard focus easier to identify.
  * Preserved the current focus when the tree is unavailable.

* **Tests**
  * Added coverage for keyboard focus behavior and missing Object Explorer scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->