### PR TITLE
Allow ADMIN OPTION holders to manage Group Role membership

### DIFF
--- a/web/pgadmin/browser/server_groups/servers/roles/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/__init__.py
@@ -619,6 +619,7 @@ rolmembership:{
         return fetch_name, check_permission, forbidden_msg
 
     def _check_permission(self, check_permission, action, kwargs):
+        self.membership_only_update = False
         if check_permission:
             user = self.manager.user_info
 
@@ -627,6 +628,15 @@ rolmembership:{
                 (action != 'update' or 'rid' in kwargs) and \
                 kwargs['rid'] != -1 and \
                     user['id'] != kwargs['rid']:
+                # A role that only has ADMIN OPTION on this specific role
+                # (rather than being a superuser or having CREATEROLE) may
+                # still manage that role's membership, so don't forbid the
+                # request outright; the update handler restricts what such
+                # a request is allowed to change to membership only.
+                if action == 'update' and getattr(
+                        self, 'has_admin_option', False):
+                    self.membership_only_update = True
+                    return False
                 return True
         return False
 
@@ -658,6 +668,7 @@ rolmembership:{
             self.role = row['rolname']
             self.rolCanLogin = row['rolcanlogin']
             self.rolSuper = row['rolsuper']
+            self.has_admin_option = row.get('has_admin_option', False)
 
         return False, ''
 
@@ -713,15 +724,19 @@ rolmembership:{
                 fetch_name, check_permission, \
                     forbidden_msg = RoleView._check_action(action, kwargs)
 
-                is_permission_error = self._check_permission(check_permission,
-                                                             action, kwargs)
-                if is_permission_error:
-                    return forbidden(forbidden_msg)
-
+                # Fetched first: the permission check needs to know
+                # whether the current user holds ADMIN OPTION on this
+                # role before it can decide whether to forbid the
+                # request.
                 is_error, errmsg = self._check_and_fetch_name(fetch_name,
                                                               kwargs)
                 if is_error:
                     return errmsg
+
+                is_permission_error = self._check_permission(check_permission,
+                                                             action, kwargs)
+                if is_permission_error:
+                    return forbidden(forbidden_msg)
 
                 return f(self, **kwargs)
 
@@ -1023,6 +1038,13 @@ rolmembership:{
     @check_precondition(action='update')
     @validate_request
     def update(self, gid, sid, rid):
+        if getattr(self, 'membership_only_update', False) and \
+                not set(self.request) <= {'rolmembers'}:
+            return forbidden(
+                _("The current user does not have permission to update "
+                  "the role. Users with ADMIN OPTION on this role may "
+                  "only manage its membership.")
+            )
 
         sql = render_template(
             self.sql_path + self._UPDATE_SQL,

--- a/web/pgadmin/browser/server_groups/servers/roles/__init__.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/__init__.py
@@ -567,6 +567,13 @@ rolmembership:{
                     except ValueError:
                         data[k] = v
 
+            # Capture the client-supplied keys before the validators below
+            # mutate 'data' (e.g. _validate_rolemembers adds derived keys
+            # such as 'rol_members_list'), so callers that need to know what
+            # the client actually sent (e.g. the membership-only update
+            # check) can rely on this instead of the mutated dict.
+            self.request_keys = set(data)
+
             invalid_msg_arr = [
                 self._validate_rolname(kwargs.get('rid', -1), data),
                 self._validate_rolvaliduntil(data),
@@ -1039,7 +1046,7 @@ rolmembership:{
     @validate_request
     def update(self, gid, sid, rid):
         if getattr(self, 'membership_only_update', False) and \
-                not set(self.request) <= {'rolmembers'}:
+                not self.request_keys <= {'rolmembers'}:
             return forbidden(
                 _("The current user does not have permission to update "
                   "the role. Users with ADMIN OPTION on this role may "

--- a/web/pgadmin/browser/server_groups/servers/roles/static/js/role.ui.js
+++ b/web/pgadmin/browser/server_groups/servers/roles/static/js/role.ui.js
@@ -55,6 +55,18 @@ export default class RoleSchema extends BaseUISchema {
     return (!(user.is_superuser || user.can_create_role) && user.id != state.oid);
   }
 
+  // A role that isn't a superuser or CREATEROLE holder can still manage
+  // this role's membership if they hold ADMIN OPTION on it themselves.
+  isMemberAdmin(state) {
+    return (state.rolmembers ?? []).some(
+      (member) => member.role === this.user.name && member.admin
+    );
+  }
+
+  membersReadOnly(state) {
+    return this.readOnly(state) && !this.isMemberAdmin(state);
+  }
+
   memberDataFormatter(rawData) {
     let members = '';
     if(_.isObject(rawData)) {
@@ -194,8 +206,8 @@ export default class RoleSchema extends BaseUISchema {
         mode: ['edit', 'create'], cell: 'text',
         type: 'collection',
         schema: obj.membershipSchema,
-        disabled: obj.readOnly,
-        canDelete: (state) => !obj.readOnly(state),
+        disabled: (state) => obj.membersReadOnly(state),
+        canDelete: (state) => !obj.membersReadOnly(state),
         canDeleteRow: true,
         helpMessage: obj.isReadOnly ? gettext('Select the checkbox for roles to include WITH ADMIN OPTION.') : gettext('Roles shown with a check mark have the WITH ADMIN OPTION set.'),
       },

--- a/web/pgadmin/browser/server_groups/servers/roles/templates/roles/sql/default/permission.sql
+++ b/web/pgadmin/browser/server_groups/servers/roles/templates/roles/sql/default/permission.sql
@@ -1,5 +1,14 @@
 SELECT
-    rolname, rolcanlogin, rolsuper
+    rolname, rolcanlogin, rolsuper,
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_auth_members am
+        WHERE am.roleid = {{ rid }}::OID
+          AND am.member = (
+              SELECT oid FROM pg_catalog.pg_roles
+              WHERE rolname = current_user
+          )
+          AND am.admin_option
+    ) AS has_admin_option
 FROM
     pg_catalog.pg_roles
 WHERE oid = {{ rid }}::OID

--- a/web/pgadmin/browser/server_groups/servers/roles/tests/test_role_check_permission_unit_test.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/tests/test_role_check_permission_unit_test.py
@@ -60,3 +60,57 @@ class RoleCheckPermissionTest(BaseTestGenerator):
 
     def tearDown(self):
         pass
+
+
+class RoleMembersOnlyUpdateRequestKeysTest(BaseTestGenerator):
+    """Regression test for the membership-only update guard.
+
+    _validate_rolemembers() mutates the request dict in place, adding
+    derived keys ('rol_members_list', 'rol_members_revoked_list') that
+    the client never sent. The membership-only update guard in
+    RoleView.update() must check the client-supplied keys captured
+    before that mutation (self.request_keys), not the mutated dict,
+    otherwise a valid ADMIN OPTION request containing only 'rolmembers'
+    would be wrongly rejected as forbidden.
+    """
+    scenarios = [
+        ('Check Role Node', dict(url='/browser/role/obj/'))
+    ]
+
+    def setUp(self):
+        pass
+
+    def runTest(self):
+        view = RoleView(cmd=None)
+        view.manager = MagicMock()
+        view.manager.version = 170000
+
+        data = {
+            'rolmembers': {
+                'added': [
+                    {'role': 'member_role', 'admin': True,
+                     'inherit': True, 'set': True}
+                ],
+                'changed': [],
+                'deleted': []
+            }
+        }
+
+        # Mirror what validate_request() does: capture the client
+        # supplied keys before running the validators.
+        request_keys = set(data)
+
+        # This mutates 'data' in place, adding derived keys.
+        self.assertIsNone(view._validate_rolemembers(10, data))
+        self.assertIn('rol_members_list', data)
+
+        # The mutated dict is no longer a subset of {'rolmembers'} ...
+        self.assertFalse(set(data) <= {'rolmembers'})
+
+        # ... but the keys captured before mutation still are, so the
+        # membership-only guard (which must use request_keys) allows
+        # the request through instead of returning 403.
+        self.assertTrue(request_keys <= {'rolmembers'})
+
+    def tearDown(self):
+        pass

--- a/web/pgadmin/browser/server_groups/servers/roles/tests/test_role_check_permission_unit_test.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/tests/test_role_check_permission_unit_test.py
@@ -1,0 +1,62 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+from unittest.mock import MagicMock
+
+from pgadmin.utils.route import BaseTestGenerator
+from pgadmin.browser.server_groups.servers.roles import RoleView
+
+
+class RoleCheckPermissionTest(BaseTestGenerator):
+    """Unit tests for RoleView._check_permission's ADMIN OPTION carve-out.
+
+    A role holder who is neither a superuser nor a CREATEROLE holder, but
+    who has been granted ADMIN OPTION on the specific role being updated,
+    should be allowed through the permission gate so they can manage that
+    role's membership - but only for 'update', never for 'drop', and the
+    view should record that the request must be restricted to membership
+    changes only.
+    """
+    scenarios = [
+        ('Check Role Node', dict(url='/browser/role/obj/'))
+    ]
+
+    def setUp(self):
+        pass
+
+    def runTest(self):
+        view = RoleView(cmd=None)
+        view.manager = MagicMock()
+
+        # Plain user, no admin option: update is forbidden.
+        view.manager.user_info = {
+            'is_superuser': False, 'can_create_role': False, 'id': 5
+        }
+        view.has_admin_option = False
+        self.assertTrue(view._check_permission(True, 'update', {'rid': 10}))
+        self.assertFalse(view.membership_only_update)
+
+        # Same user, but with ADMIN OPTION on the target role: allowed
+        # through, flagged as membership-only.
+        view.has_admin_option = True
+        self.assertFalse(view._check_permission(True, 'update', {'rid': 10}))
+        self.assertTrue(view.membership_only_update)
+
+        # ADMIN OPTION does not extend to dropping the role.
+        self.assertTrue(view._check_permission(True, 'drop', {'rid': 10}))
+
+        # Superusers are unaffected by the ADMIN OPTION check.
+        view.manager.user_info = {
+            'is_superuser': True, 'can_create_role': False, 'id': 5
+        }
+        view.has_admin_option = False
+        self.assertFalse(view._check_permission(True, 'update', {'rid': 10}))
+
+    def tearDown(self):
+        pass

--- a/web/pgadmin/browser/server_groups/servers/roles/tests/test_role_check_permission_unit_test.py
+++ b/web/pgadmin/browser/server_groups/servers/roles/tests/test_role_check_permission_unit_test.py
@@ -7,7 +7,8 @@
 #
 ##########################################################################
 
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 
 from pgadmin.utils.route import BaseTestGenerator
 from pgadmin.browser.server_groups.servers.roles import RoleView
@@ -111,6 +112,87 @@ class RoleMembersOnlyUpdateRequestKeysTest(BaseTestGenerator):
         # membership-only guard (which must use request_keys) allows
         # the request through instead of returning 403.
         self.assertTrue(request_keys <= {'rolmembers'})
+
+    def tearDown(self):
+        pass
+
+
+class RoleUpdateAdminOptionMembershipOnlyTest(BaseTestGenerator):
+    """End-to-end regression test for the ADMIN OPTION membership-only
+    update guard.
+
+    The two tests above exercise _check_permission() and
+    _validate_rolemembers() individually, but neither actually calls
+    validate_request() or RoleView.update(), so a regression that broke
+    how those two decorators interact (e.g. the membership-only guard
+    reading the wrong dict, or request_keys being set/consumed at the
+    wrong point in the chain) would slip past them.
+
+    This test drives RoleView.update() through its real decorator chain
+    (check_precondition -> validate_request -> update) with the driver,
+    connection and SQL rendering mocked out, submitting a 'rolmembers'
+    -only body as a user who holds ADMIN OPTION on the target role (but
+    is neither a superuser nor a CREATEROLE holder), and asserts the
+    request is NOT rejected with 403.
+    """
+    scenarios = [
+        ('Check Role Node', dict(url='/browser/role/obj/'))
+    ]
+
+    def setUp(self):
+        pass
+
+    @patch('pgadmin.browser.server_groups.servers.roles.get_driver')
+    @patch('pgadmin.browser.server_groups.servers.roles.render_template')
+    def runTest(self, render_template_mock, get_driver_mock):
+        view = RoleView(cmd=None)
+
+        manager = MagicMock()
+        manager.version = 170000
+        manager.db_info = None
+        manager.user_info = {
+            'is_superuser': False, 'can_create_role': False, 'id': 5
+        }
+
+        conn = MagicMock()
+        conn.connected.return_value = True
+        # Used for the permission lookup, the ALTER ROLE, and the
+        # post-update node fetch alike; has_admin_option=True is what
+        # drives the ADMIN OPTION carve-out in _check_permission().
+        conn.execute_dict.return_value = (True, {'rows': [{
+            'rolname': 'grp_role', 'rolcanlogin': False, 'rolsuper': False,
+            'has_admin_option': True, 'description': None
+        }]})
+        manager.connection.return_value = conn
+
+        get_driver_mock.return_value.connection_manager.return_value = \
+            manager
+
+        # The client sends only 'rolmembers' - exactly what an ADMIN
+        # OPTION holder (who may manage membership only) is allowed to
+        # change.
+        body = {
+            'rolmembers': {
+                'added': [
+                    {'role': 'member_role', 'admin': True,
+                     'inherit': True, 'set': True}
+                ],
+                'changed': [],
+                'deleted': []
+            }
+        }
+
+        with self.app.test_request_context(
+            data=json.dumps(body), content_type='application/json'
+        ):
+            response = view.update(gid=1, sid=1, rid=10)
+
+        # The real _check_permission() call, driven off the mocked
+        # has_admin_option row, must have flagged this as a
+        # membership-only update ...
+        self.assertTrue(view.membership_only_update)
+        # ... and update() must let it through rather than forbidding it.
+        self.assertNotEqual(response.status_code, 403)
 
     def tearDown(self):
         pass

--- a/web/regression/javascript/schema_ui_files/role.ui.spec.js
+++ b/web/regression/javascript/schema_ui_files/role.ui.spec.js
@@ -45,5 +45,32 @@ describe('RoleSchema', ()=>{
   it('properties', async ()=>{
     await getPropertiesView(createSchemaObject(), getInitData);
   });
+
+  describe('membersReadOnly', ()=>{
+    it('is read only for a plain user who is not an admin member', ()=>{
+      const schemaObj = createSchemaObject();
+      const state = {oid: 123, rolmembers: [{role: 'postgres', admin: false}]};
+      expect(schemaObj.membersReadOnly(state)).toBe(true);
+    });
+
+    it('is editable for a user with ADMIN OPTION on the role', ()=>{
+      const schemaObj = createSchemaObject();
+      const state = {oid: 123, rolmembers: [{role: 'postgres', admin: true}]};
+      expect(schemaObj.membersReadOnly(state)).toBe(false);
+    });
+
+    it('is editable regardless when the user is a superuser/can create roles', ()=>{
+      const schemaObj = new RoleSchema(
+        ()=>new MockSchema(),
+        ()=>new MockSchema(),
+        {
+          role: ()=>[],
+          nodeInfo: {server: {user: {name: 'postgres', id: 0, is_superuser: true}}}
+        },
+      );
+      const state = {oid: 123, rolmembers: []};
+      expect(schemaObj.membersReadOnly(state)).toBe(false);
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary

The Group Role dialog's Membership tab only enabled the add/remove member controls (the "+" icon) for superusers and CREATEROLE holders. A user who was themselves granted `ADMIN OPTION` on that specific role - and who can therefore `GRANT`/`REVOKE` its membership directly in SQL - had no way to add other members through the UI, and hit `"The current user does not have permission to update the role."` server-side if they tried some other way in.

- Frontend: the role schema now also enables the Members collection when the connected user appears in the role's own member list with `admin: true`.
- Backend: `permission.sql` now also reports whether the connecting user holds `ADMIN OPTION` on the target role (a direct `pg_auth_members` lookup, matching how the role's member list is already built elsewhere in this module). The `update` permission check lets such a user through, but the update handler then restricts what they're allowed to submit to `rolmembers` changes only, so this can't be used to escalate other role attributes (superuser, CREATEROLE, password, etc.) they otherwise have no permission to change.

Fixes #9450.

## Test plan

- [x] Verified the underlying `pg_auth_members` admin-option query directly against a live PostgreSQL 18 server, both for a role with and without admin option on the target
- [x] Added a unit test (`test_role_check_permission_unit_test.py`) covering the permission carve-out: allowed for `update` with admin option, still forbidden for `drop`, unaffected for superusers
- [x] Added Jest coverage for the new `isMemberAdmin`/`membersReadOnly` schema logic
- [x] `python regression/runtests.py --pkg browser.server_groups.servers.roles` passes with no regressions against a live PostgreSQL 18 server
- [x] `yarn jest regression/javascript/schema_ui_files/role.ui.spec.js` passes (6/6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users with `ADMIN OPTION` can manage role memberships without unrestricted role-editing permissions.
  - Membership editing and removal remain available to authorized administrators while other role settings stay read-only.

- **Bug Fixes**
  - Membership-only role updates are now correctly accepted.
  - Unauthorized role changes continue to be rejected.

- **Tests**
  - Added coverage for `ADMIN OPTION`, superuser access, read-only behavior, and membership-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->