### PR TITLE
fix: dedupe concurrent getNodeAjaxOptions requests (#10155)

### DIFF
--- a/web/pgadmin/browser/static/js/node_ajax.js
+++ b/web/pgadmin/browser/static/js/node_ajax.js
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////
 
 import _ from 'lodash';
-import getApiInstance from '../../../static/js/api_instance';
+import getApiInstance, {getInflight} from '../../../static/js/api_instance';
 import {generate_url} from 'sources/browser/generate_url';
 import pgAdmin from 'sources/pgadmin';
 
@@ -77,13 +77,6 @@ export function generateNodeUrl(treeNodeInfo, actionType, itemNodeData, withId, 
 }
 
 
-/* Tracks AJAX requests that are currently in flight, keyed by the resolved
- * URL + query params. This lets concurrent callers asking for the same options
- * (e.g. every row's Data Type dropdown mounting at once) share a single HTTP
- * request instead of each firing their own before the cache is populated.
- */
-const _inflightAjaxRequests = new Map();
-
 /* Get the nodes list as options required by select controls
  * The options are cached for performance reasons.
  */
@@ -123,25 +116,16 @@ export function getNodeAjaxOptions(url, nodeObj, treeNodeInfo, itemNodeData, par
       if (_.isUndefined(data) || _.isNull(data)) {
         // Share a single in-flight request among all concurrent callers asking
         // for the same URL + params, so we don't fire duplicate GETs before the
-        // first response lands and populates the cache.
-        let inflightKey = fullUrl + '#' + JSON.stringify(otherParams.urlParams || {});
-        let request = _inflightAjaxRequests.get(inflightKey);
-        if (!request) {
-          request = api.get(fullUrl, {
-            params: otherParams.urlParams,
-          }).then((res)=>{
-            let resData = res.data;
-            if(res.data.data) {
-              resData = res.data.data;
-            }
-            otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, resData);
-            return resData;
-          }).finally(()=>{
-            _inflightAjaxRequests.delete(inflightKey);
-          });
-          _inflightAjaxRequests.set(inflightKey, request);
-        }
-        request.then((resData)=>{
+        // first response lands and populates the cache. Each caller still runs
+        // its own caching + transform on the shared response.
+        getInflight(api, fullUrl, {
+          params: otherParams.urlParams,
+        }).then((res)=>{
+          let resData = res.data;
+          if(res.data.data) {
+            resData = res.data.data;
+          }
+          otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, resData);
           resolve(transform(resData));
         }).catch((err)=>{
           reject(err instanceof Error ? err : Error('Something went wrong'));

--- a/web/pgadmin/browser/static/js/node_ajax.js
+++ b/web/pgadmin/browser/static/js/node_ajax.js
@@ -77,6 +77,13 @@ export function generateNodeUrl(treeNodeInfo, actionType, itemNodeData, withId, 
 }
 
 
+/* Tracks AJAX requests that are currently in flight, keyed by the resolved
+ * URL + query params. This lets concurrent callers asking for the same options
+ * (e.g. every row's Data Type dropdown mounting at once) share a single HTTP
+ * request instead of each firing their own before the cache is populated.
+ */
+const _inflightAjaxRequests = new Map();
+
 /* Get the nodes list as options required by select controls
  * The options are cached for performance reasons.
  */
@@ -114,15 +121,28 @@ export function getNodeAjaxOptions(url, nodeObj, treeNodeInfo, itemNodeData, par
       let data = cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel);
 
       if (_.isUndefined(data) || _.isNull(data)) {
-        api.get(fullUrl, {
-          params: otherParams.urlParams,
-        }).then((res)=>{
-          data = res.data;
-          if(res.data.data) {
-            data = res.data.data;
-          }
-          otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, data);
-          resolve(transform(data));
+        // Share a single in-flight request among all concurrent callers asking
+        // for the same URL + params, so we don't fire duplicate GETs before the
+        // first response lands and populates the cache.
+        let inflightKey = fullUrl + '#' + JSON.stringify(otherParams.urlParams || {});
+        let request = _inflightAjaxRequests.get(inflightKey);
+        if (!request) {
+          request = api.get(fullUrl, {
+            params: otherParams.urlParams,
+          }).then((res)=>{
+            let resData = res.data;
+            if(res.data.data) {
+              resData = res.data.data;
+            }
+            otherParams.useCache && cacheNode.cache(nodeObj.type + '#' + url, treeNodeInfo, cacheLevel, resData);
+            return resData;
+          }).finally(()=>{
+            _inflightAjaxRequests.delete(inflightKey);
+          });
+          _inflightAjaxRequests.set(inflightKey, request);
+        }
+        request.then((resData)=>{
+          resolve(transform(resData));
         }).catch((err)=>{
           reject(err instanceof Error ? err : Error('Something went wrong'));
         });

--- a/web/pgadmin/static/js/api_instance.js
+++ b/web/pgadmin/static/js/api_instance.js
@@ -23,6 +23,44 @@ export default function getApiInstance(headers={}) {
   });
 }
 
+/* Tracks GET requests that are currently in flight, keyed by the resolved URL +
+ * params. This lets concurrent callers asking for the exact same resource
+ * (e.g. every column row's Data Type dropdown mounting at once on a wide table)
+ * share a single HTTP request instead of each firing their own identical GET.
+ */
+const _inflightGetRequests = new Map();
+
+/* Builds a key that is independent of object key insertion order, so that
+ * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key. */
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  return '{' + Object.keys(value).sort().map(
+    (key) => JSON.stringify(key) + ':' + stableStringify(value[key])
+  ).join(',') + '}';
+}
+
+/* Like api.get(url, config), but shares a single in-flight request among all
+ * concurrent callers requesting the same url + params. The shared entry is
+ * removed once the request settles (success or failure), so it never leaks and
+ * later calls fetch fresh data. Each caller attaches its own then/catch, so
+ * response handling (transform, caching, etc.) stays per-caller. */
+export function getInflight(api, url, config={}) {
+  const key = url + '#' + stableStringify(config.params ?? {});
+  let request = _inflightGetRequests.get(key);
+  if (!request) {
+    request = api.get(url, config).finally(() => {
+      _inflightGetRequests.delete(key);
+    });
+    _inflightGetRequests.set(key, request);
+  }
+  return request;
+}
+
 export function parseApiError(error, withData=false) {
   if (error.response) {
     // The request was made and the server responded with a status code

--- a/web/pgadmin/static/js/api_instance.js
+++ b/web/pgadmin/static/js/api_instance.js
@@ -31,10 +31,19 @@ export default function getApiInstance(headers={}) {
 const _inflightGetRequests = new Map();
 
 /* Builds a key that is independent of object key insertion order, so that
- * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key. */
+ * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key.
+ * Params are expected to be plain JSON-like query values (primitives, plain
+ * objects, arrays); exotic inputs like Date/Map/cyclic objects are not valid
+ * GET query params and are out of scope here.
+ * Primitives are type-tagged so that values that share a JSON form but differ
+ * in type never collide, e.g. the number 1 vs the string "1", or an array hole
+ * ([undefined]) vs the empty array ([]). */
 function stableStringify(value) {
+  if (value === undefined) {
+    return 'undefined';
+  }
   if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value);
+    return typeof value + ':' + JSON.stringify(value);
   }
   if (Array.isArray(value)) {
     return '[' + value.map(stableStringify).join(',') + ']';
@@ -50,7 +59,15 @@ function stableStringify(value) {
  * later calls fetch fresh data. Each caller attaches its own then/catch, so
  * response handling (transform, caching, etc.) stays per-caller. */
 export function getInflight(api, url, config={}) {
-  const key = url + '#' + stableStringify(config.params ?? {});
+  // Key on url + params + any per-request headers, so callers that differ only
+  // in headers (e.g. a different Authorization) never share a response. The
+  // instance-level headers set by getApiInstance() are the session-global CSRF
+  // token and Content-type, identical across concurrent callers, so they don't
+  // need to be in the key; anything caller-specific should be passed here via
+  // config.headers.
+  const key = url
+    + '#' + stableStringify(config.params ?? {})
+    + '#' + stableStringify(config.headers ?? {});
   let request = _inflightGetRequests.get(key);
   if (!request) {
     request = api.get(url, config).finally(() => {

--- a/web/pgadmin/static/js/api_instance.js
+++ b/web/pgadmin/static/js/api_instance.js
@@ -23,18 +23,26 @@ export default function getApiInstance(headers={}) {
   });
 }
 
-/* Tracks GET requests that are currently in flight, keyed by the resolved URL +
- * params. This lets concurrent callers asking for the exact same resource
- * (e.g. every column row's Data Type dropdown mounting at once on a wide table)
- * share a single HTTP request instead of each firing their own identical GET.
+/* Tracks GET requests that are currently in flight, keyed by the request axios
+ * will actually make (see requestKey below). This lets concurrent callers asking
+ * for the exact same resource (e.g. every column row's Data Type dropdown
+ * mounting at once on a wide table) share a single HTTP request instead of each
+ * firing their own identical GET.
  */
 const _inflightGetRequests = new Map();
 
+/* Config keys whose effect on the request is fully captured by the dedup key:
+ * params and paramsSerializer both land in the URI that api.getUri() builds,
+ * and headers are hashed into the key directly. Anything else changes what a
+ * caller gets back or how it can be aborted (transformResponse, responseType,
+ * validateStatus, timeout, signal/cancelToken, onDownloadProgress, ...), so a
+ * request carrying any of those is never shared. */
+const SHAREABLE_CONFIG_KEYS = ['params', 'headers', 'paramsSerializer'];
+
 /* Builds a key that is independent of object key insertion order, so that
  * {a:1, b:2} and {b:2, a:1} (and nested variants) resolve to the same key.
- * Params are expected to be plain JSON-like query values (primitives, plain
- * objects, arrays); exotic inputs like Date/Map/cyclic objects are not valid
- * GET query params and are out of scope here.
+ * Values are expected to be plain JSON-like ones (primitives, plain objects,
+ * arrays); exotic inputs like Date/Map/cyclic objects are out of scope.
  * Primitives are type-tagged so that values that share a JSON form but differ
  * in type never collide, e.g. the number 1 vs the string "1", or an array hole
  * ([undefined]) vs the empty array ([]). */
@@ -53,21 +61,63 @@ function stableStringify(value) {
   ).join(',') + '}';
 }
 
-/* Like api.get(url, config), but shares a single in-flight request among all
- * concurrent callers requesting the same url + params. The shared entry is
- * removed once the request settles (success or failure), so it never leaks and
- * later calls fetch fresh data. Each caller attaches its own then/catch, so
- * response handling (transform, caching, etc.) stays per-caller. */
-export function getInflight(api, url, config={}) {
-  // Key on url + params + any per-request headers, so callers that differ only
-  // in headers (e.g. a different Authorization) never share a response. The
-  // instance-level headers set by getApiInstance() are the session-global CSRF
-  // token and Content-type, identical across concurrent callers, so they don't
-  // need to be in the key; anything caller-specific should be passed here via
-  // config.headers.
-  const key = url
-    + '#' + stableStringify(config.params ?? {})
+/* Sorts params so that callers passing the same values in a different order
+ * still share a request. axios serialises params in insertion order, so this
+ * only reorders the query string, it never changes which values are sent.
+ * Arrays keep their order, as position is significant in the query string. */
+function canonicaliseParams(params) {
+  if (params instanceof URLSearchParams) {
+    const sorted = new URLSearchParams(params);
+    sorted.sort();
+    return sorted;
+  }
+  if (params === null || typeof params !== 'object' || Array.isArray(params)) {
+    return params;
+  }
+  return Object.keys(params).sort().reduce((acc, key) => {
+    acc[key] = canonicaliseParams(params[key]);
+    return acc;
+  }, {});
+}
+
+/* Keys a GET on the request axios will actually issue, so two calls share a
+ * response only when that response would have been identical anyway:
+ *
+ * - api.getUri() resolves the URI exactly as the request will, honouring the
+ *   instance baseURL, plain-object params, URLSearchParams and any custom
+ *   paramsSerializer, so params that differ only on the wire never collide.
+ * - The instance's header config is included, so instances built with extra
+ *   headers (e.g. getApiInstance({'Content-Encoding': 'gzip'})) never share
+ *   with plain ones, whilst the fresh-but-identical instances that callers
+ *   typically create still do.
+ * - Per-request config.headers are included for the same reason. */
+function requestKey(api, url, config) {
+  const uri = api.getUri({
+    ...config, url, params: canonicaliseParams(config.params),
+  });
+  return uri
+    + '#' + stableStringify(api.defaults?.headers ?? {})
     + '#' + stableStringify(config.headers ?? {});
+}
+
+/* Like api.get(url, config), but shares a single in-flight request among all
+ * concurrent callers requesting the same url + params + headers. The shared
+ * entry is removed once the request settles (success or failure), so it never
+ * leaks and later calls fetch fresh data. Each caller attaches its own
+ * then/catch, so response handling (transform, caching, etc.) stays per-caller.
+ *
+ * Callers share the response object itself, so treat it as read-only. Requests
+ * whose config carries anything beyond SHAREABLE_CONFIG_KEYS are passed
+ * straight through to api.get() rather than shared. */
+export function getInflight(api, url, config={}) {
+  const shareable = Object.keys(config).every(
+    (key) => SHAREABLE_CONFIG_KEYS.includes(key)
+  );
+  if (!shareable) {
+    return api.get(url, config);
+  }
+
+  const key = requestKey(api, url, config);
   let request = _inflightGetRequests.get(key);
   if (!request) {
     request = api.get(url, config).finally(() => {

--- a/web/regression/javascript/api_instance.spec.js
+++ b/web/regression/javascript/api_instance.spec.js
@@ -1,0 +1,152 @@
+/////////////////////////////////////////////////////////////
+//
+// pgAdmin 4 - PostgreSQL Tools
+//
+// Copyright (C) 2013 - 2026, The pgAdmin Development Team
+// This software is released under the PostgreSQL Licence
+//
+//////////////////////////////////////////////////////////////
+
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import getApiInstance, {getInflight} from 'sources/api_instance';
+
+describe('getInflight', ()=>{
+  let networkMock;
+
+  beforeEach(()=>{
+    networkMock = new MockAdapter(axios);
+    networkMock.onGet('/types/').reply(200, {data: [{label: 'text'}]});
+    networkMock.onGet('/broken/').reply(500, {errormsg: 'nope'});
+  });
+
+  afterEach(()=>{
+    networkMock.restore();
+  });
+
+  it('shares one request among concurrent callers', async ()=>{
+    // Every getNodeAjaxOptions() call builds its own api instance, so the
+    // shared request has to survive distinct-but-identically-configured ones.
+    const [res1, res2] = await Promise.all([
+      getInflight(getApiInstance(), '/types/', {params: {tid: 1}}),
+      getInflight(getApiInstance(), '/types/', {params: {tid: 1}}),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(1);
+    expect(res1.data).toEqual({data: [{label: 'text'}]});
+    expect(res2).toBe(res1);
+  });
+
+  it('ignores param order when matching', async ()=>{
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {params: {tid: 1, scid: 2}}),
+      getInflight(getApiInstance(), '/types/', {params: {scid: 2, tid: 1}}),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(1);
+  });
+
+  it('does not share requests with different params', async ()=>{
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {params: {tid: 1}}),
+      getInflight(getApiInstance(), '/types/', {params: {tid: 2}}),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(2);
+  });
+
+  it('does not share requests with different URLSearchParams', async ()=>{
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {
+        params: new URLSearchParams([['tid', '1']]),
+      }),
+      getInflight(getApiInstance(), '/types/', {
+        params: new URLSearchParams([['tid', '2']]),
+      }),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(2);
+    expect(
+      networkMock.history.get.map((r)=>r.params.toString()).sort()
+    ).toEqual(['tid=1', 'tid=2']);
+  });
+
+  it('does not share requests serialised differently', async ()=>{
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {
+        params: {tid: 1},
+        paramsSerializer: {serialize: ()=>'tid=1'},
+      }),
+      getInflight(getApiInstance(), '/types/', {
+        params: {tid: 1},
+        paramsSerializer: {serialize: ()=>'tid=2'},
+      }),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(2);
+  });
+
+  it('does not share requests with different instance headers', async ()=>{
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {params: {tid: 1}}),
+      getInflight(
+        getApiInstance({'Content-Encoding': 'gzip'}), '/types/',
+        {params: {tid: 1}}
+      ),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(2);
+  });
+
+  it('does not share requests with different per-request headers', async ()=>{
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {
+        params: {tid: 1}, headers: {'X-Test': 'a'},
+      }),
+      getInflight(getApiInstance(), '/types/', {
+        params: {tid: 1}, headers: {'X-Test': 'b'},
+      }),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(2);
+  });
+
+  it('never shares requests carrying unkeyed config', async ()=>{
+    // responseType changes what the caller gets back, so these two must not
+    // be handed the same response even though url and params match.
+    await Promise.all([
+      getInflight(getApiInstance(), '/types/', {
+        params: {tid: 1}, responseType: 'text',
+      }),
+      getInflight(getApiInstance(), '/types/', {
+        params: {tid: 1}, responseType: 'text',
+      }),
+    ]);
+
+    expect(networkMock.history.get.length).toBe(2);
+  });
+
+  it('fetches again once the shared request has settled', async ()=>{
+    await getInflight(getApiInstance(), '/types/', {params: {tid: 1}});
+    await getInflight(getApiInstance(), '/types/', {params: {tid: 1}});
+
+    expect(networkMock.history.get.length).toBe(2);
+  });
+
+  it('rejects every caller and retries after a failure', async ()=>{
+    const attempts = [
+      getInflight(getApiInstance(), '/broken/'),
+      getInflight(getApiInstance(), '/broken/'),
+    ];
+
+    await expect(attempts[0]).rejects.toThrow();
+    await expect(attempts[1]).rejects.toThrow();
+    expect(networkMock.history.get.length).toBe(1);
+
+    // The failed entry must not stick around and poison later callers.
+    await expect(
+      getInflight(getApiInstance(), '/broken/')
+    ).rejects.toThrow();
+    expect(networkMock.history.get.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #10155. _(Re-opens #10159, which was auto-closed when the source fork was recreated — same branch, same change.)_

`getNodeAjaxOptions()` in `web/pgadmin/browser/static/js/node_ajax.js` — the shared helper behind every AJAX-backed dropdown — cached responses **only after they resolved**. So when many components requested the same URL before the first response landed (e.g. every column row's Data Type dropdown mounting at once on a wide table's Columns tab), each one saw an empty cache and fired its own identical `GET`. A 150-column table produced ~150 concurrent duplicate `get_types` requests.

## Fix

Added in-flight request sharing:

- A module-level `Map` tracks requests currently in progress, keyed by the resolved full URL + query params.
- On a cache miss, a caller reuses an existing in-flight request if one matches; otherwise it starts one and stores it.
- The first request to resolve populates the cache exactly as before.
- The map entry is removed on settle (`.finally()`), success or failure, so it doesn't leak.

Result: one shared `get_types` request for all concurrent callers instead of one per row. Cached behavior and response-shape handling are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Concurrent identical data requests are combined, reducing duplicate network traffic.
  * Shared requests consistently account for request parameters and headers.

* **Reliability**
  * Completed or failed requests are cleared so future requests continue normally.
  * Existing response processing, caching, transformations, and error handling remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->