### PR TITLE
fix(deps): pin psycopg[c] back to 3.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ libgravatar==1.0.*
 paramiko==3.5.1
 psutil==7.2.*
 psycopg[c]==3.2.13; python_version < '3.10'
-psycopg[c]==3.3.5; python_version >= '3.10'
+psycopg[c]==3.3.4; python_version >= '3.10'
 pyotp==2.*
 python-dateutil==2.*
 pytz==2026.*

--- a/web/pgadmin/utils/driver/psycopg3/tests/test_encoding.py
+++ b/web/pgadmin/utils/driver/psycopg3/tests/test_encoding.py
@@ -31,8 +31,13 @@ class TestEncoding(BaseTestGenerator):
     scenarios = [
         ('UTF8 maps to the utf-8 python codec',
          dict(key='UTF8', expected=['utf-8', 'utf-8'])),
+        # psycopg >= 3.3.5 carries an ISO88591 alias in its encoding
+        # table, so inverting py_codecs resolves iso8859-1 to that name;
+        # <= 3.3.4 only has LATIN1. Both are valid PostgreSQL names for
+        # the same encoding, so accept either.
         ('LATIN1 maps to the iso8859-1 python codec',
-         dict(key='LATIN1', expected=['ISO88591', 'iso8859-1'])),
+         dict(key='LATIN1', expected=['ISO88591', 'iso8859-1'],
+              also_valid=['LATIN1', 'iso8859-1'])),
         ('SQL_ASCII falls back to the pgAdmin-only override',
          dict(key='SQL_ASCII', expected=['utf-8', 'utf-8'])),
         ('EUC_TW falls back to the pgAdmin-only override',
@@ -43,6 +48,9 @@ class TestEncoding(BaseTestGenerator):
          dict(key='ascii', expected=['SQLASCII', 'raw-unicode-escape'])),
     ]
 
+    # Only set by scenarios where more than one result is correct.
+    also_valid = None
+
     def setUp(self):
         # No DB connection needed for this test.
         pass
@@ -52,7 +60,12 @@ class TestEncoding(BaseTestGenerator):
         configure_driver_encodings(encodings)
 
         with self.app.app_context():
-            self.assertEqual(get_encoding(self.key), self.expected)
+            result = get_encoding(self.key)
+
+        if self.also_valid is None:
+            self.assertEqual(result, self.expected)
+        else:
+            self.assertIn(result, [self.expected, self.also_valid])
 
         # py_codecs/pg_codecs must stay plain dicts and stay in sync,
         # regardless of how psycopg represents its internal encoding


### PR DESCRIPTION
## Problem

The macOS x64 packaging job fails installing `requirements.txt`:

```
Collecting psycopg-c==3.3.5 (from psycopg[c]==3.3.5->-r .../requirements.txt (line 56))
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  │ exit code: -10
  ╰─> [2 lines of output]
      .../setuptools/config/pyprojecttoml.py:72: _ExperimentalConfiguration: [tool.setuptools.ext-modules] in pyproject.toml is still experimental and likely to change in future releases.
```

Exit code `-10` is SIGBUS. The only output before the crash is setuptools' own experimental-config warning, so it dies while setuptools reads the project config — well before `pg_config` is invoked.

## Cause

`psycopg-c` publishes no wheels, so every platform compiles it from the sdist. The only build-tooling change between 3.3.4 and 3.3.5 is the strictly pinned build requirement:

| psycopg-c | build requirement |
|---|---|
| 3.3.0 – 3.3.4 | `setuptools == 80.3.1` |
| 3.3.5 | `setuptools == 83.0.0` |

Because the pin is an equality, `PIP_CONSTRAINT` cannot override the version inside the isolated build environment. Keeping 3.3.5 would mean either `--no-build-isolation` with a pre-seeded setuptools — forking the macOS build procedure from Linux's, with a silent drift risk whenever `requirements.txt` changes — or an upstream fix. Linux builds 3.3.5 without trouble, so this looks specific to the `relocatable-python` framework the macOS bundle is built against.

## Change

Pin `psycopg[c]` to 3.3.4 for `python_version >= '3.10'`. The Python 3.9 pin (3.2.13) is untouched.

The `encoding.py` rewrite that shipped alongside the 3.3.5 bump in #10370 needs no change: it reads the derived `py_codecs`/`pg_codecs` dicts, which are plain dicts in both versions.

One test expectation was 3.3.5-specific. psycopg 3.3.5 added an `ISO88591` alias to its encoding table, so inverting `py_codecs` resolves `iso8859-1` to `ISO88591`; on 3.3.4 only `LATIN1` exists, so `get_encoding('LATIN1')` returns `['LATIN1', 'iso8859-1']` instead of `['ISO88591', 'iso8859-1']`. Both are valid PostgreSQL names for the same encoding, so the scenario now accepts either.

## Testing

- `python regression/runtests.py --pkg utils.driver.psycopg3` — 7/7 pass with psycopg **3.3.4**.
- Same suite re-run with psycopg **3.3.5** installed — 7/7 pass, so the test stays valid across both.
- `pycodestyle` clean on the modified test.

Not verified: that 3.3.4 actually builds on the failing macOS x64 host. That change is reasoned from the sdist diff above; it needs confirmation from a Jenkins run.

## Follow-up

Worth reporting the SIGBUS upstream (setuptools 83.0.0 inside a relocated `Python.framework`) so the pin can be lifted. A quick reproducer on the x64 build host:

```bash
$PY/python3 -c "from distutils.command.build_ext import build_ext; print('ok')"
$PY/pip3 install "setuptools==83.0.0" && $PY/python3 -c "import setuptools; print(setuptools.__version__)"
$PY/pip3 install -v --no-binary :all: --no-deps psycopg-c==3.3.5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with psycopg versions that report equivalent character encodings under different aliases.
  * Pinned the psycopg dependency to version 3.3.4 for Python 3.10 and newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->