### PR TITLE
Fix invalid SQL from Maintenance dialog REINDEX ... CONCURRENTLY

### DIFF
--- a/web/pgadmin/tools/maintenance/templates/maintenance/sql/command.sql
+++ b/web/pgadmin/tools/maintenance/templates/maintenance/sql/command.sql
@@ -14,7 +14,6 @@
 {% if data.vacuum_parallel %}{{ maintenance_options.append('PARALLEL ' + data.vacuum_parallel) or "" }}{% endif %}
 {% if data.buffer_usage_limit %}{{ maintenance_options.append('BUFFER_USAGE_LIMIT "' + data.buffer_usage_limit + '"') or "" }}{% endif %}
 {% if data.reindex_tablespace %}{{ maintenance_options.append('TABLESPACE ' + conn|qtIdent(data.reindex_tablespace)) or "" }}{% endif %}
-{% if data.reindex_concurrently %}{{ maintenance_options.append('CONCURRENTLY') or "" }}{% endif %}
 {% if data.op == "VACUUM" %}
 VACUUM{% for option in maintenance_options %}{% if loop.first %} ({% endif %}{{ option }}{% if not loop.last %}, {% endif %}{% if loop.last %}){% endif %}{% endfor %}{% if data.schema %} {{ conn|qtIdent(data.schema) }}.{{ conn|qtIdent(data.table) }}{% endif %};
 {% endif %}
