### PR TITLE
Reject empty or null Username on non-shared server import

### DIFF
--- a/web/pgadmin/utils/__init__.py
+++ b/web/pgadmin/utils/__init__.py
@@ -649,9 +649,11 @@ def validate_json_data(data, is_admin):
                         "found for server '%s'" % server
                     )
             else:
-                errmsg = check_attrib("Username")
-                if errmsg:
-                    return errmsg
+                if not obj.get("Username"):
+                    return gettext(
+                        "'Username' attribute not found for server '%s'" %
+                        server
+                    )
 
         errmsg = check_attrib("MaintenanceDB")
         if errmsg:

--- a/web/pgadmin/utils/tests/test_validate_json_data.py
+++ b/web/pgadmin/utils/tests/test_validate_json_data.py
@@ -47,6 +47,20 @@ class TestValidateJsonData(BaseTestGenerator):
              expected_error="'Username' attribute not found",
              expected_servers=["1"]
          )),
+        ('A non-shared server with an empty username is rejected',
+         dict(
+             servers={"1": server(Username="")},
+             is_admin=True,
+             expected_error="'Username' attribute not found",
+             expected_servers=["1"]
+         )),
+        ('A non-shared server with a null username is rejected',
+         dict(
+             servers={"1": server(Username=None)},
+             is_admin=True,
+             expected_error="'Username' attribute not found",
+             expected_servers=["1"]
+         )),
         ('A shared server with only a shared username is valid',
          dict(
              servers={"1": server(Shared=True, SharedUsername="postgres")},


### PR DESCRIPTION
## Summary

`validate_json_data()` only checked that the `Username` key was *present*
on a non-shared server entry in `servers.json`, not that it held anything
useful. `{"Username": ""}` and `{"Username": null}` both imported
cleanly and left behind a server that couldn't sensibly connect: libpq
treats an empty `user` as "unset" and substitutes the OS account running
pgAdmin, so the resulting authentication failure has no obvious link
back to the servers.json that caused it. The server dialog already
rejects an empty username ("Username must be specified."); import was
more permissive than the UI it's meant to mirror.

This checks the value rather than just the key, matching the truthiness
check already used for the shared-server `Username`/`SharedUsername`
pair a few lines above.

Fixes #10309.

## Test plan

- Added two scenarios to `test_validate_json_data.py` covering an empty
  and a null `Username` on a non-shared server (both now rejected).
- `python regression/runtests.py --pkg utils.tests.test_validate_json_data`
  passes (14/14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server validation to reject non-shared server configurations with missing, empty, or null usernames.
  * Ensured a clear validation error is displayed for invalid username values.

* **Tests**
  * Added coverage for empty and null username validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->