### PR TITLE
chore: configure 3-day release age gate for npm packages

### DIFF
--- a/runtime/.yarnrc.yml
+++ b/runtime/.yarnrc.yml
@@ -5,3 +5,5 @@ logFilters:
     level: discard
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 3d

--- a/web/.yarnrc.yml
+++ b/web/.yarnrc.yml
@@ -10,3 +10,5 @@ logFilters:
     level: discard
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 3d


### PR DESCRIPTION
Part of #10363.

Configures Yarn's `npmMinimalAgeGate` setting to `3d` in both `web/.yarnrc.yml` and `runtime/.yarnrc.yml`.

This introduces a 3-day cooldown period for newly published package versions before they can be resolved, protecting the project against freshly published or compromised npm supply-chain packages while giving the community time to detect and revoke malicious versions.

#### Changes
- Added `npmMinimalAgeGate: 3d` to `web/.yarnrc.yml`
- Added `npmMinimalAgeGate: 3d` to `runtime/.yarnrc.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Package installation now applies a three-day minimum age requirement to npm packages.
  - This configuration is enabled consistently across runtime and web environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->