### PR TITLE
Stop shipping the JavaScript build configuration in packages

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -246,8 +246,18 @@ REM Main build sequence Ends
     RD /Q /S "%BUILDROOT%\web\regression" 1> nul 2>&1
     ECHO Removing tools...
     RD /Q /S "%BUILDROOT%\web\tools" 1> nul 2>&1
-    ECHO Removing yarn cache...
+    ECHO Removing the JavaScript build configuration...
     RD /Q /S "%BUILDROOT%\web\.yarn" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\yarn.lock" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\.yarnrc.yml" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\package.json" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\jest.config.js" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\babel.cfg" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\babel.config.json" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\webpack.config.js" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\webpack.shim.js" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\.eslintrc.js" 1> nul 2>&1
+    DEL /q "%BUILDROOT%\web\.editorconfig" 1> nul 2>&1
     ECHO Removing any existing configurations...
     DEL /q "%BUILDROOT%\web\pgadmin4.db" 1> nul 2>&1
     DEL /q "%BUILDROOT%\web\config_local.py" 1> nul 2>&1

--- a/pkg/linux/build-functions.sh
+++ b/pkg/linux/build-functions.sh
@@ -313,7 +313,7 @@ _copy_code() {
     cp "${SOURCEDIR}/pkg/linux/config_distro.py" "${SERVERROOT}/usr/${APP_NAME}/web/"
     cd "${SERVERROOT}/usr/${APP_NAME}/web/" || exit
     rm -f pgadmin4.db config_local.*
-    rm -rf jest.config.js babel.* package.json .yarn* yarn* .editorconfig .eslint* node_modules/ regression/ tools/ pgadmin/static/js/generated/.cache
+    rm -rf jest.config.js babel.* package.json .yarn* yarn* webpack.* .editorconfig .eslint* node_modules/ regression/ tools/ pgadmin/static/js/generated/.cache
     find . -name "tests" -type d -print0 | xargs -0 rm -rf
     find . -name "feature_tests" -type d -print0 | xargs -0 rm -rf
     find . -name "__pycache__" -type d -print0 | xargs -0 rm -rf

--- a/pkg/mac/build-functions.sh
+++ b/pkg/mac/build-functions.sh
@@ -346,7 +346,7 @@ _complete_bundle() {
     cp -r "${SOURCE_DIR}/web" "${BUNDLE_DIR}/Contents/Resources/"
     cd "${BUNDLE_DIR}/Contents/Resources/web" || exit
     rm -f pgadmin4.db config_local.*
-    rm -rf jest.config.js babel.* package.json .yarn* yarn* .editorconfig .eslint* node_modules/ regression/ tools/ pgadmin/static/js/generated/.cache
+    rm -rf jest.config.js babel.* package.json .yarn* yarn* webpack.* .editorconfig .eslint* node_modules/ regression/ tools/ pgadmin/static/js/generated/.cache
     find . -name "tests" -type d -print0 | xargs -0 rm -rf
     find . -name "feature_tests" -type d -print0 | xargs -0 rm -rf
     find . -name "__pycache__" -type d -print0 | xargs -0 rm -rf

--- a/pkg/pip/build.sh
+++ b/pkg/pip/build.sh
@@ -76,6 +76,15 @@ do
     tar cf - "${FILE}" | (cd ../pip-build/pgadmin4; tar xf -)
 done
 
+# Remove the JavaScript build configuration from the tree we're shipping. None
+# of it is used at runtime (only the bundle under pgadmin/static/js/generated
+# is), and leaving yarn.lock in place means vulnerability scanners report the
+# entire build-time dependency tree against the installed package. This happens
+# before the SBOM is generated so that the SBOM describes what actually ships.
+echo Removing the JavaScript build configuration...
+(cd ../pip-build/pgadmin4 && rm -rf jest.config.js babel.* package.json \
+    .yarn* yarn* webpack.* .editorconfig .eslint*)
+
 cd ../docs || exit
 for FILE in $(git ls-files)
 do


### PR DESCRIPTION
The Windows installer and the pip wheel both ship `web/yarn.lock`, `web/package.json` and the rest of the JavaScript build configuration into the installed tree, none of which is used at runtime, since only the webpack output under `pgadmin/static/js/generated` is. As `node_modules` is stripped, the lockfile that remains describes packages that are not actually present, so vulnerability scanners run against an installation report the whole build-time dependency tree, `devDependencies` included. That produces findings nobody can act on, and they recur on every release however current the pinned versions happen to be. The report that prompted this flagged `postcss` and `tar` against `C:\PostgreSQL\18\pgAdmin 4\web\yarn.lock`, where `postcss` is only ever invoked by `postcss-loader` at bundle time and `tar` only arrives transitively through `cacache` and `node-gyp`.

The Linux, macOS and Docker builds already removed these files, so this only brings Windows and pip into line with them:

- `Make.bat` removed `node_modules` and the `.yarn` cache but left `yarn.lock`, `package.json`, `jest.config.js`, `babel.*`, `webpack.*` and the lint/editor configuration behind.
- `pkg/pip/build.sh` assembles the wheel from `git ls-files`, so it shipped the same files; the new cleanup runs before `syft`, so the SBOM now describes what actually ships rather than the build tree.
- `webpack.*` is added to the Linux and macOS lists, which Docker already dropped, so all four packagers now strip an identical set.

`pkg/src/build.sh` deliberately keeps `yarn.lock`, since the source tarball genuinely is source.

I verified this rather than assuming it: I assembled a `web` tree with the cleanup applied, started pgAdmin from it, and both `/misc/ping` and `/browser/` return 200 with every generated bundle served, so nothing removed here is load-bearing at runtime. The Windows and macOS packagers I have not been able to exercise end to end locally, so those paths would benefit from a check on the build machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Packaging**
  * Reduced packaged application contents by removing JavaScript build-time configuration, dependency, and tooling files from Windows, Linux, macOS, and pip distributions.
  * Ensured generated bundles exclude unnecessary development artifacts, including Yarn, Webpack, Babel, Jest, and ESLint files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->