### PR TITLE
fix: render Validate binary path modal as HTML instead of raw markup

### DIFF
--- a/web/pgadmin/misc/__init__.py
+++ b/web/pgadmin/misc/__init__.py
@@ -335,23 +335,19 @@ def validate_binary_path():
     if data != '':
         data = json.loads(data)
 
-    version_str = ''
-
     # Do not allow storage dir as utility path
     if 'utility_path' in data and data['utility_path'] is not None and \
         Path(config.STORAGE_DIR) != Path(data['utility_path']) and \
             Path(config.STORAGE_DIR) not in Path(data['utility_path']).parents:
         binary_versions = get_binary_path_versions(data['utility_path'])
-        for utility, version in binary_versions.items():
-            if version is None:
-                version_str += "<b>" + utility + ":</b> " + \
-                               "not found on the specified binary path.<br/>"
-            else:
-                version_str += "<b>" + utility + ":</b> " + version + "<br/>"
+        utilities = [
+            {'utility': utility, 'version': version}
+            for utility, version in binary_versions.items()
+        ]
     else:
         return precondition_required(gettext('Invalid binary path.'))
 
-    return make_json_response(data=gettext(version_str), status=200)
+    return make_json_response(data=utilities, status=200)
 
 
 @blueprint.route("/upgrade_check", endpoint="upgrade_check",

--- a/web/pgadmin/preferences/static/js/components/binary_path.ui.jsx
+++ b/web/pgadmin/preferences/static/js/components/binary_path.ui.jsx
@@ -13,6 +13,7 @@ import url_for from 'sources/url_for';
 import BaseUISchema from 'sources/SchemaView/base_schema.ui';
 import getApiInstance from '../../../../static/js/api_instance';
 import pgAdmin from 'sources/pgadmin';
+import { SafeMessage } from '../../../../static/js/components/SafeMessage';
 
 export function getBinaryPathSchema() {
 
@@ -68,7 +69,13 @@ export default class BinaryPathSchema extends BaseUISchema {
             api.post(url_for('misc.validate_binary_path'),
               JSON.stringify({ 'utility_path': data }))
               .then(function (res) {
-                pgAdmin.Browser.notifier.alertText(gettext('Validate binary path'), gettext(res.data.data));
+                const rows = (res.data.data ?? []).map(({utility, version}) => (
+                  <div key={utility}>
+                    <b>{utility}:</b>{' '}
+                    <SafeMessage text={version ?? gettext('not found on the specified binary path.')} />
+                  </div>
+                ));
+                pgAdmin.Browser.notifier.alert(gettext('Validate binary path'), <>{rows}</>);
               })
               .catch(function (error) {
                 pgAdmin.Browser.notifier.pgNotifier('error', error, gettext('Failed to validate binary path.'));

--- a/web/pgadmin/preferences/static/js/components/binary_path.ui.jsx
+++ b/web/pgadmin/preferences/static/js/components/binary_path.ui.jsx
@@ -72,7 +72,7 @@ export default class BinaryPathSchema extends BaseUISchema {
                 const rows = (res.data.data ?? []).map(({utility, version}) => (
                   <div key={utility}>
                     <b>{utility}:</b>{' '}
-                    <SafeMessage text={version ?? gettext('not found on the specified binary path.')} />
+                    <SafeMessage text={version || gettext('not found on the specified binary path.')} />
                   </div>
                 ));
                 pgAdmin.Browser.notifier.alert(gettext('Validate binary path'), <>{rows}</>);

--- a/web/pgadmin/static/js/helpers/ModalProvider.jsx
+++ b/web/pgadmin/static/js/helpers/ModalProvider.jsx
@@ -68,7 +68,7 @@ export function AlertContent({ text, confirm, okLabel = gettext('OK'), cancelLab
   );
 }
 AlertContent.propTypes = {
-  text: PropTypes.string,
+  text: PropTypes.node,
   confirm: PropTypes.bool,
   onOkClick: PropTypes.func,
   onCancelClick: PropTypes.func,

--- a/web/regression/javascript/schema_ui_files/binary_path.ui.spec.js
+++ b/web/regression/javascript/schema_ui_files/binary_path.ui.spec.js
@@ -8,9 +8,13 @@
 //////////////////////////////////////////////////////////////
 
 
+import {render} from '@testing-library/react';
 import {genericBeforeEach, getEditView} from '../genericFunctions';
 import pgAdmin from '../fake_pgadmin';
 import { getBinaryPathSchema } from '../../../pgadmin/preferences/static/js/components/binary_path.ui';
+
+let mockPost = jest.fn();
+jest.mock('sources/api_instance', () => () => ({ post: mockPost }));
 
 describe('BinaryPathschema', ()=>{
 
@@ -25,16 +29,51 @@ describe('BinaryPathschema', ()=>{
 
   beforeEach(()=>{
     genericBeforeEach();
+    mockPost.mockReset();
+    pgAdmin.Browser.notifier.alert.mockClear();
   });
 
   it('edit', async ()=>{
     await getEditView(schemaObj, getInitData);
   });
 
-  it('validate path', ()=>{
+  it('validate path - empty path', ()=>{
     let validate = _.find(schemaObj.fields, (f)=>f.id=='binaryPath').validate;
     let status = validate('');
     expect(status).toBe(true);
+  });
+
+  it('validate path - renders bold labels and line breaks, not raw markup', async ()=>{
+    mockPost.mockResolvedValue({
+      data: {
+        data: [
+          {utility: 'pg_dump', version: null},
+          {utility: 'psql', version: 'psql 17.2'},
+        ],
+      },
+    });
+
+    let validate = _.find(schemaObj.fields, (f)=>f.id=='binaryPath').validate;
+    let status = validate('/some/path');
+    expect(status).toBe(true);
+
+    // Let the post().then() microtask run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(pgAdmin.Browser.notifier.alert).toHaveBeenCalledTimes(1);
+    const [title, node] = pgAdmin.Browser.notifier.alert.mock.calls[0];
+    expect(title).toBe('Validate binary path');
+
+    const ctrl = render(node);
+    expect(ctrl.container.querySelectorAll('b')).toHaveLength(2);
+    expect(ctrl.container.textContent).toContain('pg_dump:');
+    expect(ctrl.container.textContent).toContain('not found on the specified binary path.');
+    expect(ctrl.container.textContent).toContain('psql:');
+    expect(ctrl.container.textContent).toContain('psql 17.2');
+    // No literal markup should ever appear in the rendered text.
+    expect(ctrl.container.textContent).not.toContain('<b>');
+    expect(ctrl.container.textContent).not.toContain('<br/>');
   });
 
 });


### PR DESCRIPTION
## Summary
Fixes #10393.

- `Preferences → Paths → Binary Paths → Validate binary path` was showing literal `<b>...</b>`/`<br/>` tags instead of formatted text. The endpoint built a pre-rendered HTML string, and the frontend call site was switched to the escaping `notifier.alertText()` during the XSS hardening pass (`9e370d3cb`) — correct for untrusted binary output, but the backend never stopped speaking HTML.
- `misc.validate_binary_path` now returns structured data (`[{utility, version}]`) instead of markup.
- The frontend composes the modal content as real React elements (`<b>` label + `SafeMessage` for the untrusted version text) and calls `notifier.alert()`, so nothing is HTML-parsed and no plaintext escaping is needed.
- Renamed `binary_path.ui.js` → `.jsx` since it now contains JSX; widened `AlertContent`'s `text` propType to `node` to match its existing behavior (it already accepted non-string nodes from other callers).

## Test plan
- [x] `pycodestyle` on the changed Python file — clean
- [x] `yarn run eslint` on the changed JS/JSX files — clean
- [x] `yarn run jest --testPathPatterns="binary_path.ui"` — 3 passed, including a new case asserting bold labels/line breaks render and no literal `<b>`/`<br/>` ever appears in the DOM
- [x] `yarn run jest --testPathPatterns="ModalProvider"` — 4 passed (propType widening doesn't regress existing behavior)
- [ ] Manual: Preferences → Paths → Binary Paths → enter an invalid path → Validate binary path → confirm formatted, line-broken output (no raw tags)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Binary path validation results now display clear, per-utility version information.
  - Utilities without detected versions now show an appropriate fallback message.
  - Validation alerts render formatted labels and line breaks correctly instead of displaying raw markup.

- **UI Improvements**
  - Binary path validation feedback is presented in a clearer alert dialog.
  - Alert content now supports richer formatted messages for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->