### PR TITLE
Javascript dependency: Bump use-resize-observer from 9.1.0 to 10.0.0 (#10265)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -152,7 +152,7 @@
     "sql-formatter": "^15.8.2",
     "uplot": "^1.6.32",
     "uplot-react": "^1.2.4",
-    "use-resize-observer": "^9.1.0",
+    "use-resize-observer": "^10.0.0",
     "valid-filename": "^4.0.0",
     "vanilla-jsoneditor": "^3.12.0",
     "wkx": "^0.5.0",

--- a/web/pgadmin/static/js/PgTreeView/index.jsx
+++ b/web/pgadmin/static/js/PgTreeView/index.jsx
@@ -16,7 +16,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import PropTypes from 'prop-types';
 import EmptyPanelMessage from '../components/EmptyPanelMessage';
-import useResizeObserver from 'use-resize-observer';
+import { useResizeObserver } from 'use-resize-observer';
 
 
 const Root = styled('div')(({ theme }) => ({

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2910,13 +2910,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juggle/resize-observer@npm:^3.3.1":
-  version: 3.4.0
-  resolution: "@juggle/resize-observer@npm:3.4.0"
-  checksum: 10c0/12930242357298c6f2ad5d4ec7cf631dfb344ca7c8c830ab7f64e6ac11eb1aae486901d8d880fd08fb1b257800c160a0da3aee1e7ed9adac0ccbb9b7c5d93347
-  languageName: node
-  linkType: hard
-
 "@kurkle/color@npm:^0.3.0":
   version: 0.3.4
   resolution: "@kurkle/color@npm:0.3.4"
@@ -13333,7 +13326,7 @@ __metadata:
     uplot: "npm:^1.6.32"
     uplot-react: "npm:^1.2.4"
     url-loader: "npm:^4.1.1"
-    use-resize-observer: "npm:^9.1.0"
+    use-resize-observer: "npm:^10.0.0"
     valid-filename: "npm:^4.0.0"
     vanilla-jsoneditor: "npm:^3.12.0"
     webfonts-loader: "npm:^8.1.1"
@@ -15148,15 +15141,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-resize-observer@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "use-resize-observer@npm:9.1.0"
-  dependencies:
-    "@juggle/resize-observer": "npm:^3.3.1"
+"use-resize-observer@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "use-resize-observer@npm:10.0.0"
   peerDependencies:
-    react: 16.8.0 - 18
-    react-dom: 16.8.0 - 18
-  checksum: 10c0/6ccdeb09fe20566ec182b1635a22f189e13d46226b74610432590e69b31ef5d05d069badc3306ebd0d2bb608743b17981fb535763a1d7dc2c8ae462ee8e5999c
+    react: ">=18.2"
+  checksum: 10c0/90b3c913f18f17775fab09cc56f2b2962ce1f3aa3604bab2807b722f4ea6809ab0b987d2e9177f2643305d104f027fb4c83d79d7a77b47630ccd54df7bd32cb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Supersedes #10265, which could not be merged as it stood.

use-resize-observer 10.0.0 removes the default export in favour of a named one, whilst `web/pgadmin/static/js/PgTreeView/index.jsx:19` imported it as a default. Left alone, `useResizeObserver` resolves to `undefined` and the Object Explorer dies the moment the hook is called, so the bump needs the import change to go with it:

```js
-import useResizeObserver from 'use-resize-observer';
+import { useResizeObserver } from 'use-resize-observer';
```

I checked the published package rather than relying on the release notes: v10 exports `useResizeObserver` as a named export only, in both `dist/index.mjs` and `dist/index.cjs`, with no default in either. The hook signature still returns the `{ ref, width, height }` shape that line 81 destructures, this is the only use of the package in the tree, and there is no webpack or jest alias for it.

The rest of v10 costs us nothing: it drops the `/polyfilled` entrypoint and the `@juggle/resize-observer` dependency, no longer takes `react-dom` as a peer, and requires React >= 18.2, comfortably met on React 19.

### Testing

Verified by hand in both Chrome and Safari against a local PostgreSQL 18, with the tree expanded through databases, schemas, casts, tables and tablespaces, resizing both the Object Explorer panel and the window. The tree renders and redraws correctly in both.

Worth stating why this one was hand-tested rather than merged on a green board: `run-javascript-tests` cannot see this class of breakage, since the component only fails when it mounts. That is exactly how the pickr bump in #10264 reached master and took the feature tests down for three days (reverted in #10278), and why #10287 was closed rather than merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree view resizing compatibility following an update to the resize observer dependency.
  * Preserved existing tree view behavior while ensuring resize detection continues to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->