### PR TITLE
chore(deps): pin and bump @fortawesome/fontawesome-free to 7.3.1 in /web

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -79,7 +79,7 @@
     "@date-io/date-fns": "^3.2.1",
     "@emotion/sheet": "^1.4.0",
     "@fluentui/keyboard-key": "^0.4.23",
-    "@fortawesome/fontawesome-free": "latest",
+    "@fortawesome/fontawesome-free": "7.3.1",
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
     "@mui/x-date-pickers": "^8.29.3",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3195,10 +3195,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-free@npm:latest":
-  version: 7.2.0
-  resolution: "@fortawesome/fontawesome-free@npm:7.2.0"
-  checksum: 10c0/fc95989739857a2622c993929c6748c8c7eac3b490b0de6beb843b0b6a5de99f1e99c92901706c73e4da6be9413853a7382dfe82d2313c217489210a5b9965ed
+"@fortawesome/fontawesome-free@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@fortawesome/fontawesome-free@npm:7.3.1"
+  checksum: 10c0/85b70ea64e69b9635ff0b949871acaaf0e6c6fd41860b8a78a5067123a42dd71144f7f7feea7aee013a485166ee8bf8ee3aafb15146dc0f55512d07015adddee
   languageName: node
   linkType: hard
 
@@ -14429,7 +14429,7 @@ __metadata:
     "@emotion/styled": "npm:^11.14.1"
     "@emotion/utils": "npm:^1.4.2"
     "@fluentui/keyboard-key": "npm:^0.4.23"
-    "@fortawesome/fontawesome-free": "npm:latest"
+    "@fortawesome/fontawesome-free": "npm:7.3.1"
     "@mui/icons-material": "npm:^7.3.11"
     "@mui/material": "npm:^7.3.11"
     "@mui/x-date-pickers": "npm:^8.29.3"


### PR DESCRIPTION
### Description
Replaces `@fortawesome/fontawesome-free: latest` with exact `7.3.1` in `web/package.json` and updates `yarn.lock`.

### Motivation
- Replaces floating `latest` spec with exact version `7.3.1` to prevent silent minor/patch/major shifts during lockfile refreshes.
- Aligns with upstream maintainer feedback on #10372.

This PR is related to #10363.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release consistency by locking the icon library to a specific version.
  * No user-facing features or behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->