### PR TITLE
Fix Desktop file dialogs always opening in Downloads (#10226)

### DIFF
--- a/runtime/src/js/pgadmin.js
+++ b/runtime/src/js/pgadmin.js
@@ -478,9 +478,44 @@ function notifyUpdateInstalled() {
   }
 }
 
+// Native file dialogs don't reliably remember the last used directory across
+// calls, so we track it ourselves and use it as the default when the caller
+// hasn't asked for a specific location.
+function withLastVisitedDirectory(options) {
+  if (options.defaultPath) {
+    return options;
+  }
+  const lastVisitedDirectory = configStore.get('lastVisitedDirectory');
+  if (lastVisitedDirectory && fs.existsSync(lastVisitedDirectory)) {
+    return { ...options, defaultPath: lastVisitedDirectory };
+  }
+  return options;
+}
+
+function rememberVisitedDirectory(options, result) {
+  const chosenPath = result.filePath || result.filePaths?.[0];
+  if (!chosenPath) {
+    return;
+  }
+  const isDirectory = options.properties?.includes('openDirectory');
+  configStore.set('lastVisitedDirectory', isDirectory ? chosenPath : path.dirname(chosenPath));
+}
+
 // setup preload events.
-ipcMain.handle('showOpenDialog', (e, options) => dialog.showOpenDialog(BrowserWindow.fromWebContents(e.sender), options));
-ipcMain.handle('showSaveDialog', (e, options) => dialog.showSaveDialog(BrowserWindow.fromWebContents(e.sender), options));
+ipcMain.handle('showOpenDialog', async (e, options) => {
+  const result = await dialog.showOpenDialog(BrowserWindow.fromWebContents(e.sender), withLastVisitedDirectory(options));
+  if (!result.canceled) {
+    rememberVisitedDirectory(options, result);
+  }
+  return result;
+});
+ipcMain.handle('showSaveDialog', async (e, options) => {
+  const result = await dialog.showSaveDialog(BrowserWindow.fromWebContents(e.sender), withLastVisitedDirectory(options));
+  if (!result.canceled) {
+    rememberVisitedDirectory(options, result);
+  }
+  return result;
+});
 ipcMain.handle('showMessageBox', (e, options) => dialog.showMessageBox(BrowserWindow.fromWebContents(e.sender), options));
 ipcMain.handle('getStoreData', (_e, key) => key ? configStore.get(key) : configStore.store);
 ipcMain.handle('setStoreData', (_e, newValues) => {

--- a/runtime/src/js/pgadmin.js
+++ b/runtime/src/js/pgadmin.js
@@ -509,7 +509,11 @@ function rememberVisitedDirectory(options, result) {
   try {
     configStore.set('lastVisitedDirectory', isDirectory ? chosenPath : path.dirname(chosenPath));
   } catch (error) {
-    misc.writeServerLog(`Error remembering last visited directory: ${error}`);
+    try {
+      misc.writeServerLog(`Error remembering last visited directory: ${error}`);
+    } catch (logError) {
+      console.error('Error remembering last visited directory:', error, logError);
+    }
   }
 }
 

--- a/runtime/src/js/pgadmin.js
+++ b/runtime/src/js/pgadmin.js
@@ -481,13 +481,21 @@ function notifyUpdateInstalled() {
 // Native file dialogs don't reliably remember the last used directory across
 // calls, so we track it ourselves and use it as the default when the caller
 // hasn't asked for a specific location.
-function withLastVisitedDirectory(options) {
+async function withLastVisitedDirectory(options) {
   if (options.defaultPath) {
     return options;
   }
   const lastVisitedDirectory = configStore.get('lastVisitedDirectory');
-  if (lastVisitedDirectory && fs.existsSync(lastVisitedDirectory)) {
-    return { ...options, defaultPath: lastVisitedDirectory };
+  if (!lastVisitedDirectory) {
+    return options;
+  }
+  try {
+    const stats = await fs.promises.stat(lastVisitedDirectory);
+    if (stats.isDirectory()) {
+      return { ...options, defaultPath: lastVisitedDirectory };
+    }
+  } catch {
+    // Remembered directory no longer exists (e.g. removable/network drive) - fall through.
   }
   return options;
 }
@@ -498,19 +506,23 @@ function rememberVisitedDirectory(options, result) {
     return;
   }
   const isDirectory = options.properties?.includes('openDirectory');
-  configStore.set('lastVisitedDirectory', isDirectory ? chosenPath : path.dirname(chosenPath));
+  try {
+    configStore.set('lastVisitedDirectory', isDirectory ? chosenPath : path.dirname(chosenPath));
+  } catch (error) {
+    misc.writeServerLog(`Error remembering last visited directory: ${error}`);
+  }
 }
 
 // setup preload events.
 ipcMain.handle('showOpenDialog', async (e, options) => {
-  const result = await dialog.showOpenDialog(BrowserWindow.fromWebContents(e.sender), withLastVisitedDirectory(options));
+  const result = await dialog.showOpenDialog(BrowserWindow.fromWebContents(e.sender), await withLastVisitedDirectory(options));
   if (!result.canceled) {
     rememberVisitedDirectory(options, result);
   }
   return result;
 });
 ipcMain.handle('showSaveDialog', async (e, options) => {
-  const result = await dialog.showSaveDialog(BrowserWindow.fromWebContents(e.sender), withLastVisitedDirectory(options));
+  const result = await dialog.showSaveDialog(BrowserWindow.fromWebContents(e.sender), await withLastVisitedDirectory(options));
   if (!result.canceled) {
     rememberVisitedDirectory(options, result);
   }


### PR DESCRIPTION
## Summary

- Desktop 9.17 file dialogs (Open SQL file, Backup, Restore, Import/Export Data) always opened in the Downloads folder instead of the last visited directory. The behaviour changed when the bundled Electron went from 42 to 43: as of [electron/electron@7f21d31](https://github.com/electron/electron/commit/7f21d3149808ce70f2a4aae7cde2113324e72eb9) the native `showOpenDialog`/`showSaveDialog` calls deliberately no longer remember the last used folder across invocations, and fall back to Chromium's hardcoded default (Downloads) every time. That is an intentional upstream change rather than an Electron bug, but it is not the behaviour we want in pgAdmin, so we have to work around it ourselves.
- `runtime/src/js/pgadmin.js` now tracks the last visited directory itself in the persistent `electron-store` config and passes it as `defaultPath` whenever the caller hasn't already specified a location, restoring the pre-9.17 behaviour regardless of the underlying Electron/Chromium dialog implementation.
- Selecting a folder (`openDirectory`) remembers the folder itself as the next default; selecting/saving a file remembers its containing directory.
- The Downloads-folder default used specifically for the query tool's "download" flow (`runtime/src/js/downloader.js`) is untouched — that's a deliberate, separate download-manager style default, not the bug reported here.

## Test plan

- [ ] `yarn run eslint -c .eslintrc.js src/js/pgadmin.js` passes in `runtime/` (verified locally)
- [ ] On Windows/macOS/Linux Desktop build: open Backup, browse to a non-Downloads folder, complete/cancel, then reopen Backup/Restore/Import-Export/Open SQL file and confirm it reopens in that folder
- [ ] Confirm query tool "download" (CSV/image export) still defaults to Downloads as before

Closes #10226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native open and save dialogs now remember the last directory used.
  * Dialogs reuse the remembered directory when no default location is specified.
  * The remembered directory updates only after a successful selection; canceled dialogs leave it unchanged.

* **Bug Fixes**
  * Invalid or inaccessible remembered directories are now ignored.
  * Directory preference save failures no longer interrupt dialog workflows.
  * Dialogs now wait for remembered-directory validation before opening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
