### PR TITLE
Normalise dashboard TPS graph by the configured refresh interval

### DIFF
--- a/web/pgadmin/dashboard/static/js/Graphs.jsx
+++ b/web/pgadmin/dashboard/static/js/Graphs.jsx
@@ -64,16 +64,27 @@ export function statsReducer(state, action) {
     action.counterData = action.incoming;
   }
 
+  /* When the counter represents a rate (e.g. transactions per second),
+   * the raw delta between two polls must be normalised by the number of
+   * seconds elapsed between them, otherwise it only reads correctly when
+   * the refresh interval happens to be 1 second.
+   */
+  let rate = action.rate || 1;
+
   let newState = {};
   Object.keys(action.incoming).forEach(label => {
+    let value = action.incoming[label];
+    if(action.counter) {
+      value = (action.incoming[label] - action.counterData[label]) / rate;
+    }
     if(state[label]) {
       newState[label] = [
-        action.counter ?  action.incoming[label] - action.counterData[label] : action.incoming[label],
+        value,
         ...state[label].slice(0, X_AXIS_LENGTH-1),
       ];
     } else {
       newState[label] = [
-        action.counter ?  action.incoming[label] - action.counterData[label] : action.incoming[label],
+        value,
       ];
     }
   });
@@ -169,7 +180,7 @@ export default function Graphs({preferences, sid, did, pageVisible, enablePoll=t
         let data = resp.data;
         setErrorMsg(null);
         sessionStatsReduce({incoming: data['session_stats']});
-        tpsStatsReduce({incoming: data['tps_stats'], counter: true, counterData: counterData['tps_stats']});
+        tpsStatsReduce({incoming: data['tps_stats'], counter: true, counterData: counterData['tps_stats'], rate: preferences['tps_stats_refresh']});
         tiStatsReduce({incoming: data['ti_stats'], counter: true, counterData: counterData['ti_stats']});
         toStatsReduce({incoming: data['to_stats'], counter: true, counterData: counterData['to_stats']});
         bioStatsReduce({incoming: data['bio_stats'], counter: true, counterData: counterData['bio_stats']});

--- a/web/pgadmin/dashboard/static/js/Graphs.jsx
+++ b/web/pgadmin/dashboard/static/js/Graphs.jsx
@@ -125,6 +125,14 @@ export default function Graphs({preferences, sid, did, pageVisible, enablePoll=t
       }
       if(prevPrefernces['tps_stats_refresh'] != preferences['tps_stats_refresh']) {
         tpsStatsReduce({reset:chartsDefault['tps_stats']});
+        /* The rate divisor is changing, so the previous counter baseline
+         * can no longer be used to compute the next delta.
+         */
+        setCounterData((prevCounterData)=>{
+          const nextCounterData = {...prevCounterData};
+          delete nextCounterData['tps_stats'];
+          return nextCounterData;
+        });
         calcPollDelay = true;
       }
       if(prevPrefernces['ti_stats_refresh'] != preferences['ti_stats_refresh']) {

--- a/web/regression/javascript/dashboard/graphs_spec.js
+++ b/web/regression/javascript/dashboard/graphs_spec.js
@@ -72,6 +72,25 @@ describe('Graphs.js', ()=>{
       expect(state).toEqual(newState);
     });
 
+    it('with incoming with counter and rate', ()=>{
+      let state = {
+        'Label1': [1], 'Label2': [2],
+      };
+      let action = {
+        incoming: {
+          'Label1': 11, 'Label2': 23,
+        },
+        counter: true,
+        counterData: {'Label1': 1, 'Label2': 3},
+        rate: 5,
+      };
+      let newState = {
+        'Label1': [2, 1], 'Label2': [4, 2],
+      };
+      state = statsReducer(state, action);
+      expect(state).toEqual(newState);
+    });
+
     it('with reset', ()=>{
       let state = {
         'Label1': [0, 1], 'Label2': [1, 2],


### PR DESCRIPTION
## Summary
- The "Transactions per second" dashboard chart plotted the raw `xact_commit`/`xact_rollback` delta between two polls without dividing by the elapsed time, so it only read correctly at the 1s refresh interval; at any other interval it showed transactions per refresh interval instead of per second.
- `statsReducer` now accepts an optional `rate` on the action and divides the counter delta by it; `Graphs.jsx` passes `preferences['tps_stats_refresh']` as the rate for the TPS chart only (the other counters - tuples in/out, block I/O - are not labelled as per-second metrics, so they are left as raw per-interval deltas).

## Test plan
- [x] Added a Jest case for `statsReducer` covering the counter+rate normalisation.
- [x] `yarn jest regression/javascript/dashboard/graphs_spec.js regression/javascript/dashboard/graphs_wrapper_spec.js` passes (14/14).
- [x] `yarn run linter` clean.

Closes #10273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard transaction-per-second (TPS) calculations by accounting for the configured refresh interval.
  - Ensured counter-based statistics are normalized consistently, providing more accurate rate displays across different refresh settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->