### PR TITLE
Fix dynamic type function not receiving correct state for collection

### DIFF
--- a/web/pgadmin/static/js/SchemaView/MappedControl.jsx
+++ b/web/pgadmin/static/js/SchemaView/MappedControl.jsx
@@ -401,7 +401,12 @@ export const MappedFormControl = ({
   }
 
   if (typeof (field.type) === 'function') {
-    const typeProps = evalFunc(null, field.type, state);
+    let typeState = state;
+    if (accessPath && accessPath.length > 1) {
+      const parentPath = accessPath.slice(0, -1);
+      typeState = schemaState.value(parentPath);
+    }
+    const typeProps = evalFunc(null, field.type, typeState);
     newProps = {
       ...newProps,
       ...typeProps,


### PR DESCRIPTION
…row fields

When a schema field uses a dynamic type function (type as a function) and is rendered inside a collection (e.g., chain tasks), the function always received the top-level schema data instead of the row-level data. This caused the field to fall through to its default type, ignoring the actual field values in the row.

Pass the parent-path state to the dynamic type function so it receives the correct context for collection row fields.


I ran into this issue when building pg_timetable UI - #10152  that when building a new Chain and Tasks in one step, the Kind toggle didn't change options based on Kind.  This patch fixes it, but didn't seem appropriate to put in as part of pg_timetable since it's a global issue.  I don't think any existing elements are impacted by it yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic field type evaluation for nested form fields.
  * Ensures field types are determined using the appropriate parent field state when applicable.
  * Improved handling of dependent field values when dynamically determining form behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->