### PR TITLE
Remove redundant passlib pin that conflicts with libpass

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,6 @@ keyring==25.*
 ldap3==2.*
 libgravatar==1.0.*
 paramiko==3.5.1
-passlib==1.*
 psutil==7.2.*
 psycopg[c]==3.2.13; python_version < '3.10'
 psycopg[c]==3.3.4; python_version >= '3.10'


### PR DESCRIPTION
## Summary
- `requirements.txt` pinned `passlib==1.*` directly, but `Flask-Security-Too` (>= 5.7) depends on `libpass`, a fork of passlib that installs its files under the same `passlib/` import path.
- Installing both packages in one environment causes a file-level collision under `site-packages/passlib/`; with parallel installers such as `uv` the result depends on install order and can leave a mixed or overwritten set of files (see issue for the exact failure modes).
- pgAdmin's own code never imports `passlib` directly. The older `Flask-Security-Too` 5.6.x branch (used on Python 3.9) still depends on real `passlib` itself, so removing our direct pin doesn't change what gets installed there; on newer Python versions only `libpass` is installed, which resolves the conflict.

## Test plan
- [x] Confirmed no direct `passlib`/`libpass` imports anywhere under `web/pgadmin` (excluding tests).
- [x] Confirmed via `pip show` that the installed `Flask-Security-Too==5.8.2` requires `libpass`, not `passlib`, and nothing in the current dependency graph requires `passlib`.
- [x] Confirmed via the `Flask-Security-Too` 5.6.1 wheel metadata that the Python 3.9 branch still requires `passlib>=1.7.4` transitively, so dropping the top-level pin doesn't remove it from that branch.
- [ ] No functional test applicable — this is a dependency pin removal with no code changes.

Closes #10239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->