### PR TITLE
Fix UI language not persisting beyond the request that set it (server mode)

### DIFF
--- a/web/pgadmin/__init__.py
+++ b/web/pgadmin/__init__.py
@@ -328,12 +328,12 @@ def create_app(app_name=None):
             data = request.form
             if 'language' in data:
                 language = data['language'] or language
-                setattr(session, 'PGADMIN_LANGUAGE', language)
-            elif hasattr(session, 'PGADMIN_LANGUAGE'):
-                language = getattr(session, 'PGADMIN_LANGUAGE', language)
-            elif hasattr(request.cookies, 'PGADMIN_LANGUAGE'):
-                language = getattr(
-                    request.cookies, 'PGADMIN_LANGUAGE', language
+                session['PGADMIN_LANGUAGE'] = language
+            elif 'PGADMIN_LANGUAGE' in session:
+                language = session.get('PGADMIN_LANGUAGE', language)
+            elif 'PGADMIN_LANGUAGE' in request.cookies:
+                language = request.cookies.get(
+                    'PGADMIN_LANGUAGE', language
                 )
 
         return language

--- a/web/pgadmin/preferences/__init__.py
+++ b/web/pgadmin/preferences/__init__.py
@@ -289,7 +289,7 @@ def save():
                 config.COOKIE_DEFAULT_DOMAIN != 'localhost':
             domain['domain'] = config.COOKIE_DEFAULT_DOMAIN
 
-        setattr(session, 'PGADMIN_LANGUAGE', language)
+        session['PGADMIN_LANGUAGE'] = language
         response.set_cookie("PGADMIN_LANGUAGE", value=language,
                             path=config.SESSION_COOKIE_PATH,
                             secure=config.SESSION_COOKIE_SECURE,

--- a/web/pgadmin/tests/__init__.py
+++ b/web/pgadmin/tests/__init__.py
@@ -1,0 +1,8 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################

--- a/web/pgadmin/tests/test_get_locale.py
+++ b/web/pgadmin/tests/test_get_locale.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+# pgAdmin 4 - PostgreSQL Tools
+#
+# Copyright (C) 2013 - 2026, The pgAdmin Development Team
+# This software is released under the PostgreSQL Licence
+#
+##########################################################################
+
+"""Verify that the Babel locale_selector registered in create_app() reads
+the selected UI language back from the session and cookie on requests that
+don't include the 'language' form field (issue #10347).
+"""
+
+import config
+from pgadmin.utils.route import BaseTestGenerator
+
+
+class GetLocaleTestCase(BaseTestGenerator):
+    """Exercises pgadmin.__init__.create_app()'s get_locale() directly via
+    the Babel extension, bypassing the need for a database connection.
+    """
+
+    # No server interaction needed, so skip BaseTestGenerator.setUp's
+    # connect_server().
+    def setUp(self):
+        self._orig_server_mode = config.SERVER_MODE
+        config.SERVER_MODE = True
+
+    def tearDown(self):
+        config.SERVER_MODE = self._orig_server_mode
+
+    def _get_locale(self):
+        return self.app.extensions['babel'].locale_selector()
+
+    def runTest(self):
+        # The 'language' form field sets the language for this request and
+        # must persist it to the session for subsequent requests.
+        from flask import session
+        with self.app.test_request_context(
+                '/', method='POST', data={'language': 'fr'}):
+            self.assertEqual(self._get_locale(), 'fr')
+            self.assertEqual(session.get('PGADMIN_LANGUAGE'), 'fr')
+
+        # A request with no 'language' field but an existing session value
+        # must keep using that language.
+        with self.app.test_request_context('/'):
+            session['PGADMIN_LANGUAGE'] = 'de'
+            self.assertEqual(self._get_locale(), 'de')
+
+        # With no session value, the PGADMIN_LANGUAGE cookie must be read.
+        with self.app.test_request_context(
+                '/', headers={'Cookie': 'PGADMIN_LANGUAGE=it'}):
+            self.assertEqual(self._get_locale(), 'it')


### PR DESCRIPTION
## Summary
- `get_locale()` in `web/pgadmin/__init__.py` used `setattr()`/`hasattr()` against Flask's `session` (a dict-like `SecureCookieSession`) and `request.cookies` (a `MultiDict`), neither of which expose their contents as object attributes. As a result the session/cookie fallback branches never fired, and the UI silently reverted to English on every request that didn't include the `language` form field.
- Switched to dict-style access (`session['PGADMIN_LANGUAGE'] = ...`, `'PGADMIN_LANGUAGE' in session`, `request.cookies.get(...)`) so the selected language persists via the session and the `PGADMIN_LANGUAGE` cookie that other parts of the app (`preferences`, `browser`) already set correctly.

## Test plan
- [x] Added `web/pgadmin/tests/test_get_locale.py`, exercising the registered Babel `locale_selector` directly for all three branches (form field, session, cookie fallback). Confirmed it fails against the pre-fix code and passes with the fix.
- [x] `pycodestyle` clean on the changed/added files.

Closes #10347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language preference handling in server mode.
  * Language selections now persist correctly across requests.
  * Added fallback support using the configured language cookie when no session preference exists.

* **Tests**
  * Added coverage for selecting, persisting, and restoring language preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->