### PR TITLE
chore(security): disable install scripts by default in /web

### DIFF
--- a/web/.yarnrc.yml
+++ b/web/.yarnrc.yml
@@ -1,9 +1,7 @@
 approvedGitRepositories:
-  - "**"
+  - "https://github.com/pgadmin-org/react-data-grid.git"
 
 checksumBehavior: update
-
-enableScripts: true
 
 logFilters:
   - code: YN0013

--- a/web/package.json
+++ b/web/package.json
@@ -158,6 +158,14 @@
     "wkx": "^0.5.0",
     "zustand": "^5.0.15"
   },
+  "dependenciesMeta": {
+    "ttf2woff2": {
+      "built": true
+    },
+    "unrs-resolver": {
+      "built": true
+    }
+  },
   "resolutions": {
     "rc-resize-observer": "1.4.0",
     "@xmldom/xmldom": "^0.8.13",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -14558,6 +14558,10 @@ __metadata:
   dependenciesMeta:
     sharp:
       optional: true
+    ttf2woff2:
+      built: true
+    unrs-resolver:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Part of #10363

Following up on Dave's feedback, this drops the global `enableScripts: true` from `web/.yarnrc.yml` so we're back to Yarn's safe default of blocking install scripts. 

To keep things building properly, `ttf2woff2` and `unrs-resolver` are explicitly allowlisted via `dependenciesMeta` in `web/package.json`. The only other script in the tree (`core-js`) is just a funding banner, so that stays blocked.

I also narrowed down `approvedGitRepositories` to just `pgadmin-org/react-data-grid` while touching the config.

Tested locally with `yarn install --immutable`, the linter, and Jest tests all ran and passed without issues.

> Pretty sure that covers all the packages that actually need build scripts, but if I missed any or if something else should be excluded, please point it out, happy to fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and package configuration to allow required dependencies to compile correctly.
  * Restricted approved Git repository access during package installation.
  * Disabled package installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->