### PR TITLE
chore(security): restore checksumBehavior to throw in web and runtime

### DIFF
--- a/runtime/.yarnrc.yml
+++ b/runtime/.yarnrc.yml
@@ -1,4 +1,4 @@
-checksumBehavior: update
+checksumBehavior: throw
 
 logFilters:
   - code: YN0013

--- a/web/.yarnrc.yml
+++ b/web/.yarnrc.yml
@@ -1,7 +1,7 @@
 approvedGitRepositories:
   - "**"
 
-checksumBehavior: update
+checksumBehavior: throw
 
 enableScripts: true
 


### PR DESCRIPTION
Part of #10363 (Item 4 from the tracking table).

This PR switches `checksumBehavior` from `update` back to Yarn's default (`throw`) in both `web/.yarnrc.yml` and `runtime/.yarnrc.yml`.

### Addressing Dave's Concerns
In #10363, Dave rightly cautioned:
> *"I'd like it back at throw, but it needs doing carefully and on its own: the original mismatch wants understanding and the lockfile checksums regenerating first, otherwise CI goes red the moment it lands and we'll be tempted to paper over it the same way again."*

To be completely certain this won't break CI, I investigated and tested both directories with `checksumBehavior: throw` enabled:

1. **`runtime/`**:
   - `yarn install --immutable` &rarr; **Passed (Exit code 0)**
   - `yarn install --check-cache --immutable` &rarr; **Passed (Exit code 0)**
2. **`web/`**:
   - `yarn install --immutable` &rarr; **Passed (Exit code 0)**
   - `yarn install --check-cache --immutable` &rarr; **Passed (Exit code 0)**

The `--check-cache` run forced Yarn to re-verify every single package archive against the remote npm registry. Zero mismatches were found, confirming that the historical 2023 mismatch is resolved and our lockfiles are 100% consistent today.

#### Changes
- Changed `checksumBehavior: update` to `checksumBehavior: throw` in `web/.yarnrc.yml`
- Changed `checksumBehavior: update` to `checksumBehavior: throw` in `runtime/.yarnrc.yml`

<details>
<summary><b>Background</b></summary>

### Why was it originally set to `update`?
Back in July 2023 (commit `25e05de27`), `checksumBehavior: update` was added to get around failing GitHub Actions test cases caused by a Yarn checksum error during the transition to Yarn Berry. While that unblocked CI at the time, leaving it set to `update` permanently silenced Yarn's checksum mismatch detection across both `web/` and `runtime/`

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package installation now fails when dependency checksums do not match, rather than silently updating them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->