### PR TITLE
fix(pkg): stop the Windows build overwriting the venv's pip

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -161,13 +161,13 @@ REM Main build sequence Ends
     CD "%TMPDIR%"
 
     REM Note that we must use virtualenv.exe here, as the venv module doesn't allow python.exe to relocate.
-    "%PGADMIN_PYTHON_DIR%\Scripts\virtualenv.exe" venv
+    "%PGADMIN_PYTHON_DIR%\Scripts\virtualenv.exe" venv || EXIT /B 1
 
     XCOPY /S /I /E /H /Y "%PGADMIN_PYTHON_DIR%\DLLs" "%TMPDIR%\venv\DLLs" > nul || EXIT /B 1
     REM Copy the standard library, but NOT site-packages: the venv already has its
     REM own seeded pip there, and overwriting only the files the system Python also
     REM has leaves a mix of two pip versions behind.
-    ROBOCOPY /E /R:3 /W:5 "%PGADMIN_PYTHON_DIR%\Lib" "%TMPDIR%\venv\Lib" /XD "%PGADMIN_PYTHON_DIR%\Lib\site-packages" > nul
+    ROBOCOPY /E /R:3 /W:5 /NFL /NDL /NP "%PGADMIN_PYTHON_DIR%\Lib" "%TMPDIR%\venv\Lib" /XD site-packages
     CALL :CHECK_ROBOCOPY_ERROR || EXIT /B 1
 
     ECHO Activating virtual environment -  %TMPDIR%\venv...
@@ -220,8 +220,8 @@ REM Main build sequence Ends
     RD /Q /S "%WD%\web\pgadmin\static\js\generated\.cache" 1> nul 2>&1
 
     ECHO Copying web directory...
-    ROBOCOPY /S "%WD%\web" "%BUILDROOT%\web" > nul
-    CALL :CHECK_ROBOCOPY_ERROR
+    ROBOCOPY /S /NFL /NDL /NP "%WD%\web" "%BUILDROOT%\web"
+    CALL :CHECK_ROBOCOPY_ERROR || EXIT /B 1
 
     ECHO Installing javascript dependencies...
     CD "%BUILDROOT%\web"

--- a/Make.bat
+++ b/Make.bat
@@ -164,7 +164,11 @@ REM Main build sequence Ends
     "%PGADMIN_PYTHON_DIR%\Scripts\virtualenv.exe" venv
 
     XCOPY /S /I /E /H /Y "%PGADMIN_PYTHON_DIR%\DLLs" "%TMPDIR%\venv\DLLs" > nul || EXIT /B 1
-    XCOPY /S /I /E /H /Y "%PGADMIN_PYTHON_DIR%\Lib" "%TMPDIR%\venv\Lib" > nul || EXIT /B 1
+    REM Copy the standard library, but NOT site-packages: the venv already has its
+    REM own seeded pip there, and overwriting only the files the system Python also
+    REM has leaves a mix of two pip versions behind.
+    ROBOCOPY /E /R:3 /W:5 "%PGADMIN_PYTHON_DIR%\Lib" "%TMPDIR%\venv\Lib" /XD "%PGADMIN_PYTHON_DIR%\Lib\site-packages" > nul
+    CALL :CHECK_ROBOCOPY_ERROR || EXIT /B 1
 
     ECHO Activating virtual environment -  %TMPDIR%\venv...
     CALL "%TMPDIR%\venv\Scripts\activate" || EXIT /B 1


### PR DESCRIPTION
The Windows x64 build has been failing since the buildfarm's virtualenv started seeding pip 26.2.x:

```
File "...\win-temp\venv\Lib\site-packages\pip\_internal\build_env\installer.py", line 22, in <module>
  from pip._internal.utils.misc import get_runnable_pip
ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'
```

`CREATE_VIRTUAL_ENV` creates a virtualenv and then copies the whole of the system Python's `Lib` over it, so the relocated interpreter has a standard library. That copy includes `Lib\site-packages`, and `XCOPY /Y` overwrites the files present on both sides without removing the ones only the venv has, so the venv's freshly seeded pip ends up spliced together with whatever pip `C:\Python313` happens to have.

That was harmless while the two layouts agreed. pip 26.2 turned `pip/_internal/build_env` from a module into a package, so on a builder whose system pip predates 26.2 the new `build_env/` directory survives the copy whilst `utils/misc.py` is overwritten by the older one — and the resulting install is internally inconsistent. I checked the pristine 26.2.1 wheel: `build_env/` is a package and `utils/misc.py` does define `get_runnable_pip`, so the released artifact is fine; only the spliced copy is broken.

It cannot recover on its own, because the next line of the script is the pip invocation that upgrades pip.

Copy the standard library with `ROBOCOPY` and exclude `site-packages`, which the venv is entitled to keep to itself. `ROBOCOPY` rather than `XCOPY /EXCLUDE` because `/XD` takes a directory to skip, whereas `/EXCLUDE` takes a file of path substrings and breaks on quoted paths containing spaces. `/R:3 /W:5` so a locked file fails the build instead of retrying a million times.

Note that `CALL :CHECK_ROBOCOPY_ERROR` is followed by `|| EXIT /B 1` here: `EXIT /B` inside the label returns from the label rather than from the caller, so without it a failed copy would be ignored.

Upgrading the system pip on the builder (`C:\Python313\python.exe -m pip install --upgrade pip`) also unblocks it immediately, but the splice will bite again the next time the two pip layouts diverge.

Not verified on a Windows builder — I have no Windows host to run `Make.bat` on. A buildfarm run is the real test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by stopping setup when virtual environment creation or required file-copy operations fail.
  * Updated environment setup to avoid overwriting bundled package tooling.
  * Simplified file-copy progress output for a cleaner build experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->