@@ -23,9 +22,9 @@ ANALYZE{% for option in maintenance_options %}{% if loop.first %} ({% endif %}{{
 {% endif %}
 {% if data.op == "REINDEX" %}
 {% if index_name %}
-REINDEX{% for option in maintenance_options %}{% if loop.first %} ({% endif %}{{ option }}{% if not loop.last %}, {% endif %}{% if loop.last %}){% endif %}{% endfor %} INDEX {{ conn|qtIdent(data.schema, index_name) }};
+REINDEX{% for option in maintenance_options %}{% if loop.first %} ({% endif %}{{ option }}{% if not loop.last %}, {% endif %}{% if loop.last %}){% endif %}{% endfor %} INDEX{% if data.reindex_concurrently %} CONCURRENTLY{% endif %} {{ conn|qtIdent(data.schema, index_name) }};
 {% else %}
-REINDEX{% for option in maintenance_options %}{% if loop.first %} ({% endif %}{{ option }}{% if not loop.last %}, {% endif %}{% if loop.last %}){% endif %}{% endfor %}{% if not data.schema and not data.reindex_system %} DATABASE {{ conn|qtIdent(data.database) }}{% elif not data.schema and data.reindex_system%} SYSTEM {{ conn|qtIdent(data.database) }}{% elif data.schema and not data.table and not data.primary_key and not data.unique_constraint and not data.index and not data.mview %} SCHEMA {{ conn|qtIdent(data.schema) }}{% else %} TABLE {{ conn|qtIdent(data.schema, data.table) }}{% endif %};
+REINDEX{% for option in maintenance_options %}{% if loop.first %} ({% endif %}{{ option }}{% if not loop.last %}, {% endif %}{% if loop.last %}){% endif %}{% endfor %}{% if not data.schema and not data.reindex_system %} DATABASE{% if data.reindex_concurrently %} CONCURRENTLY{% endif %} {{ conn|qtIdent(data.database) }}{% elif not data.schema and data.reindex_system%} SYSTEM {{ conn|qtIdent(data.database) }}{% elif data.schema and not data.table and not data.primary_key and not data.unique_constraint and not data.index and not data.mview %} SCHEMA{% if data.reindex_concurrently %} CONCURRENTLY{% endif %} {{ conn|qtIdent(data.schema) }}{% else %} TABLE{% if data.reindex_concurrently %} CONCURRENTLY{% endif %} {{ conn|qtIdent(data.schema, data.table) }}{% endif %};
 {% endif %}
 {% endif %}
 {% if data.op == "CLUSTER" %}

--- a/web/pgadmin/tools/maintenance/tests/test_maintenance_create_job_unit_test.py
+++ b/web/pgadmin/tools/maintenance/tests/test_maintenance_create_job_unit_test.py
@@ -606,6 +606,29 @@ class MaintenanceCreateJobTest(BaseTestGenerator):
              url=MAINTENANCE_URL,
              expected_cmd_opts=['REINDEX (VERBOSE) SCHEMA my_schema;\n'],
          )),
+        ('When maintenance the object with the REINDEX CONCURRENTLY SCHEMA',
+         dict(
+             class_params=dict(
+                 sid=1,
+                 name='test_maintenance_server',
+                 port=5444,
+                 host='localhost',
+                 username='postgres'
+             ),
+             params=dict(
+                 database='postgres',
+                 schema='my_schema',
+                 op='REINDEX',
+                 reindex_concurrently=True,
+                 verbose=True
+             ),
+             url=MAINTENANCE_URL,
+             expected_cmd_opts=['REINDEX (VERBOSE) SCHEMA CONCURRENTLY '
+                                'my_schema;\n'],
+             server_min_version=120000,
+             message='REINDEX CONCURRENTLY SCHEMA is not supported by '
+                     'EPAS/PG server less than 12.0'
+         )),
         ('When maintenance the object with the REINDEX TABLE',
          dict(
              class_params=dict(

--- a/web/pgadmin/tools/maintenance/tests/test_maintenance_create_job_unit_test.py
+++ b/web/pgadmin/tools/maintenance/tests/test_maintenance_create_job_unit_test.py
@@ -537,7 +537,7 @@ class MaintenanceCreateJobTest(BaseTestGenerator):
                  verbose=True
              ),
              url=MAINTENANCE_URL,
-             expected_cmd_opts=['REINDEX (VERBOSE, CONCURRENTLY) DATABASE '
+             expected_cmd_opts=['REINDEX (VERBOSE) DATABASE CONCURRENTLY '
                                 'postgres;\n'],
              server_min_version=120000,
              message='REINDEX CONCURRENTLY is not supported by EPAS/PG server '
@@ -643,7 +643,7 @@ class MaintenanceCreateJobTest(BaseTestGenerator):
                  verbose=True
              ),
              url=MAINTENANCE_URL,
-             expected_cmd_opts=['REINDEX (VERBOSE, CONCURRENTLY) TABLE '
+             expected_cmd_opts=['REINDEX (VERBOSE) TABLE CONCURRENTLY '
                                 'my_schema.my_table;\n'],
              server_min_version=120000,
              message='REINDEX CONCURRENTLY TABLE is not supported by '
@@ -710,7 +710,7 @@ class MaintenanceCreateJobTest(BaseTestGenerator):
                  verbose=True
              ),
              url=MAINTENANCE_URL,
-             expected_cmd_opts=['REINDEX (VERBOSE, CONCURRENTLY) INDEX '
+             expected_cmd_opts=['REINDEX (VERBOSE) INDEX CONCURRENTLY '
                                 'my_schema.my_index;\n'],
              server_min_version=120000,
              message='REINDEX CONCURRENTLY is not supported by EPAS/PG server '


### PR DESCRIPTION
## Summary

Running REINDEX with "Concurrently" enabled from the Maintenance dialog generated invalid SQL:

```sql
REINDEX (VERBOSE, CONCURRENTLY) TABLE public."Command";
-- ERROR: syntax error at or near "CONCURRENTLY"
```

`CONCURRENTLY` was being appended to the parenthesised option list alongside `VERBOSE`/`TABLESPACE`/etc., but it isn't a parenthesizable REINDEX option. Per the PostgreSQL grammar it must appear standalone, between the target type keyword (`TABLE`/`INDEX`/`SCHEMA`/`DATABASE`) and the target name:

```sql
REINDEX (VERBOSE) TABLE CONCURRENTLY public."Command";
```

Fixes #10251.

## Test plan

- [x] Updated the three existing unit tests that had been asserting the invalid SQL to expect the corrected syntax
- [x] `python regression/runtests.py --pkg tools.maintenance` passes (69/69) against a live PostgreSQL 18 server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated maintenance SQL so `CONCURRENTLY` appears in the proper position for database, schema, table, and index reindex operations.
  * Fixed secret checksum annotation handling to use the configured authentication secret reference.
* **Tests**
  * Updated maintenance operation checks to validate the corrected PostgreSQL `REINDEX CONCURRENTLY` syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->