### PR TITLE
Relax azure-mgmt-resource pin to allow 24.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,10 @@ Authlib==1.6.*; python_version <= '3.9'
 Authlib==1.7.*; python_version > '3.9'
 azure-identity==1.25.3
 azure-mgmt-rdbms==10.1.1
-azure-mgmt-resource==25.0.0
+# Azure CLI (a common companion package on Linux distros) still pins
+# azure-mgmt-resource<25, so keep the lower bound at 24.0.0 to avoid
+# conflicts for distro packagers; see pgadmin-org/pgadmin4#10247.
+azure-mgmt-resource>=24.0.0,<26.0.0
 azure-mgmt-subscription==3.1.1
 bcrypt==5.0.*
 boto3==1.42.*; python_version <= '3.9'


### PR DESCRIPTION
## Why

The `azure-mgmt-resource==25.0.0` pin was introduced incidentally in 2dedb6e69a4257d5782f1fb0506c76fbbe279707, a mass dependency-version bump, not because pgAdmin needed anything new from 25.0.0.

pgAdmin's own usage (`web/pgadmin/misc/cloud/azure/__init__.py`) is limited to:

- `from azure.mgmt.resource import ResourceManagementClient` (the top-level re-export)
- `resource_client.resource_groups.list()`

Both are unchanged between 24.0.0 and 25.0.0 (confirmed the import still resolves against the installed 25.0.0 package).

The exact pin blocks Linux distro packagers from shipping pgAdmin alongside Azure CLI, which still requires `azure-mgmt-resource<25` (see https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/setup.py#L114).

## Change

Relax the pin to `azure-mgmt-resource>=24.0.0,<26.0.0`, following the existing range-pin-with-rationale-comment convention already used for `Flask-Security-Too` in this file. This keeps 25.0.0 working for anyone who already has it installed while allowing 24.0.0.

Closes #10247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure resource management package compatibility to support versions from 24.0.0 up to, but not including, 26.0.0.
  * Documented compatibility constraints for Azure CLI integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->