### PR TITLE
ci: add --check-cache to yarn install in CI workflows

### DIFF
--- a/.github/workflows/check-javascript-style.yml
+++ b/.github/workflows/check-javascript-style.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Node modules
         run: |
           cd web
-          yarn install
+          yarn install --check-cache
 
       - name: Run the linter
         run: |

--- a/.github/workflows/run-feature-tests-epas.yml
+++ b/.github/workflows/run-feature-tests-epas.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Build the JS bundle
         run: |
           cd web
-          yarn install
+          yarn install --check-cache
           yarn run bundle
 
       - name: Run the tests

--- a/.github/workflows/run-feature-tests-pg.yml
+++ b/.github/workflows/run-feature-tests-pg.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Build the JS bundle
         run: |
           cd web
-          yarn install
+          yarn install --check-cache
           yarn run bundle
 
       - name: Run the tests

--- a/.github/workflows/run-javascript-tests.yml
+++ b/.github/workflows/run-javascript-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Node modules
         run: |
           cd web
-          yarn install
+          yarn install --check-cache
 
       - name: Run the tests
         run: |


### PR DESCRIPTION
Part of #10363 (Item 6 from the tracking table).

As Dave noted in the issue discussion, `yarn install --check-cache` is a stronger form of cache and lockfile verification in CI.

Instead of just checking that the lockfile is self-consistent and trusting whatever is already in the runner's disk cache, `--check-cache` tells Yarn to re-verify the cached archives against the registry checksums to catch any cache tampering or poisoned archives.

#### Changes
- Added `--check-cache` to `yarn install` across the 4 GitHub Actions workflows:
  - `check-javascript-style.yml`
  - `run-javascript-tests.yml`
  - `run-feature-tests-epas.yml`
  - `run-feature-tests-pg.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated JavaScript checks and feature-test workflows to validate the Yarn cache during dependency installation.
  - Workflows now fail when cached dependencies are incomplete, stale, or corrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->