### PR TITLE
Fix OpenAI streaming tool calls being split into two entries

### DIFF
--- a/web/pgadmin/llm/providers/openai.py
+++ b/web/pgadmin/llm/providers/openai.py
@@ -844,7 +844,10 @@ class OpenAIClient(LLMClient):
         response.completed for the final response.
         """
         content_parts = []
-        # tool_calls_data: {call_id: {name, arguments}}
+        # tool_calls_data: {item_id: {call_id, name, arguments}}
+        # Keyed by item_id because response.function_call_arguments.delta
+        # events carry item_id (matching item.id from output_item.added),
+        # not call_id.
         tool_calls_data = {}
         model_name = self._model
         usage = Usage()
@@ -884,19 +887,20 @@ class OpenAIClient(LLMClient):
             elif event_type == 'response.output_item.added':
                 item = data.get('item', {})
                 if item.get('type') == 'function_call':
-                    call_id = item.get('call_id', '')
-                    tool_calls_data[call_id] = {
+                    item_id = item.get('id', '')
+                    tool_calls_data[item_id] = {
+                        'call_id': item.get('call_id', ''),
                         'name': item.get('name', ''),
                         'arguments': ''
                     }
 
             elif event_type == 'response.function_call_arguments.delta':
-                call_id = data.get('call_id', '')
-                if call_id not in tool_calls_data:
-                    tool_calls_data[call_id] = {
-                        'name': '', 'arguments': ''
+                item_id = data.get('item_id', '')
+                if item_id not in tool_calls_data:
+                    tool_calls_data[item_id] = {
+                        'call_id': '', 'name': '', 'arguments': ''
                     }
-                tool_calls_data[call_id]['arguments'] += data.get(
+                tool_calls_data[item_id]['arguments'] += data.get(
                     'delta', ''
                 )
 
@@ -915,14 +919,14 @@ class OpenAIClient(LLMClient):
         # Build final response
         content = ''.join(content_parts)
         tool_calls = []
-        for call_id, tc in tool_calls_data.items():
+        for tc in tool_calls_data.values():
             try:
                 arguments = json.loads(tc['arguments']) \
                     if tc['arguments'] else {}
             except json.JSONDecodeError:
                 arguments = {}
             tool_calls.append(ToolCall(
-                id=call_id or str(uuid.uuid4()),
+                id=tc['call_id'] or str(uuid.uuid4()),
                 name=tc['name'],
                 arguments=arguments
             ))

--- a/web/pgadmin/llm/tests/test_openai_stream.py
+++ b/web/pgadmin/llm/tests/test_openai_stream.py
@@ -118,3 +118,64 @@ class OpenAIStreamToolCallTestCase(BaseTestGenerator):
         # The real provider id must survive a null id in a later delta,
         # rather than being clobbered (and replaced by a random uuid).
         self.assertEqual(tc.id, self.expected_id)
+
+
+class OpenAIResponsesStreamToolCallTestCase(BaseTestGenerator):
+    """Responses API function-call deltas must be correlated on item_id,
+    not call_id (issue #10348): response.function_call_arguments.delta
+    events carry item_id, not call_id.
+    """
+
+    scenarios = [
+        ('A single streamed tool call keeps its name and arguments '
+         'together', dict(
+             stream=[
+                 _sse({'type': 'response.output_item.added', 'item': {
+                     'type': 'function_call', 'id': 'item_1',
+                     'call_id': 'call_abc', 'name': 'get_database_schema'
+                 }}),
+                 _sse({'type': 'response.function_call_arguments.delta',
+                       'item_id': 'item_1', 'delta': '{"table":'}),
+                 _sse({'type': 'response.function_call_arguments.delta',
+                       'item_id': 'item_1', 'delta': '"users"}'}),
+                 _sse({'type': 'response.completed', 'response': {}}),
+             ],
+             expected=[
+                 ('call_abc', 'get_database_schema', {'table': 'users'}),
+             ],
+         )),
+        ('Two parallel tool calls are not merged into one', dict(
+            stream=[
+                _sse({'type': 'response.output_item.added', 'item': {
+                    'type': 'function_call', 'id': 'item_1',
+                    'call_id': 'call_1', 'name': 'run_query'
+                }}),
+                _sse({'type': 'response.output_item.added', 'item': {
+                    'type': 'function_call', 'id': 'item_2',
+                    'call_id': 'call_2', 'name': 'get_database_schema'
+                }}),
+                _sse({'type': 'response.function_call_arguments.delta',
+                      'item_id': 'item_1', 'delta': '{"sql": "SELECT 1"}'}),
+                _sse({'type': 'response.function_call_arguments.delta',
+                      'item_id': 'item_2', 'delta': '{}'}),
+                _sse({'type': 'response.completed', 'response': {}}),
+            ],
+            expected=[
+                ('call_1', 'run_query', {'sql': 'SELECT 1'}),
+                ('call_2', 'get_database_schema', {}),
+            ],
+        )),
+    ]
+
+    def runTest(self):
+        client = OpenAIClient(api_key='test-key', model='gpt-5')
+        result = None
+        for item in client._read_responses_stream(_FakeStream(self.stream)):
+            if isinstance(item, LLMResponse):
+                result = item
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.tool_calls), len(self.expected))
+        actual = [(tc.id, tc.name, tc.arguments)
+                  for tc in result.tool_calls]
+        self.assertEqual(actual, self.expected)


### PR DESCRIPTION
## Summary
- `OpenAIClient._read_responses_stream()` accumulated Responses API (`/v1/responses`) streamed function-call arguments in a `tool_calls_data` dict keyed by `call_id`. But per OpenAI's Responses API streaming event reference, `response.function_call_arguments.delta` events carry `item_id`, `output_index`, `delta` and `sequence_number` — there is no `call_id` on that event. `data.get('call_id', '')` always evaluated to `''`, so every delta missed the entry seeded by the preceding `response.output_item.added` event and accumulated into a second, empty-name entry instead — one tool call came back as two separate `ToolCall`s (name with no arguments, and arguments with no name).
- Correlates delta events on `item_id` (matching `item.id` from `response.output_item.added`) instead, while still carrying the real `call_id` through so the emitted `ToolCall.id` (used later to reference the call, e.g. `'call_id': tc.id` when replaying tool calls back to the API) is correct.

## Test plan
- [x] Added two scenarios to `web/pgadmin/llm/tests/test_openai_stream.py` covering a single streamed tool call and two parallel tool calls, using fake Responses API SSE events.
- [x] Confirmed both new tests fail against the pre-fix `call_id`-keyed logic and pass with the fix.
- [x] `pycodestyle` clean on the changed/added files.

Closes #10348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed AI tool calls.
  * Preserved correct associations for parallel tool calls, including their IDs, names, and arguments.

* **Tests**
  * Added coverage for streamed function-call handling and argument accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->