### PR TITLE
ci: stop fetching an unpinned Yarn before the pinned one

### DIFF
--- a/.github/workflows/check-javascript-style.yml
+++ b/.github/workflows/check-javascript-style.yml
@@ -19,10 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Upgrade yarn
-        run: |
-          yarn set version berry
-          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
+      # Corepack reads packageManager from web/package.json and provisions
+      # exactly that Yarn: a single pinned download, with nothing written
+      # into the checkout.
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install Node modules
         run: |

--- a/.github/workflows/run-feature-tests-epas.yml
+++ b/.github/workflows/run-feature-tests-epas.yml
@@ -141,10 +141,11 @@ jobs:
           }
           EOF
 
-      - name: Upgrade yarn
-        run: |
-          yarn set version berry
-          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
+      # Corepack reads packageManager from web/package.json and provisions
+      # exactly that Yarn: a single pinned download, with nothing written
+      # into the checkout.
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Build the JS bundle
         run: |

--- a/.github/workflows/run-feature-tests-pg.yml
+++ b/.github/workflows/run-feature-tests-pg.yml
@@ -151,10 +151,11 @@ jobs:
           }
           EOF
 
-      - name: Upgrade yarn
-        run: |
-          yarn set version berry
-          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
+      # Corepack reads packageManager from web/package.json and provisions
+      # exactly that Yarn: a single pinned download, with nothing written
+      # into the checkout.
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Build the JS bundle
         run: |

--- a/.github/workflows/run-javascript-tests.yml
+++ b/.github/workflows/run-javascript-tests.yml
@@ -28,10 +28,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Upgrade yarn
-        run: |
-          yarn set version berry
-          yarn set version $(node -p "require('./web/package.json').packageManager.split('@')[1]")
+      # Corepack reads packageManager from web/package.json and provisions
+      # exactly that Yarn: a single pinned download, with nothing written
+      # into the checkout.
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install Node modules
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ RUN --mount=type=bind,source=.git,target=/pgadmin4/.git \
     export CPPFLAGS="-DPNG_ARM_NEON_OPT=0" && \
     npm install -g corepack && \
     corepack enable && \
-    yarn set version berry && \
-    yarn set version "$(node -p "require('./package.json').packageManager.split('@')[1]")" && \
     yarn install && \
     yarn run bundle && \
     rm -rf yarn.lock \

--- a/Make.bat
+++ b/Make.bat
@@ -227,7 +227,6 @@ REM Main build sequence Ends
         ECHO ERROR: Could not determine Yarn version from package.json packageManager field.
         EXIT /B 1
     )
-    CALL yarn set version berry || EXIT /B 1
     CALL yarn set version %YARN_VERSION% || EXIT /B 1
     CALL yarn install || EXIT /B 1
     CALL npm rebuild || EXIT /B 1
@@ -288,7 +287,6 @@ REM Main build sequence Ends
         ECHO ERROR: Could not determine Yarn version from package.json packageManager field.
         EXIT /B 1
     )
-    CALL yarn set version berry || EXIT /B 1
     CALL yarn set version %YARN_VERSION% || EXIT /B 1
     CALL yarn workspaces focus --production || EXIT /B 1
 

--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -71,7 +71,6 @@ _build_runtime() {
             echo "ERROR: Could not determine Yarn version from package.json packageManager field."
             exit 1
         fi
-        yarn set version berry
         yarn set version "${YARN_VERSION}"
         yarn workspaces focus --production
 
@@ -308,7 +307,6 @@ _complete_bundle() {
             echo "ERROR: Could not determine Yarn version from package.json packageManager field."
             exit 1
         fi
-        yarn set version berry
         yarn set version "${YARN_VERSION}"
         yarn install 2>&1
 

--- a/pkg/pip/build.sh
+++ b/pkg/pip/build.sh
@@ -61,7 +61,6 @@ if [ -z "${YARN_VERSION}" ]; then
     echo "ERROR: Could not determine Yarn version from package.json packageManager field."
     exit 1
 fi
-yarn set version berry
 yarn set version "${YARN_VERSION}"
 yarn install
 yarn run bundle


### PR DESCRIPTION
Everywhere we build the JS, we asked Yarn to install itself twice:

```
yarn set version berry
yarn set version <the version from packageManager>
```

The first call fetches whichever release is "berry" today and the second immediately replaces it, so every build made two downloads to arrive at one Yarn, and the one that could not be reproduced tomorrow was fetched first.

That first fetch broke CI outright today, during the GitHub incident, when it returned an empty body and Yarn 1 died writing it out:

```
error TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type
string or an instance of Buffer, TypedArray, or DataView
    at writeFile (node:fs:2373:5)
```

It took out `check-javascript-style` and `run-javascript-tests` on #10299, and killed three separate runs of an unrelated investigation before any test executed.

### What changes

The unpinned call goes everywhere it appeared: `Make.bat`, the macOS and pip package builds, and the four workflows. The packaging scripts keep their pinned `yarn set version "${YARN_VERSION}"`, which still reads `packageManager` from `package.json`, so their behaviour is unchanged beyond losing a download. `pkg/linux/build-functions.sh` needed nothing, having only ever used the pinned form.

The four workflows go further and use Corepack, which reads `packageManager` itself and provisions exactly that Yarn without writing `.yarnrc.yml` and `.yarn/releases` into the repository root, where the JS project is not.

The `Dockerfile` already ran `npm install -g corepack && corepack enable` immediately before both `set version` calls, so both were redundant there and are simply removed.

### Testing

`docker build --target app-builder` succeeds with the change, building the image through `yarn install` and `yarn run bundle` to a clean `webpack compiled` and a tagged image. Since `web/yarn.lock` is `__metadata: version: 10`, which Yarn 1 cannot parse, the install succeeding is itself proof that Corepack provisioned Yarn 4 from `packageManager` with no `set version` involved.

All four workflows parse as YAML with exactly one `corepack enable` step each, and the three modified shell scripts pass `bash -n`.

### Worth knowing

Corepack ships with Node.js only up to (but not including) 25.0.0, so once the runners move past that it will need installing explicitly, as the `Dockerfile` already does.

Only `run-javascript-tests.yml` pins a Node version (20.x); the other three take the runner default, so `corepack enable` depends on that default staying below 25. Pinning them explicitly would make it deterministic, but it also changes which Node builds the bundle, so I have left that out of a CI plumbing fix rather than slipping it in.

`Dockerfile` line 31 still installs Alpine's `yarn` package alongside `npm`, which looks redundant now that Corepack provides the shim. I have not touched it here, as it deserves its own verification.
