### PR TITLE
ci: make yarn install --immutable explicit in CI workflows

### DIFF
--- a/.github/workflows/check-javascript-style.yml
+++ b/.github/workflows/check-javascript-style.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Node modules
         run: |
           cd web
-          yarn install
+          yarn install --immutable
 
       - name: Run the linter
         run: |

--- a/.github/workflows/run-feature-tests-epas.yml
+++ b/.github/workflows/run-feature-tests-epas.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Build the JS bundle
         run: |
           cd web
-          yarn install
+          yarn install --immutable
           yarn run bundle
 
       - name: Run the tests

--- a/.github/workflows/run-feature-tests-pg.yml
+++ b/.github/workflows/run-feature-tests-pg.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Build the JS bundle
         run: |
           cd web
-          yarn install
+          yarn install --immutable
           yarn run bundle
 
       - name: Run the tests

--- a/.github/workflows/run-javascript-tests.yml
+++ b/.github/workflows/run-javascript-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Node modules
         run: |
           cd web
-          yarn install
+          yarn install --immutable
 
       - name: Run the tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=bind,source=.git,target=/pgadmin4/.git \
     export CPPFLAGS="-DPNG_ARM_NEON_OPT=0" && \
     npm install -g corepack && \
     corepack enable && \
-    yarn install && \
+    yarn install --immutable && \
     yarn run bundle && \
     rm -rf yarn.lock \
            package.json \

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ appbundle:
 	./pkg/mac/build.sh $(BUILD_OPTS)
 
 install-node:
-	cd web && yarn install
+	cd web && yarn install --immutable
 
 install-python:
 	./tools/setup-python-env.sh

--- a/pkg/linux/build-functions.sh
+++ b/pkg/linux/build-functions.sh
@@ -304,7 +304,7 @@ _copy_code() {
             exit 1
         fi
         yarn set version "${YARN_VERSION}"
-        yarn install
+        yarn install --immutable
         yarn run bundle
     popd > /dev/null || exit
 

--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -308,7 +308,7 @@ _complete_bundle() {
             exit 1
         fi
         yarn set version "${YARN_VERSION}"
-        yarn install 2>&1
+        yarn install --immutable 2>&1
 
         # Record the source commit hash before the heavy lint/webpack
         # steps. `yarn run` needs node_modules so this runs after install,

--- a/pkg/pip/build.sh
+++ b/pkg/pip/build.sh
@@ -62,7 +62,7 @@ if [ -z "${YARN_VERSION}" ]; then
     exit 1
 fi
 yarn set version "${YARN_VERSION}"
-yarn install
+yarn install --immutable
 yarn run bundle
 
 # Copy the commit_hash file, it doesn't show up in git ls-files


### PR DESCRIPTION
Part of #10363.

Yarn's `enableImmutableInstalls` setting already defaults to `true` when `CI` is present in the environment (such as in GitHub Actions). Passing `--immutable` explicitly in CI workflows keeps this enforcement self-documenting and transparent.

Additionally, this adds `--immutable` to build and packaging scripts outside CI (`Makefile`, `Dockerfile`, and packaging build scripts for pip, Linux, and macOS) so release and local build processes fail loudly if `yarn.lock` would be modified instead of silently rewriting it.

#### Changes
- Added `--immutable` to `yarn install` in GitHub Actions workflows:
  - `.github/workflows/check-javascript-style.yml`
  - `.github/workflows/run-javascript-tests.yml`
  - `.github/workflows/run-feature-tests-epas.yml`
  - `.github/workflows/run-feature-tests-pg.yml`
- Added `--immutable` to `yarn install` in build and packaging scripts:
  - `Makefile`
  - `Dockerfile`
  - `pkg/pip/build.sh`
  - `pkg/linux/build-functions.sh`
  - `pkg/mac/build-functions.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation across automated checks, application builds, and packaging processes to consistently honor the committed lockfile.
  * Builds, style checks, and JavaScript tests now fail when dependency definitions and the lockfile are out of sync, helping prevent unplanned dependency changes.
  * Improved consistency and reproducibility across supported build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->